### PR TITLE
#30 Display actual/expected values in all output formats

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageRenderer.java
@@ -43,6 +43,14 @@ public class MessageRenderer {
         // File location
         writer.println("  File: " + message.getLocation().formatLocation());
         
+        // Actual and expected values
+        if (message.getActualValue().isPresent() || message.getExpectedValue().isPresent()) {
+            message.getActualValue().ifPresent(value -> 
+                writer.println("  Actual: " + value));
+            message.getExpectedValue().ifPresent(value -> 
+                writer.println("  Expected: " + value));
+        }
+        
         // Stack trace if available
         if (message.getCause().isPresent()) {
             writer.println();
@@ -102,6 +110,21 @@ public class MessageRenderer {
                .append(" [")
                .append(message.getRuleId())
                .append("]");
+        
+        // Add actual/expected values inline if present
+        if (message.getActualValue().isPresent() || message.getExpectedValue().isPresent()) {
+            compact.append(" (");
+            if (message.getActualValue().isPresent()) {
+                compact.append("actual: ").append(message.getActualValue().get());
+                if (message.getExpectedValue().isPresent()) {
+                    compact.append(", ");
+                }
+            }
+            if (message.getExpectedValue().isPresent()) {
+                compact.append("expected: ").append(message.getExpectedValue().get());
+            }
+            compact.append(")");
+        }
         
         // Add inline fix suggestion if available
         if (message.hasSuggestions() && !message.getSuggestions().isEmpty()) {

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatterTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatterTest.java
@@ -133,8 +133,8 @@ class ConsoleFormatterTest {
         }
         
         @Test
-        @DisplayName("should include actual and expected values")
-        void shouldIncludeActualAndExpectedValues() {
+        @DisplayName("should include actual and expected values in SIMPLE format")
+        void shouldIncludeActualAndExpectedValuesInSimpleFormat() {
             // Given
             ValidationMessage message = ValidationMessage.builder()
                 .severity(Severity.ERROR)
@@ -161,6 +161,91 @@ class ConsoleFormatterTest {
             String output = stringWriter.toString();
             assertTrue(output.contains("Actual: 100"));
             assertTrue(output.contains("Expected: 80"));
+        }
+        
+        @Test
+        @DisplayName("should include actual and expected values in ENHANCED format")
+        void shouldIncludeActualAndExpectedValuesInEnhancedFormat() {
+            // Given
+            OutputConfiguration enhancedConfig = OutputConfiguration.builder()
+                .format(OutputFormat.ENHANCED)
+                .display(DisplayConfig.builder()
+                    .useColors(false)
+                    .contextLines(0) // Disable context for cleaner test
+                    .build())
+                .build();
+            ConsoleFormatter enhancedFormatter = new ConsoleFormatter(enhancedConfig);
+            
+            ValidationMessage message = ValidationMessage.builder()
+                .severity(Severity.ERROR)
+                .ruleId("listing.language.allowed")
+                .location(SourceLocation.builder()
+                    .filename("test.adoc")
+                    .startLine(15)
+                    .build())
+                .message("Listing block has unsupported language")
+                .actualValue("ruby")
+                .expectedValue("One of: java, python, javascript")
+                .build();
+            
+            ValidationResult result = ValidationResult.builder()
+                .addMessage(message)
+                .complete()
+                .build();
+            
+            // When
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            enhancedFormatter.format(result, pw);
+            pw.flush();
+            
+            // Then
+            String output = sw.toString();
+            assertTrue(output.contains("Actual: ruby"), 
+                "Enhanced format should display actual value. Output was:\n" + output);
+            assertTrue(output.contains("Expected: One of: java, python, javascript"), 
+                "Enhanced format should display expected value. Output was:\n" + output);
+        }
+        
+        @Test
+        @DisplayName("should include actual and expected values inline in COMPACT format")
+        void shouldIncludeActualAndExpectedValuesInCompactFormat() {
+            // Given
+            OutputConfiguration compactConfig = OutputConfiguration.builder()
+                .format(OutputFormat.COMPACT)
+                .display(DisplayConfig.builder()
+                    .useColors(false)
+                    .build())
+                .build();
+            ConsoleFormatter compactFormatter = new ConsoleFormatter(compactConfig);
+            
+            ValidationMessage message = ValidationMessage.builder()
+                .severity(Severity.ERROR)
+                .ruleId("listing.language.allowed")
+                .location(SourceLocation.builder()
+                    .filename("test.adoc")
+                    .startLine(15)
+                    .build())
+                .message("Listing block has unsupported language")
+                .actualValue("ruby")
+                .expectedValue("One of: java, python, javascript")
+                .build();
+            
+            ValidationResult result = ValidationResult.builder()
+                .addMessage(message)
+                .complete()
+                .build();
+            
+            // When
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            compactFormatter.format(result, pw);
+            pw.flush();
+            
+            // Then
+            String output = sw.toString();
+            assertTrue(output.contains("(actual: ruby, expected: One of: java, python, javascript)"), 
+                "Compact format should display actual/expected values inline. Output was:\n" + output);
         }
         
         @Test


### PR DESCRIPTION
Updated MessageRenderer to display actual/expected values in all output formats (ENHANCED, COMPACT, SIMPLE).

Fixes #30