### PR TITLE
#21 Remove exactMatch validation

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/Linter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/Linter.java
@@ -385,21 +385,14 @@ public class Linter {
         }
         
         // Then check title constraints if configured
-        if (config.title() != null) {
+        if (config.title() != null && config.title().pattern() != null) {
             String title = section.getTitle();
             if (title == null) {
                 return false;
             }
             
-            // Check exact match
-            if (config.title().exactMatch() != null) {
-                return title.equals(config.title().exactMatch());
-            }
-            
             // Check pattern match
-            if (config.title().pattern() != null) {
-                return title.matches(config.title().pattern());
-            }
+            return title.matches(config.title().pattern());
         }
         
         // Level matches and no title constraints

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/TitleConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/TitleConfig.java
@@ -10,20 +10,15 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 @JsonDeserialize(builder = TitleConfig.Builder.class)
 public final class TitleConfig {
     private final String pattern;
-    private final String exactMatch;
     private final Severity severity;
 
     private TitleConfig(Builder builder) {
         this.pattern = builder.pattern;
-        this.exactMatch = builder.exactMatch;
         this.severity = builder.severity;
     }
 
     @JsonProperty("pattern")
     public String pattern() { return pattern; }
-    
-    @JsonProperty("exactMatch")
-    public String exactMatch() { return exactMatch; }
     
     @JsonProperty("severity")
     public Severity severity() { return severity; }
@@ -35,18 +30,11 @@ public final class TitleConfig {
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private String pattern;
-        private String exactMatch;
         private Severity severity = Severity.ERROR;
 
         @JsonProperty("pattern")
         public Builder pattern(String pattern) {
             this.pattern = pattern;
-            return this;
-        }
-
-        @JsonProperty("exactMatch")
-        public Builder exactMatch(String exactMatch) {
-            this.exactMatch = exactMatch;
             return this;
         }
 
@@ -57,11 +45,8 @@ public final class TitleConfig {
         }
 
         public TitleConfig build() {
-            if (pattern == null && exactMatch == null) {
-                throw new IllegalStateException("Either pattern or exactMatch must be specified");
-            }
-            if (pattern != null && exactMatch != null) {
-                throw new IllegalStateException("Cannot specify both pattern and exactMatch");
+            if (pattern == null) {
+                throw new IllegalStateException("Pattern must be specified");
             }
             return new TitleConfig(this);
         }
@@ -73,12 +58,11 @@ public final class TitleConfig {
         if (o == null || getClass() != o.getClass()) return false;
         TitleConfig that = (TitleConfig) o;
         return Objects.equals(pattern, that.pattern) &&
-               Objects.equals(exactMatch, that.exactMatch) &&
                severity == that.severity;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pattern, exactMatch, severity);
+        return Objects.hash(pattern, severity);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/SectionValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/SectionValidator.java
@@ -97,17 +97,13 @@ public final class SectionValidator {
                 // Find the first config with a pattern to show in error message
                 SectionConfig configWithPattern = levelConfigs.stream()
                     .filter(config -> config.title() != null && 
-                           (config.title().pattern() != null || config.title().exactMatch() != null))
+                           config.title().pattern() != null)
                     .findFirst()
                     .orElse(levelConfigs.get(0));
                 
                 String expectedPattern = null;
-                if (configWithPattern.title() != null) {
-                    if (configWithPattern.title().pattern() != null) {
-                        expectedPattern = "Pattern: " + configWithPattern.title().pattern();
-                    } else if (configWithPattern.title().exactMatch() != null) {
-                        expectedPattern = "Exact match: " + configWithPattern.title().exactMatch();
-                    }
+                if (configWithPattern.title() != null && configWithPattern.title().pattern() != null) {
+                    expectedPattern = "Pattern: " + configWithPattern.title().pattern();
                 }
                 
                 ValidationMessage message = ValidationMessage.builder()
@@ -174,18 +170,6 @@ public final class SectionValidator {
                     .build();
                 resultBuilder.addMessage(message);
             }
-        }
-        
-        if (titleConfig.exactMatch() != null && !title.equals(titleConfig.exactMatch())) {
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(titleConfig.severity())
-                .ruleId("section.title.exact")
-                .location(location)
-                .message("Section title does not match expected value")
-                .actualValue(title)
-                .expectedValue(titleConfig.exactMatch())
-                .build();
-            resultBuilder.addMessage(message);
         }
     }
 
@@ -287,18 +271,6 @@ public final class SectionValidator {
                 resultBuilder.addMessage(message);
             }
         }
-        
-        if (titleConfig.exactMatch() != null && !title.equals(titleConfig.exactMatch())) {
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(titleConfig.severity())
-                .ruleId("section.title.exactMatch")
-                .location(location)
-                .message("Document title does not match expected value")
-                .actualValue(title)
-                .expectedValue(titleConfig.exactMatch())
-                .build();
-            resultBuilder.addMessage(message);
-        }
     }
     
     private void validateDocumentTitle(Document document, String filename, ValidationResult.Builder resultBuilder) {
@@ -332,7 +304,7 @@ public final class SectionValidator {
             return;
         }
         
-        // Validate title pattern/exactMatch if title exists
+        // Validate title pattern if title exists
         if (documentTitle != null && titleConfig.title() != null) {
             validateDocumentTitleConfig(documentTitle, titleConfig.title(), location, resultBuilder);
         }
@@ -399,17 +371,10 @@ public final class SectionValidator {
                 continue;
             }
             
-            if (config.title() != null) {
-                if (config.title().exactMatch() != null && 
-                    config.title().exactMatch().equals(title)) {
+            if (config.title() != null && config.title().pattern() != null) {
+                Pattern pattern = Pattern.compile(config.title().pattern());
+                if (pattern.matcher(title).matches()) {
                     return config;
-                }
-                
-                if (config.title().pattern() != null) {
-                    Pattern pattern = Pattern.compile(config.title().pattern());
-                    if (pattern.matcher(title).matches()) {
-                        return config;
-                    }
                 }
             } else if (config.name() != null) {
                 return config;

--- a/src/main/resources/schemas/rules/section-schema.yaml
+++ b/src/main/resources/schemas/rules/section-schema.yaml
@@ -37,18 +37,12 @@ properties:
         type: string
         description: Regular expression pattern the section title must match
         minLength: 1
-      exactMatch:
-        type: string
-        description: Exact string the section title must match
-        minLength: 1
       severity:
         type: string
         description: Severity level for title validation violations
         enum: [error, warn, info]
         default: error
-    oneOf:
-      - required: [pattern, severity]
-      - required: [exactMatch, severity]
+    required: [pattern, severity]
     additionalProperties: false
   allowedBlocks:
     type: array

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/SectionValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/SectionValidatorTest.java
@@ -157,7 +157,7 @@ class SectionValidatorTest {
                 .min(1)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Introduction")
+                    .pattern("^Introduction$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -168,7 +168,7 @@ class SectionValidatorTest {
                 .min(0)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Getting Started")
+                    .pattern("^Getting Started$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -204,7 +204,7 @@ class SectionValidatorTest {
                 .min(1)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Introduction")
+                    .pattern("^Introduction$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -252,10 +252,6 @@ class SectionValidatorTest {
                 .level(1)
                 .min(0)
                 .max(1)
-                .title(TitleConfig.builder()
-                    .exactMatch("Introduction")
-                    .severity(Severity.ERROR)
-                    .build())
                 .build();
             
             DocumentConfiguration config = DocumentConfiguration.builder()
@@ -482,10 +478,6 @@ class SectionValidatorTest {
                 .level(1)
                 .min(0)
                 .max(1)
-                .title(TitleConfig.builder()
-                    .exactMatch("Introduction")
-                    .severity(Severity.ERROR)
-                    .build())
                 .build();
             
             DocumentConfiguration config = DocumentConfiguration.builder()
@@ -537,7 +529,7 @@ class SectionValidatorTest {
                 .level(1)
                 .order(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Introduction")
+                    .pattern("^Introduction$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -547,7 +539,7 @@ class SectionValidatorTest {
                 .level(1)
                 .order(2)
                 .title(TitleConfig.builder()
-                    .exactMatch("Prerequisites")
+                    .pattern("^Prerequisites$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -557,7 +549,7 @@ class SectionValidatorTest {
                 .level(1)
                 .order(3)
                 .title(TitleConfig.builder()
-                    .exactMatch("Installation")
+                    .pattern("^Installation$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -595,7 +587,7 @@ class SectionValidatorTest {
                 .level(1)
                 .order(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Introduction")
+                    .pattern("^Introduction$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -605,7 +597,7 @@ class SectionValidatorTest {
                 .level(1)
                 .order(2)
                 .title(TitleConfig.builder()
-                    .exactMatch("Installation")
+                    .pattern("^Installation$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -658,7 +650,7 @@ class SectionValidatorTest {
                 .min(1)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Core Features")
+                    .pattern("^Core Features$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -669,7 +661,7 @@ class SectionValidatorTest {
                 .min(0)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Advanced Features")
+                    .pattern("^Advanced Features$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -680,7 +672,7 @@ class SectionValidatorTest {
                 .min(1)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Features")
+                    .pattern("^Features$")
                     .severity(Severity.ERROR)
                     .build())
                 .subsections(Arrays.asList(coreFeatures, advancedFeatures))
@@ -720,7 +712,7 @@ class SectionValidatorTest {
                 .min(1)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Core Features")
+                    .pattern("^Core Features$")
                     .severity(Severity.ERROR)
                     .build())
                 .build();
@@ -731,7 +723,7 @@ class SectionValidatorTest {
                 .min(1)
                 .max(1)
                 .title(TitleConfig.builder()
-                    .exactMatch("Features")
+                    .pattern("^Features$")
                     .severity(Severity.ERROR)
                     .build())
                 .subsections(Arrays.asList(coreFeatures))

--- a/src/test/java/com/dataliquid/linter/LinterValidationIntegrationTest.java
+++ b/src/test/java/com/dataliquid/linter/LinterValidationIntegrationTest.java
@@ -851,9 +851,6 @@ class LinterValidationIntegrationTest {
                           level: 1
                           min: 1
                           max: 1
-                          title:
-                            exactMatch: "Introduction"
-                            severity: error
                           allowedBlocks:
                             - paragraph:
                                 severity: error
@@ -912,7 +909,7 @@ class LinterValidationIntegrationTest {
                           min: 1
                           max: 1
                           title:
-                            exactMatch: "Einleitung"
+                            pattern: "^Einleitung$"
                             severity: error
                           allowedBlocks:
                             - paragraph:
@@ -926,7 +923,7 @@ class LinterValidationIntegrationTest {
                           min: 1
                           max: 1
                           title:
-                            exactMatch: "Tutorial"
+                            pattern: "^Tutorial$"
                             severity: error
                           allowedBlocks:
                             - paragraph:
@@ -1002,9 +999,6 @@ class LinterValidationIntegrationTest {
                           level: 1
                           min: 1
                           max: 1
-                          title:
-                            exactMatch: "Einleitung"
-                            severity: error
                           allowedBlocks:
                             - paragraph:
                                 severity: error
@@ -1386,9 +1380,6 @@ class LinterValidationIntegrationTest {
                   sections:
                     - name: mainSection
                       level: 1
-                      title:
-                        exactMatch: "Implementation"
-                        severity: error
                       allowedBlocks:
                         - paragraph:
                             severity: error
@@ -1433,9 +1424,6 @@ class LinterValidationIntegrationTest {
                   sections:
                     - name: mainSection
                       level: 1
-                      title:
-                        exactMatch: "Overview"
-                        severity: error
                       allowedBlocks:
                         - paragraph:
                             severity: error
@@ -1488,9 +1476,6 @@ class LinterValidationIntegrationTest {
                   sections:
                     - name: mainSection
                       level: 1
-                      title:
-                        exactMatch: "Configuration"
-                        severity: error
                       allowedBlocks:
                         - paragraph:
                             severity: error
@@ -1607,7 +1592,7 @@ class LinterValidationIntegrationTest {
                     - name: introSection
                       level: 1
                       title:
-                        exactMatch: "Introduction"
+                        pattern: "^Introduction$"
                         severity: error
                       allowedBlocks:
                         - paragraph:
@@ -1619,7 +1604,7 @@ class LinterValidationIntegrationTest {
                     - name: detailsSection
                       level: 1
                       title:
-                        exactMatch: "Details"
+                        pattern: "^Details$"
                         severity: error
                       allowedBlocks:
                         - paragraph:


### PR DESCRIPTION
Remove exactMatch validation in favor of pattern-only validation to simplify the codebase.

## Changes
- Removed exactMatch field from TitleConfig
- Updated schema to remove exactMatch property
- Refactored validators to use pattern instead of exactMatch
- Updated all tests to use pattern validation