### PR TITLE
#32 Display default output config when none is specified

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
@@ -73,6 +73,8 @@ public class ConfigurationDisplay {
         } else if (config.getOutputConfigFile() != null) {
             drawConfigLine("Output config:", 
                 config.getOutputConfigFile().toString());
+        } else {
+            drawConfigLine("Output config:", "enhanced (default)");
         }
         
         // Report format - always shown
@@ -119,9 +121,14 @@ public class ConfigurationDisplay {
             config.getConfigFile().toString() : "default";
         entries.add(new ConfigEntry("Configuration", configFile));
         
-        if (config.getOutputConfigFile() != null) {
+        if (config.getOutputConfigName() != null) {
+            entries.add(new ConfigEntry("Output config", 
+                config.getOutputConfigName() + " (predefined)"));
+        } else if (config.getOutputConfigFile() != null) {
             entries.add(new ConfigEntry("Output config", 
                 config.getOutputConfigFile().toString()));
+        } else {
+            entries.add(new ConfigEntry("Output config", "enhanced (default)"));
         }
         
         entries.add(new ConfigEntry("Report format", config.getReportFormat()));


### PR DESCRIPTION
## Summary
- Fixes issue where default output configuration is not displayed in console when no explicit configuration is provided
- Now shows "enhanced (default)" when neither --output-config nor --output-config-file is specified

## Changes
- Updated `ConfigurationDisplay.drawConfiguration()` to show default output config
- Updated `ConfigurationDisplay.getConfigurationEntries()` to include default output config

## Test plan
- [x] Manually tested running linter without output config parameters
- [x] Verified "Output config: enhanced (default)" appears in configuration display
- [x] All existing tests pass