### PR TITLE
#25 Add separate CLI options for output configurations

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIConfig.java
@@ -15,6 +15,7 @@ public class CLIConfig {
     private final List<String> inputPatterns;
     private final Path baseDirectory;
     private final Path configFile;
+    private final String outputConfigName;
     private final Path outputConfigFile;
     private final String reportFormat;
     private final Path reportOutput;
@@ -27,6 +28,7 @@ public class CLIConfig {
         }
         this.baseDirectory = Objects.requireNonNull(builder.baseDirectory, "[" + getClass().getName() + "] baseDirectory must not be null");
         this.configFile = builder.configFile;
+        this.outputConfigName = builder.outputConfigName;
         this.outputConfigFile = builder.outputConfigFile;
         this.reportFormat = Objects.requireNonNull(builder.reportFormat, "[" + getClass().getName() + "] reportFormat must not be null");
         this.reportOutput = builder.reportOutput;
@@ -43,6 +45,10 @@ public class CLIConfig {
     
     public Path getConfigFile() {
         return configFile;
+    }
+    
+    public String getOutputConfigName() {
+        return outputConfigName;
     }
     
     public Path getOutputConfigFile() {
@@ -73,6 +79,7 @@ public class CLIConfig {
         private List<String> inputPatterns;
         private Path baseDirectory = Paths.get(System.getProperty("user.dir"));
         private Path configFile;
+        private String outputConfigName;
         private Path outputConfigFile;
         private String reportFormat = "console";
         private Path reportOutput;
@@ -90,6 +97,11 @@ public class CLIConfig {
         
         public Builder configFile(Path configFile) {
             this.configFile = configFile;
+            return this;
+        }
+        
+        public Builder outputConfigName(String outputConfigName) {
+            this.outputConfigName = outputConfigName;
             return this;
         }
         

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOptions.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOptions.java
@@ -56,12 +56,20 @@ public class CLIOptions {
             .desc("Exit code 1 on: error, warn, info (default: error)")
             .build());
         
-        // Output configuration
+        // Output configuration (predefined)
         options.addOption(Option.builder()
             .longOpt("output-config")
             .hasArg()
+            .argName("name")
+            .desc("Predefined output configuration: enhanced, simple, compact (default: enhanced)")
+            .build());
+        
+        // Output configuration (custom file)
+        options.addOption(Option.builder()
+            .longOpt("output-config-file")
+            .hasArg()
             .argName("file")
-            .desc("YAML output configuration file for enhanced console formatting")
+            .desc("Custom YAML output configuration file for console formatting")
             .build());
         
         // Help

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOutputHandler.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOutputHandler.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import com.dataliquid.asciidoc.linter.config.output.OutputConfiguration;
 import com.dataliquid.asciidoc.linter.report.ReportWriter;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
@@ -24,18 +25,18 @@ public class CLIOutputHandler {
     /**
      * Writes a single validation result based on the CLI configuration.
      */
-    public void writeReport(ValidationResult result, CLIConfig config) throws IOException {
+    public void writeReport(ValidationResult result, CLIConfig config, OutputConfiguration outputConfig) throws IOException {
         if (config.isOutputToFile()) {
             // Write to file
             Path outputFile = config.getReportOutput();
             ensureParentDirectoryExists(outputFile);
             
             try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile.toFile()))) {
-                reportWriter.write(result, config.getReportFormat(), writer);
+                reportWriter.write(result, config.getReportFormat(), writer, outputConfig);
             }
         } else {
             // Write to console (stdout)
-            reportWriter.writeToConsole(result, config.getReportFormat());
+            reportWriter.writeToConsole(result, config.getReportFormat(), outputConfig);
         }
     }
     
@@ -43,10 +44,10 @@ public class CLIOutputHandler {
      * Writes multiple validation results for directory input.
      */
     public void writeMultipleReports(Map<Path, ValidationResult> results, CLIConfig config, 
-                                   ValidationResult aggregated) throws IOException {
+                                   ValidationResult aggregated, OutputConfiguration outputConfig) throws IOException {
         if (!config.isOutputToFile()) {
             // Write aggregated result to console
-            reportWriter.writeToConsole(aggregated, config.getReportFormat());
+            reportWriter.writeToConsole(aggregated, config.getReportFormat(), outputConfig);
             return;
         }
         
@@ -54,15 +55,15 @@ public class CLIOutputHandler {
         
         if (Files.isDirectory(output) || output.toString().endsWith("/") || output.toString().endsWith("\\")) {
             // Write individual reports to directory
-            writeIndividualReports(results, config, output);
+            writeIndividualReports(results, config, output, outputConfig);
         } else {
             // Write aggregated report to single file
-            writeReport(aggregated, config);
+            writeReport(aggregated, config, outputConfig);
         }
     }
     
     private void writeIndividualReports(Map<Path, ValidationResult> results, CLIConfig config, 
-                                      Path outputDir) throws IOException {
+                                      Path outputDir, OutputConfiguration outputConfig) throws IOException {
         // Ensure output directory exists
         if (!Files.exists(outputDir)) {
             Files.createDirectories(outputDir);
@@ -77,7 +78,7 @@ public class CLIOutputHandler {
             Path outputFile = outputDir.resolve(outputFileName);
             
             try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile.toFile()))) {
-                reportWriter.write(result, config.getReportFormat(), writer);
+                reportWriter.write(result, config.getReportFormat(), writer, outputConfig);
             }
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
@@ -66,8 +66,11 @@ public class ConfigurationDisplay {
             config.getConfigFile().toString() : "default";
         drawConfigLine("Configuration:", configFile);
         
-        // Output config file - only shown if specified
-        if (config.getOutputConfigFile() != null) {
+        // Output config - show name or file if specified
+        if (config.getOutputConfigName() != null) {
+            drawConfigLine("Output config:", 
+                config.getOutputConfigName() + " (predefined)");
+        } else if (config.getOutputConfigFile() != null) {
             drawConfigLine("Output config:", 
                 config.getOutputConfigFile().toString());
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/LinterCLI.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/LinterCLI.java
@@ -126,9 +126,22 @@ public class LinterCLI {
             builder.configFile(Paths.get(cmd.getOptionValue("config")));
         }
         
-        // Output config file
+        // Output configuration
+        if (cmd.hasOption("output-config") && cmd.hasOption("output-config-file")) {
+            throw new IllegalArgumentException("Cannot use both --output-config and --output-config-file. Choose one.");
+        }
+        
         if (cmd.hasOption("output-config")) {
-            builder.outputConfigFile(Paths.get(cmd.getOptionValue("output-config")));
+            String configName = cmd.getOptionValue("output-config");
+            // Validate predefined names
+            if (!configName.equals("enhanced") && !configName.equals("simple") && !configName.equals("compact")) {
+                throw new IllegalArgumentException("Invalid output config name: " + configName + ". Valid options: enhanced, simple, compact");
+            }
+            builder.outputConfigName(configName);
+        }
+        
+        if (cmd.hasOption("output-config-file")) {
+            builder.outputConfigFile(Paths.get(cmd.getOptionValue("output-config-file")));
         }
         
         // Report format
@@ -172,7 +185,8 @@ public class LinterCLI {
             "  " + programName + " -i \"**/*.adoc\"\n" +
             "  " + programName + " -i \"docs/**/*.adoc,examples/**/*.asciidoc\" -f json -o report.json\n" +
             "  " + programName + " --input \"src/*/docs/**/*.adoc,README.adoc\" --config strict.yaml --fail-level warn\n" +
-            "  " + programName + " -i \"**/*.adoc\" --output-config enhanced-output.yaml\n" +
+            "  " + programName + " -i \"**/*.adoc\" --output-config simple\n" +
+            "  " + programName + " -i \"**/*.adoc\" --output-config-file my-output.yaml\n" +
             "\nAnt Pattern Syntax:\n" +
             "  **  - matches any number of directories\n" +
             "  *   - matches any number of characters (except /)\n" +

--- a/src/main/resources/output-configs/compact.yaml
+++ b/src/main/resources/output-configs/compact.yaml
@@ -1,0 +1,27 @@
+# Compact output configuration - Single-line format for CI/CD environments
+output:
+  format: compact
+  
+  display:
+    contextLines: 0
+    highlightStyle: none
+    useColors: false
+    showLineNumbers: false
+    maxLineWidth: 200
+    showHeader: false
+  
+  suggestions:
+    enabled: false
+    maxPerError: 1
+    showExamples: false
+    showAutoFixHint: false
+  
+  errorGrouping:
+    enabled: false
+    threshold: 10
+  
+  summary:
+    enabled: false
+    showStatistics: false
+    showMostCommon: false
+    showFileList: false

--- a/src/main/resources/output-configs/enhanced.yaml
+++ b/src/main/resources/output-configs/enhanced.yaml
@@ -1,0 +1,27 @@
+# Enhanced output configuration - Full featured output with all bells and whistles
+output:
+  format: enhanced
+  
+  display:
+    contextLines: 3
+    highlightStyle: underline
+    useColors: true
+    showLineNumbers: true
+    maxLineWidth: 120
+    showHeader: true
+  
+  suggestions:
+    enabled: true
+    maxPerError: 3
+    showExamples: true
+    showAutoFixHint: true
+  
+  errorGrouping:
+    enabled: true
+    threshold: 3
+  
+  summary:
+    enabled: true
+    showStatistics: true
+    showMostCommon: true
+    showFileList: false

--- a/src/main/resources/output-configs/simple.yaml
+++ b/src/main/resources/output-configs/simple.yaml
@@ -1,0 +1,27 @@
+# Simple output configuration - Basic output for quick scanning
+output:
+  format: simple
+  
+  display:
+    contextLines: 1
+    highlightStyle: arrow
+    useColors: true
+    showLineNumbers: true
+    maxLineWidth: 100
+    showHeader: false
+  
+  suggestions:
+    enabled: false
+    maxPerError: 1
+    showExamples: false
+    showAutoFixHint: false
+  
+  errorGrouping:
+    enabled: false
+    threshold: 5
+  
+  summary:
+    enabled: true
+    showStatistics: false
+    showMostCommon: false
+    showFileList: false

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/CLIRunnerOutputConfigTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/CLIRunnerOutputConfigTest.java
@@ -1,0 +1,132 @@
+package com.dataliquid.asciidoc.linter.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.dataliquid.asciidoc.linter.config.output.OutputConfiguration;
+import com.dataliquid.asciidoc.linter.config.output.OutputFormat;
+
+/**
+ * Tests for CLIRunner output configuration handling.
+ */
+class CLIRunnerOutputConfigTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testLoadPredefinedOutputConfig() throws IOException {
+        CLIRunner runner = new CLIRunner();
+        
+        // Test with predefined name
+        CLIConfig config = CLIConfig.builder()
+            .inputPatterns(java.util.List.of("*.adoc"))
+            .outputConfigName("simple")
+            .build();
+        
+        // Use reflection to access private method
+        OutputConfiguration outputConfig = invokeLoadOutputConfiguration(runner, config);
+        
+        assertNotNull(outputConfig);
+        assertEquals(OutputFormat.SIMPLE, outputConfig.getFormat());
+    }
+
+    @Test
+    void testLoadCustomOutputConfigFile() throws IOException {
+        CLIRunner runner = new CLIRunner();
+        
+        // Create a custom config file
+        Path customConfig = tempDir.resolve("custom.yaml");
+        Files.writeString(customConfig, """
+            output:
+              format: compact
+              display:
+                contextLines: 0
+                useColors: false
+            """);
+        
+        CLIConfig config = CLIConfig.builder()
+            .inputPatterns(java.util.List.of("*.adoc"))
+            .outputConfigFile(customConfig)
+            .build();
+        
+        OutputConfiguration outputConfig = invokeLoadOutputConfiguration(runner, config);
+        
+        assertNotNull(outputConfig);
+        assertEquals(OutputFormat.COMPACT, outputConfig.getFormat());
+        assertEquals(0, outputConfig.getDisplay().getContextLines());
+        assertEquals(false, outputConfig.getDisplay().isUseColors());
+    }
+
+    @Test
+    void testDefaultOutputConfig() throws IOException {
+        CLIRunner runner = new CLIRunner();
+        
+        // No output config specified
+        CLIConfig config = CLIConfig.builder()
+            .inputPatterns(java.util.List.of("*.adoc"))
+            .build();
+        
+        OutputConfiguration outputConfig = invokeLoadOutputConfiguration(runner, config);
+        
+        assertNotNull(outputConfig);
+        // Should default to enhanced
+        assertEquals(OutputFormat.ENHANCED, outputConfig.getFormat());
+    }
+
+    @Test
+    void testInvalidPredefinedName() {
+        CLIRunner runner = new CLIRunner();
+        
+        CLIConfig config = CLIConfig.builder()
+            .inputPatterns(java.util.List.of("*.adoc"))
+            .outputConfigName("invalid")
+            .build();
+        
+        IOException exception = assertThrows(IOException.class, 
+            () -> invokeLoadOutputConfiguration(runner, config));
+        
+        assertTrue(exception.getMessage().contains("Predefined output configuration not found: invalid"));
+    }
+
+    @Test
+    void testNonExistentConfigFile() {
+        CLIRunner runner = new CLIRunner();
+        
+        Path nonExistentFile = Paths.get("non-existent-config.yaml");
+        CLIConfig config = CLIConfig.builder()
+            .inputPatterns(java.util.List.of("*.adoc"))
+            .outputConfigFile(nonExistentFile)
+            .build();
+        
+        IOException exception = assertThrows(IOException.class, 
+            () -> invokeLoadOutputConfiguration(runner, config));
+        
+        assertTrue(exception.getMessage().contains("Output configuration file not found"));
+    }
+
+    // Helper method to invoke private method via reflection
+    private OutputConfiguration invokeLoadOutputConfiguration(CLIRunner runner, CLIConfig config) 
+            throws IOException {
+        try {
+            var method = CLIRunner.class.getDeclaredMethod("loadOutputConfiguration", CLIConfig.class);
+            method.setAccessible(true);
+            return (OutputConfiguration) method.invoke(runner, config);
+        } catch (Exception e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/LinterCLIOutputConfigTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/LinterCLIOutputConfigTest.java
@@ -1,0 +1,129 @@
+package com.dataliquid.asciidoc.linter.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for LinterCLI output configuration argument parsing.
+ */
+class LinterCLIOutputConfigTest {
+
+    @Test
+    void testOutputConfigParsing() {
+        LinterCLI cli = new LinterCLI();
+        
+        // Capture output
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+        
+        try {
+            // Test with predefined config name
+            int exitCode = cli.run(new String[]{
+                "--input", "test.adoc",
+                "--output-config", "simple"
+            });
+            
+            // Should fail because test.adoc doesn't exist, but parsing should succeed
+            assertEquals(2, exitCode);
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void testOutputConfigFileParsing() {
+        LinterCLI cli = new LinterCLI();
+        
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+        
+        try {
+            // Test with custom config file
+            int exitCode = cli.run(new String[]{
+                "--input", "test.adoc",
+                "--output-config-file", "custom-output.yaml"
+            });
+            
+            // Should fail because files don't exist, but parsing should succeed
+            assertEquals(2, exitCode);
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void testBothOutputConfigOptionsError() {
+        LinterCLI cli = new LinterCLI();
+        
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+        
+        try {
+            // Test with both options - should fail
+            int exitCode = cli.run(new String[]{
+                "--input", "test.adoc",
+                "--output-config", "simple",
+                "--output-config-file", "custom.yaml"
+            });
+            
+            assertEquals(2, exitCode);
+            String error = errContent.toString();
+            assertTrue(error.contains("Cannot use both --output-config and --output-config-file"));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void testInvalidOutputConfigName() {
+        LinterCLI cli = new LinterCLI();
+        
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+        
+        try {
+            // Test with invalid config name
+            int exitCode = cli.run(new String[]{
+                "--input", "test.adoc",
+                "--output-config", "invalid-name"
+            });
+            
+            assertEquals(2, exitCode);
+            String error = errContent.toString();
+            assertTrue(error.contains("Invalid output config name: invalid-name"));
+            assertTrue(error.contains("Valid options: enhanced, simple, compact"));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void testHelpShowsBothOptions() {
+        LinterCLI cli = new LinterCLI();
+        
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(outContent));
+        
+        try {
+            int exitCode = cli.run(new String[]{"--help"});
+            
+            assertEquals(0, exitCode);
+            String output = outContent.toString();
+            assertTrue(output.contains("--output-config"));
+            assertTrue(output.contains("--output-config-file"));
+            assertTrue(output.contains("enhanced, simple, compact"));
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+}

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/OutputConfigIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/OutputConfigIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.dataliquid.asciidoc.linter.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.dataliquid.asciidoc.linter.config.output.HighlightStyle;
+import com.dataliquid.asciidoc.linter.config.output.OutputConfiguration;
+import com.dataliquid.asciidoc.linter.config.output.OutputConfigurationLoader;
+import com.dataliquid.asciidoc.linter.config.output.OutputFormat;
+
+/**
+ * Integration test for output configuration loading.
+ */
+class OutputConfigIntegrationTest {
+
+    @Test
+    void testLoadEnhancedConfig() throws IOException {
+        OutputConfigurationLoader loader = new OutputConfigurationLoader();
+        OutputConfiguration config = loader.loadConfiguration(
+            getClass().getResourceAsStream("/output-configs/enhanced.yaml"));
+        
+        assertNotNull(config);
+        assertEquals(OutputFormat.ENHANCED, config.getFormat());
+        assertEquals(3, config.getDisplay().getContextLines());
+        assertEquals(HighlightStyle.UNDERLINE, config.getDisplay().getHighlightStyle());
+        assertEquals(true, config.getDisplay().isUseColors());
+        assertEquals(true, config.getSuggestions().isEnabled());
+        assertEquals(3, config.getSuggestions().getMaxPerError());
+    }
+
+    @Test
+    void testLoadSimpleConfig() throws IOException {
+        OutputConfigurationLoader loader = new OutputConfigurationLoader();
+        OutputConfiguration config = loader.loadConfiguration(
+            getClass().getResourceAsStream("/output-configs/simple.yaml"));
+        
+        assertNotNull(config);
+        assertEquals(OutputFormat.SIMPLE, config.getFormat());
+        assertEquals(1, config.getDisplay().getContextLines());
+        assertEquals(HighlightStyle.ARROW, config.getDisplay().getHighlightStyle());
+        assertEquals(false, config.getSuggestions().isEnabled());
+    }
+
+    @Test
+    void testLoadCompactConfig() throws IOException {
+        OutputConfigurationLoader loader = new OutputConfigurationLoader();
+        OutputConfiguration config = loader.loadConfiguration(
+            getClass().getResourceAsStream("/output-configs/compact.yaml"));
+        
+        assertNotNull(config);
+        assertEquals(OutputFormat.COMPACT, config.getFormat());
+        assertEquals(0, config.getDisplay().getContextLines());
+        assertEquals(HighlightStyle.NONE, config.getDisplay().getHighlightStyle());
+        assertEquals(false, config.getDisplay().isUseColors());
+        assertEquals(false, config.getSuggestions().isEnabled());
+        assertEquals(false, config.getSummary().isEnabled());
+    }
+}


### PR DESCRIPTION
## Summary
- Added `--output-config` for predefined configurations (enhanced, simple, compact)
- Added `--output-config-file` for custom YAML files
- Added validation to prevent using both options simultaneously