### PR TITLE
Add CI Build and Maven Central badges to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,8 @@
 :icons: font
 :source-highlighter: rouge
 
+image:https://github.com/dataliquid/asciidoc-linter/actions/workflows/ci.yml/badge.svg[CI Build,link=https://github.com/dataliquid/asciidoc-linter/actions/workflows/ci.yml]
+image:https://maven-badges.herokuapp.com/maven-central/com.dataliquid/asciidoc-linter/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/com.dataliquid/asciidoc-linter]
 image:https://img.shields.io/badge/license-Apache%202.0-blue.svg[License,link=https://opensource.org/licenses/Apache-2.0]
 image:https://img.shields.io/badge/Java-17%2B-blue.svg[Java Version]
 image:https://img.shields.io/badge/Maven-3.8%2B-blue.svg[Maven Version]


### PR DESCRIPTION
## Summary
- Added CI Build badge that shows GitHub Actions workflow status
- Added Maven Central badge that displays the latest available version
- Badges follow the same format as the dataliquid/commons-xml project

## Test plan
- [x] Verified badges display correctly in README.adoc
- [x] Ran `mvn clean test` - all tests pass
- [x] Badges link to correct destinations (GitHub Actions and Maven Central)

🤖 Generated with [Claude Code](https://claude.ai/code)