### PR TITLE
#5 Use parent-oss as parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,12 @@
     
     <modelVersion>4.0.0</modelVersion>
     
+    <parent>
+        <groupId>com.dataliquid</groupId>
+        <artifactId>parent-oss</artifactId>
+        <version>2.1.0</version>
+    </parent>
+    
     <groupId>com.dataliquid</groupId>
     <artifactId>asciidoc-linter</artifactId>
     <version>0.1.0-SNAPSHOT</version>
@@ -24,7 +30,6 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctorj.version>2.5.13</asciidoctorj.version>
         <jackson.version>2.18.2</jackson.version>
         <junit.version>5.13.1</junit.version>
@@ -118,7 +123,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
@@ -132,7 +136,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
             </plugin>
             
             <plugin>


### PR DESCRIPTION
## Summary
- Added parent-oss 2.1.0 as parent POM
- Removed duplicate configurations inherited from parent
- Kept license section as requested

## Changes
- Added parent configuration pointing to `com.dataliquid:parent-oss:2.1.0`
- Removed `project.build.sourceEncoding` property (inherited)
- Removed version from `maven-compiler-plugin` (managed by parent)
- Removed version from `maven-surefire-plugin` (managed by parent)

## Test plan
- [x] Maven build passes successfully
- [x] Parent POM downloaded and configurations inherited
- [x] CI build will verify compatibility

Closes #5