### PR TITLE
#39 Extract block attribute names to centralized constants

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/BlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/BlockValidator.java
@@ -297,7 +297,6 @@ public final class BlockValidator {
                 // Find the actual block positions for error reporting
                 int currentBlockIndex = -1;
                 int nextBlockIndex = -1;
-                int blockIndex = 0;
                 
                 for (int j = 0; j < blocks.size(); j++) {
                     StructuralNode block = blocks.get(j);
@@ -314,7 +313,6 @@ public final class BlockValidator {
                             nextBlockIndex = j;
                         }
                     }
-                    blockIndex++;
                 }
                 
                 String currentKey = current.getName() != null ? current.getName() : current.getType().toString();

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AdmonitionBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AdmonitionBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.AdmonitionBlock;
@@ -95,7 +97,7 @@ public final class AdmonitionBlockValidator extends AbstractBlockValidator<Admon
         }
         
         // Try role attribute as fallback
-        Object role = block.getAttribute(BlockAttributes.ROLE);
+        Object role = block.getAttribute(ROLE);
         if (role != null) {
             return role.toString().toUpperCase();
         }
@@ -106,13 +108,13 @@ public final class AdmonitionBlockValidator extends AbstractBlockValidator<Admon
     
     private boolean hasIcon(StructuralNode block) {
         // Check if icons are enabled at document level
-        Object docIcons = block.getDocument().getAttribute(BlockAttributes.ICONS);
+        Object docIcons = block.getDocument().getAttribute(ICONS);
         if (docIcons != null && "font".equals(docIcons.toString())) {
             return true;
         }
         
         // Check block-level icon attribute
-        Object blockIcon = block.getAttribute(BlockAttributes.ICON);
+        Object blockIcon = block.getAttribute(ICON);
         return blockIcon != null && !"none".equals(blockIcon.toString());
     }
     
@@ -408,7 +410,7 @@ public final class AdmonitionBlockValidator extends AbstractBlockValidator<Admon
     }
     
     private String getIconValue(StructuralNode block) {
-        Object icon = block.getAttribute(BlockAttributes.ICON);
+        Object icon = block.getAttribute(ICON);
         return icon != null ? icon.toString() : null;
     }
     

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AdmonitionBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AdmonitionBlockValidator.java
@@ -95,7 +95,7 @@ public final class AdmonitionBlockValidator extends AbstractBlockValidator<Admon
         }
         
         // Try role attribute as fallback
-        Object role = block.getAttribute("role");
+        Object role = block.getAttribute(BlockAttributes.ROLE);
         if (role != null) {
             return role.toString().toUpperCase();
         }
@@ -106,13 +106,13 @@ public final class AdmonitionBlockValidator extends AbstractBlockValidator<Admon
     
     private boolean hasIcon(StructuralNode block) {
         // Check if icons are enabled at document level
-        Object docIcons = block.getDocument().getAttribute("icons");
+        Object docIcons = block.getDocument().getAttribute(BlockAttributes.ICONS);
         if (docIcons != null && "font".equals(docIcons.toString())) {
             return true;
         }
         
         // Check block-level icon attribute
-        Object blockIcon = block.getAttribute("icon");
+        Object blockIcon = block.getAttribute(BlockAttributes.ICON);
         return blockIcon != null && !"none".equals(blockIcon.toString());
     }
     
@@ -408,7 +408,7 @@ public final class AdmonitionBlockValidator extends AbstractBlockValidator<Admon
     }
     
     private String getIconValue(StructuralNode block) {
-        Object icon = block.getAttribute("icon");
+        Object icon = block.getAttribute(BlockAttributes.ICON);
         return icon != null ? icon.toString() : null;
     }
     

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AudioBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AudioBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.AudioBlock;
@@ -81,7 +83,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
     
     private String getAudioUrl(StructuralNode block) {
         // Try different ways to get audio URL
-        Object target = block.getAttribute("target");
+        Object target = block.getAttribute(TARGET);
         if (target != null) {
             return target.toString();
         }
@@ -102,7 +104,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
         }
         
         // Then try the caption attribute
-        Object caption = block.getAttribute("caption");
+        Object caption = block.getAttribute(CAPTION);
         if (caption != null) {
             return caption.toString();
         }
@@ -186,7 +188,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
         Severity severity = autoplayConfig.getSeverity() != null ? 
             autoplayConfig.getSeverity() : audioConfig.getSeverity();
         
-        boolean hasAutoplay = hasOption(block, "autoplay");
+        boolean hasAutoplay = hasOption(block, AUTOPLAY);
         
         if (!autoplayConfig.isAllowed() && hasAutoplay) {
             messages.add(ValidationMessage.builder()
@@ -208,7 +210,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
         Severity severity = controlsConfig.getSeverity() != null ? 
             controlsConfig.getSeverity() : audioConfig.getSeverity();
         
-        boolean hasControls = !hasOption(block, "nocontrols");
+        boolean hasControls = !hasOption(block, NOCONTROLS);
         
         if (controlsConfig.isRequired() && !hasControls) {
             ControlsPosition pos = findControlsPosition(block, context);
@@ -241,7 +243,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
         Severity severity = loopConfig.getSeverity() != null ? 
             loopConfig.getSeverity() : audioConfig.getSeverity();
         
-        boolean hasLoop = hasOption(block, "loop");
+        boolean hasLoop = hasOption(block, LOOP);
         
         if (!loopConfig.isAllowed() && hasLoop) {
             messages.add(ValidationMessage.builder()
@@ -256,7 +258,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
     }
     
     private boolean hasOption(StructuralNode block, String option) {
-        Object opts = block.getAttribute("opts");
+        Object opts = block.getAttribute(OPTS);
         if (opts != null) {
             String optsStr = opts.toString();
             return optsStr.contains(option);

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockAttributes.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockAttributes.java
@@ -1,0 +1,58 @@
+package com.dataliquid.asciidoc.linter.validator.block;
+
+/**
+ * Central repository for all AsciiDoc block attribute names.
+ * This class provides constants for attribute names used across all block validators
+ * to ensure consistency and maintainability.
+ */
+public final class BlockAttributes {
+    
+    // Prevent instantiation
+    private BlockAttributes() {}
+    
+    // Common Attributes
+    public static final String TARGET = "target";
+    public static final String CAPTION = "caption";
+    public static final String TITLE = "title";
+    public static final String ROLE = "role";
+    public static final String ICONS = "icons";
+    public static final String ICON = "icon";
+    public static final String TYPE = "type";
+    public static final String REASON = "reason";
+    public static final String OPTIONS = "options";
+    public static final String OPTS = "opts";
+    public static final String POSITION = "position";
+    public static final String ALT = "alt";
+    
+    // Dimension Attributes
+    public static final String WIDTH = "width";
+    public static final String HEIGHT = "height";
+    
+    // Quote/Verse Attributes
+    public static final String ATTRIBUTION = "attribution";
+    public static final String AUTHOR = "author";
+    public static final String CITETITLE = "citetitle";
+    public static final String SOURCE = "source";
+    
+    // Numbered attributes (used in quote/verse blocks)
+    public static final String ATTR_1 = "1";
+    public static final String ATTR_2 = "2";
+    public static final String ATTR_3 = "3";
+    
+    // Media Control Attributes
+    public static final String POSTER = "poster";
+    public static final String CONTROLS = "controls";
+    public static final String NOCONTROLS = "nocontrols";
+    public static final String AUTOPLAY = "autoplay";
+    public static final String LOOP = "loop";
+    
+    // Code Attributes
+    public static final String LANGUAGE = "language";
+    
+    // Example Block Attributes
+    public static final String COLLAPSIBLE = "collapsible";
+    public static final String COLLAPSIBLE_OPTION = "collapsible-option";
+    
+    // Table Attributes
+    public static final String FRAME = "frame";
+}

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetector.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetector.java
@@ -4,6 +4,8 @@ import org.asciidoctor.ast.StructuralNode;
 
 import com.dataliquid.asciidoc.linter.config.BlockType;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 /**
  * Detects the type of AsciidoctorJ blocks and maps them to our BlockType enum.
  */
@@ -109,10 +111,10 @@ public final class BlockTypeDetector {
         }
         
         // Default: if it has attribution or citetitle, treat as quote
-        if (node.getAttribute(BlockAttributes.ATTRIBUTION) != null || 
-            node.getAttribute(BlockAttributes.CITETITLE) != null ||
-            node.getAttribute(BlockAttributes.AUTHOR) != null ||
-            node.getAttribute(BlockAttributes.SOURCE) != null) {
+        if (node.getAttribute(ATTRIBUTION) != null || 
+            node.getAttribute(CITETITLE) != null ||
+            node.getAttribute(AUTHOR) != null ||
+            node.getAttribute(SOURCE) != null) {
             return BlockType.QUOTE;
         }
         

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetector.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetector.java
@@ -109,10 +109,10 @@ public final class BlockTypeDetector {
         }
         
         // Default: if it has attribution or citetitle, treat as quote
-        if (node.getAttribute("attribution") != null || 
-            node.getAttribute("citetitle") != null ||
-            node.getAttribute("author") != null ||
-            node.getAttribute("source") != null) {
+        if (node.getAttribute(BlockAttributes.ATTRIBUTION) != null || 
+            node.getAttribute(BlockAttributes.CITETITLE) != null ||
+            node.getAttribute(BlockAttributes.AUTHOR) != null ||
+            node.getAttribute(BlockAttributes.SOURCE) != null) {
             return BlockType.QUOTE;
         }
         

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidator.java
@@ -125,9 +125,9 @@ public final class ExampleBlockValidator extends AbstractBlockValidator<ExampleB
         ExampleBlock.CollapsibleConfig config = block.getCollapsible();
         
         // Check for collapsible attribute
-        Object collapsibleAttr = node.getAttribute("collapsible-option");
+        Object collapsibleAttr = node.getAttribute(BlockAttributes.COLLAPSIBLE_OPTION);
         if (collapsibleAttr == null) {
-            collapsibleAttr = node.getAttribute("collapsible");
+            collapsibleAttr = node.getAttribute(BlockAttributes.COLLAPSIBLE);
         }
         
         // Check if collapsible is required

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.ExampleBlock;
@@ -125,9 +127,9 @@ public final class ExampleBlockValidator extends AbstractBlockValidator<ExampleB
         ExampleBlock.CollapsibleConfig config = block.getCollapsible();
         
         // Check for collapsible attribute
-        Object collapsibleAttr = node.getAttribute(BlockAttributes.COLLAPSIBLE_OPTION);
+        Object collapsibleAttr = node.getAttribute(COLLAPSIBLE_OPTION);
         if (collapsibleAttr == null) {
-            collapsibleAttr = node.getAttribute(BlockAttributes.COLLAPSIBLE);
+            collapsibleAttr = node.getAttribute(COLLAPSIBLE);
         }
         
         // Check if collapsible is required

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidator.java
@@ -86,7 +86,7 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
     
     private String getImageUrl(StructuralNode block) {
         // Try different ways to get image URL
-        Object target = block.getAttribute("target");
+        Object target = block.getAttribute(BlockAttributes.TARGET);
         if (target != null) {
             return target.toString();
         }
@@ -100,12 +100,12 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
     }
     
     private String getAltText(StructuralNode block) {
-        Object alt = block.getAttribute("alt");
+        Object alt = block.getAttribute(BlockAttributes.ALT);
         if (alt != null) {
             String altStr = alt.toString();
             // AsciidoctorJ generates default alt text from filename when none is provided
             // e.g., "missing-image.png" becomes "missing image"
-            Object target = block.getAttribute("target");
+            Object target = block.getAttribute(BlockAttributes.TARGET);
             if (target != null) {
                 String targetStr = target.toString();
                 // Remove file extension and convert to expected alt text format

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.blocks.ImageBlock;
 import com.dataliquid.asciidoc.linter.report.console.FileContentCache;
@@ -86,7 +88,7 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
     
     private String getImageUrl(StructuralNode block) {
         // Try different ways to get image URL
-        Object target = block.getAttribute(BlockAttributes.TARGET);
+        Object target = block.getAttribute(TARGET);
         if (target != null) {
             return target.toString();
         }
@@ -100,12 +102,12 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
     }
     
     private String getAltText(StructuralNode block) {
-        Object alt = block.getAttribute(BlockAttributes.ALT);
+        Object alt = block.getAttribute(ALT);
         if (alt != null) {
             String altStr = alt.toString();
             // AsciidoctorJ generates default alt text from filename when none is provided
             // e.g., "missing-image.png" becomes "missing image"
-            Object target = block.getAttribute(BlockAttributes.TARGET);
+            Object target = block.getAttribute(TARGET);
             if (target != null) {
                 String targetStr = target.toString();
                 // Remove file extension and convert to expected alt text format

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ListingBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ListingBlockValidator.java
@@ -85,13 +85,13 @@ public final class ListingBlockValidator extends AbstractBlockValidator<ListingB
     
     private String getLanguage(StructuralNode block) {
         // Language can be in different attributes
-        Object lang = block.getAttribute("language");
+        Object lang = block.getAttribute(BlockAttributes.LANGUAGE);
         if (lang != null) {
             return lang.toString();
         }
         
         // Try source attribute
-        lang = block.getAttribute("source");
+        lang = block.getAttribute(BlockAttributes.SOURCE);
         if (lang != null) {
             return lang.toString();
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ListingBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ListingBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.ListingBlock;
@@ -85,13 +87,13 @@ public final class ListingBlockValidator extends AbstractBlockValidator<ListingB
     
     private String getLanguage(StructuralNode block) {
         // Language can be in different attributes
-        Object lang = block.getAttribute(BlockAttributes.LANGUAGE);
+        Object lang = block.getAttribute(LANGUAGE);
         if (lang != null) {
             return lang.toString();
         }
         
         // Try source attribute
-        lang = block.getAttribute(BlockAttributes.SOURCE);
+        lang = block.getAttribute(SOURCE);
         if (lang != null) {
             return lang.toString();
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidator.java
@@ -73,8 +73,8 @@ public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> 
         List<ValidationMessage> messages = new ArrayList<>();
         
         // Get pass block attributes
-        String passType = getAttributeAsString(block, "type");
-        String passReason = getAttributeAsString(block, "reason");
+        String passType = getAttributeAsString(block, BlockAttributes.TYPE);
+        String passReason = getAttributeAsString(block, BlockAttributes.REASON);
         String content = getBlockContent(block);
         
         // Validate type

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.PassBlock;
@@ -73,8 +75,8 @@ public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> 
         List<ValidationMessage> messages = new ArrayList<>();
         
         // Get pass block attributes
-        String passType = getAttributeAsString(block, BlockAttributes.TYPE);
-        String passReason = getAttributeAsString(block, BlockAttributes.REASON);
+        String passType = getAttributeAsString(block, TYPE);
+        String passReason = getAttributeAsString(block, REASON);
         String content = getBlockContent(block);
         
         // Validate type

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.QuoteBlock;
@@ -274,19 +276,19 @@ public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock
     
     private String extractAttribution(StructuralNode node) {
         // Check for attribution attribute (standard way)
-        Object attribution = node.getAttribute(BlockAttributes.ATTRIBUTION);
+        Object attribution = node.getAttribute(ATTRIBUTION);
         if (attribution != null) {
             return attribution.toString();
         }
         
         // Check for author attribute (alternative way)
-        Object author = node.getAttribute(BlockAttributes.AUTHOR);
+        Object author = node.getAttribute(AUTHOR);
         if (author != null) {
             return author.toString();
         }
         
         // Check for positional attribute [quote, Author, Source]
-        Object attr1 = node.getAttribute(BlockAttributes.ATTR_1);
+        Object attr1 = node.getAttribute(ATTR_1);
         if (attr1 != null) {
             return attr1.toString();
         }
@@ -296,19 +298,19 @@ public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock
     
     private String extractCitation(StructuralNode node) {
         // Check for citetitle attribute (standard way for citation)
-        Object citetitle = node.getAttribute(BlockAttributes.CITETITLE);
+        Object citetitle = node.getAttribute(CITETITLE);
         if (citetitle != null) {
             return citetitle.toString();
         }
         
         // Check for source attribute (alternative way)
-        Object source = node.getAttribute(BlockAttributes.SOURCE);
+        Object source = node.getAttribute(SOURCE);
         if (source != null) {
             return source.toString();
         }
         
         // Check for positional attribute [quote, Author, Source]
-        Object attr2 = node.getAttribute(BlockAttributes.ATTR_2);
+        Object attr2 = node.getAttribute(ATTR_2);
         if (attr2 != null) {
             return attr2.toString();
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidator.java
@@ -274,19 +274,19 @@ public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock
     
     private String extractAttribution(StructuralNode node) {
         // Check for attribution attribute (standard way)
-        Object attribution = node.getAttribute("attribution");
+        Object attribution = node.getAttribute(BlockAttributes.ATTRIBUTION);
         if (attribution != null) {
             return attribution.toString();
         }
         
         // Check for author attribute (alternative way)
-        Object author = node.getAttribute("author");
+        Object author = node.getAttribute(BlockAttributes.AUTHOR);
         if (author != null) {
             return author.toString();
         }
         
         // Check for positional attribute [quote, Author, Source]
-        Object attr1 = node.getAttribute("1");
+        Object attr1 = node.getAttribute(BlockAttributes.ATTR_1);
         if (attr1 != null) {
             return attr1.toString();
         }
@@ -296,19 +296,19 @@ public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock
     
     private String extractCitation(StructuralNode node) {
         // Check for citetitle attribute (standard way for citation)
-        Object citetitle = node.getAttribute("citetitle");
+        Object citetitle = node.getAttribute(BlockAttributes.CITETITLE);
         if (citetitle != null) {
             return citetitle.toString();
         }
         
         // Check for source attribute (alternative way)
-        Object source = node.getAttribute("source");
+        Object source = node.getAttribute(BlockAttributes.SOURCE);
         if (source != null) {
             return source.toString();
         }
         
         // Check for positional attribute [quote, Author, Source]
-        Object attr2 = node.getAttribute("2");
+        Object attr2 = node.getAttribute(BlockAttributes.ATTR_2);
         if (attr2 != null) {
             return attr2.toString();
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidator.java
@@ -6,6 +6,8 @@ import java.util.regex.Pattern;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.SidebarBlock;
@@ -236,7 +238,7 @@ public final class SidebarBlockValidator extends AbstractBlockValidator<SidebarB
         SidebarBlock.PositionConfig positionConfig = config.getPosition();
         
         // Get position attribute
-        Object positionAttr = block.getAttribute(BlockAttributes.POSITION);
+        Object positionAttr = block.getAttribute(POSITION);
         String position = positionAttr != null ? positionAttr.toString() : null;
         
         // Get severity with fallback to block severity

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidator.java
@@ -236,7 +236,7 @@ public final class SidebarBlockValidator extends AbstractBlockValidator<SidebarB
         SidebarBlock.PositionConfig positionConfig = config.getPosition();
         
         // Get position attribute
-        Object positionAttr = block.getAttribute("position");
+        Object positionAttr = block.getAttribute(BlockAttributes.POSITION);
         String position = positionAttr != null ? positionAttr.toString() : null;
         
         // Get severity with fallback to block severity

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidator.java
@@ -325,7 +325,7 @@ public final class TableBlockValidator extends AbstractBlockValidator<TableBlock
         
         // Validate table style
         if (config.getStyle() != null) {
-            Object styleObj = table.getAttribute("options");
+            Object styleObj = table.getAttribute(BlockAttributes.OPTIONS);
             String actualStyle = styleObj != null ? styleObj.toString() : null;
             if (actualStyle == null || !actualStyle.contains(config.getStyle())) {
                 messages.add(ValidationMessage.builder()
@@ -341,7 +341,7 @@ public final class TableBlockValidator extends AbstractBlockValidator<TableBlock
         
         // Validate borders
         if (config.getBorders() != null && config.getBorders()) {
-            Object frameObj = table.getAttribute("frame");
+            Object frameObj = table.getAttribute(BlockAttributes.FRAME);
             String frame = frameObj != null ? frameObj.toString() : null;
             if (frame == null || "none".equals(frame)) {
                 messages.add(ValidationMessage.builder()

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidator.java
@@ -9,6 +9,8 @@ import org.asciidoctor.ast.Row;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Table;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.TableBlock;
@@ -325,7 +327,7 @@ public final class TableBlockValidator extends AbstractBlockValidator<TableBlock
         
         // Validate table style
         if (config.getStyle() != null) {
-            Object styleObj = table.getAttribute(BlockAttributes.OPTIONS);
+            Object styleObj = table.getAttribute(OPTIONS);
             String actualStyle = styleObj != null ? styleObj.toString() : null;
             if (actualStyle == null || !actualStyle.contains(config.getStyle())) {
                 messages.add(ValidationMessage.builder()
@@ -341,7 +343,7 @@ public final class TableBlockValidator extends AbstractBlockValidator<TableBlock
         
         // Validate borders
         if (config.getBorders() != null && config.getBorders()) {
-            Object frameObj = table.getAttribute(BlockAttributes.FRAME);
+            Object frameObj = table.getAttribute(FRAME);
             String frame = frameObj != null ? frameObj.toString() : null;
             if (frame == null || "none".equals(frame)) {
                 messages.add(ValidationMessage.builder()

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidator.java
@@ -78,20 +78,20 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
     
     private String getAuthor(StructuralNode block) {
         // Author can be in attribution attribute (standard way)
-        Object attr = block.getAttribute("attribution");
+        Object attr = block.getAttribute(BlockAttributes.ATTRIBUTION);
         if (attr != null) {
             return attr.toString();
         }
         
         // Check for author attribute
-        attr = block.getAttribute("author");
+        attr = block.getAttribute(BlockAttributes.AUTHOR);
         if (attr != null) {
             return attr.toString();
         }
         
         // Check for positional attribute [verse, Author, Source]
         // AsciidoctorJ puts "verse" in attribute "1", author in "2"
-        Object attr2 = block.getAttribute("2");
+        Object attr2 = block.getAttribute(BlockAttributes.ATTR_2);
         if (attr2 != null) {
             return attr2.toString();
         }
@@ -101,20 +101,20 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
     
     private String getAttribution(StructuralNode block) {
         // Or in citetitle attribute (this is where AsciidoctorJ puts the citation)
-        Object attr = block.getAttribute("citetitle");
+        Object attr = block.getAttribute(BlockAttributes.CITETITLE);
         if (attr != null) {
             return attr.toString();
         }
         
         // Attribution can be in attribution attribute
-        attr = block.getAttribute("attribution");
+        attr = block.getAttribute(BlockAttributes.ATTRIBUTION);
         if (attr != null) {
             return attr.toString();
         }
         
         // Check for positional attribute [verse, Author, Source]
         // AsciidoctorJ puts "verse" in attribute "1", author in "2", source in "3"
-        Object attr3 = block.getAttribute("3");
+        Object attr3 = block.getAttribute(BlockAttributes.ATTR_3);
         if (attr3 != null) {
             return attr3.toString();
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidator.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.blocks.VerseBlock;
 import com.dataliquid.asciidoc.linter.report.console.FileContentCache;
@@ -78,20 +80,20 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
     
     private String getAuthor(StructuralNode block) {
         // Author can be in attribution attribute (standard way)
-        Object attr = block.getAttribute(BlockAttributes.ATTRIBUTION);
+        Object attr = block.getAttribute(ATTRIBUTION);
         if (attr != null) {
             return attr.toString();
         }
         
         // Check for author attribute
-        attr = block.getAttribute(BlockAttributes.AUTHOR);
+        attr = block.getAttribute(AUTHOR);
         if (attr != null) {
             return attr.toString();
         }
         
         // Check for positional attribute [verse, Author, Source]
         // AsciidoctorJ puts "verse" in attribute "1", author in "2"
-        Object attr2 = block.getAttribute(BlockAttributes.ATTR_2);
+        Object attr2 = block.getAttribute(ATTR_2);
         if (attr2 != null) {
             return attr2.toString();
         }
@@ -101,20 +103,20 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
     
     private String getAttribution(StructuralNode block) {
         // Or in citetitle attribute (this is where AsciidoctorJ puts the citation)
-        Object attr = block.getAttribute(BlockAttributes.CITETITLE);
+        Object attr = block.getAttribute(CITETITLE);
         if (attr != null) {
             return attr.toString();
         }
         
         // Attribution can be in attribution attribute
-        attr = block.getAttribute(BlockAttributes.ATTRIBUTION);
+        attr = block.getAttribute(ATTRIBUTION);
         if (attr != null) {
             return attr.toString();
         }
         
         // Check for positional attribute [verse, Author, Source]
         // AsciidoctorJ puts "verse" in attribute "1", author in "2", source in "3"
-        Object attr3 = block.getAttribute(BlockAttributes.ATTR_3);
+        Object attr3 = block.getAttribute(ATTR_3);
         if (attr3 != null) {
             return attr3.toString();
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidator.java
@@ -6,6 +6,8 @@ import java.util.regex.Pattern;
 
 import org.asciidoctor.ast.StructuralNode;
 
+import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
+
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.VideoBlock;
@@ -52,11 +54,11 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
         
         // Validate dimensions
         if (videoConfig.getWidth() != null) {
-            validateDimension(node, videoConfig, "width", videoConfig.getWidth(), messages, context);
+            validateDimension(node, videoConfig, WIDTH, videoConfig.getWidth(), messages, context);
         }
         
         if (videoConfig.getHeight() != null) {
-            validateDimension(node, videoConfig, "height", videoConfig.getHeight(), messages, context);
+            validateDimension(node, videoConfig, HEIGHT, videoConfig.getHeight(), messages, context);
         }
         
         // Validate poster
@@ -79,7 +81,7 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
     
     private void validateUrl(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
         VideoBlock.UrlConfig urlConfig = videoConfig.getUrl();
-        String url = (String) node.getAttribute("target");
+        String url = (String) node.getAttribute(TARGET);
         
         // Determine severity
         Severity severity = urlConfig.getSeverity() != null ? 
@@ -158,14 +160,14 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
             
             // Check if there are existing attributes
             boolean hasOtherAttributes = false;
-            if (dimensionType.equals("width")) {
-                hasOtherAttributes = node.getAttribute("height") != null || 
-                                   node.getAttribute("poster") != null || 
-                                   node.getAttribute("options") != null;
-            } else if (dimensionType.equals("height")) {
-                hasOtherAttributes = node.getAttribute("width") != null || 
-                                   node.getAttribute("poster") != null || 
-                                   node.getAttribute("options") != null;
+            if (dimensionType.equals(WIDTH)) {
+                hasOtherAttributes = node.getAttribute(HEIGHT) != null || 
+                                   node.getAttribute(POSTER) != null || 
+                                   node.getAttribute(OPTIONS) != null;
+            } else if (dimensionType.equals(HEIGHT)) {
+                hasOtherAttributes = node.getAttribute(WIDTH) != null || 
+                                   node.getAttribute(POSTER) != null || 
+                                   node.getAttribute(OPTIONS) != null;
             }
             
             messages.add(ValidationMessage.builder()
@@ -180,7 +182,7 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                         .endColumn(pos.endColumn)
                         .build())
                     .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint(dimensionType.equals("width") ? "640" : "360")
+                    .missingValueHint(dimensionType.equals(WIDTH) ? "640" : "360")
                     .placeholderContext(PlaceholderContext.builder()
                         .type(hasOtherAttributes ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST : 
                                                   PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
@@ -252,7 +254,7 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
     
     private void validatePoster(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
         VideoBlock.PosterConfig posterConfig = videoConfig.getPoster();
-        String poster = (String) node.getAttribute("poster");
+        String poster = (String) node.getAttribute(POSTER);
         
         // Determine severity
         Severity severity = posterConfig.getSeverity() != null ? 
@@ -263,9 +265,9 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
             PosterPosition pos = findPosterPosition(node, context, poster);
             
             // Check if there are existing attributes
-            boolean hasOtherAttributes = node.getAttribute("width") != null || 
-                                       node.getAttribute("height") != null || 
-                                       node.getAttribute("options") != null;
+            boolean hasOtherAttributes = node.getAttribute(WIDTH) != null || 
+                                       node.getAttribute(HEIGHT) != null || 
+                                       node.getAttribute(OPTIONS) != null;
             
             messages.add(ValidationMessage.builder()
                     .severity(severity)
@@ -325,7 +327,7 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
     
     private void validateControls(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
         VideoBlock.ControlsConfig controlsConfig = videoConfig.getOptions().getControls();
-        String controlsAttr = (String) node.getAttribute("options");
+        String controlsAttr = (String) node.getAttribute(OPTIONS);
         
         // Determine severity
         Severity severity = controlsConfig.getSeverity() != null ? 
@@ -339,9 +341,9 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                 ControlsPosition pos = findControlsPosition(node, context);
                 
                 // Check if there are existing attributes
-                boolean hasOtherAttributes = node.getAttribute("width") != null || 
-                                           node.getAttribute("height") != null || 
-                                           node.getAttribute("poster") != null;
+                boolean hasOtherAttributes = node.getAttribute(WIDTH) != null || 
+                                           node.getAttribute(HEIGHT) != null || 
+                                           node.getAttribute(POSTER) != null;
                 
                 messages.add(ValidationMessage.builder()
                         .severity(severity)
@@ -377,7 +379,7 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
     
     private void validateCaption(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
         VideoBlock.CaptionConfig captionConfig = videoConfig.getCaption();
-        String caption = (String) node.getAttribute("caption");
+        String caption = (String) node.getAttribute(CAPTION);
         
         // If no caption attribute, check for title
         if (caption == null) {

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/DlistBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/DlistBlockValidatorTest.java
@@ -22,9 +22,7 @@ import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.blocks.DlistBlock;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
-import com.dataliquid.asciidoc.linter.validator.ErrorType;
 import org.asciidoctor.ast.Cursor;
-import java.util.regex.Pattern;
 
 /**
  * Unit tests for {@link DlistBlockValidator}.

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidatorTest.java
@@ -23,7 +23,6 @@ import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ErrorType;
 import org.asciidoctor.ast.Cursor;
-import org.asciidoctor.ast.Block;
 
 /**
  * Unit tests for {@link ParagraphBlockValidator}.

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidatorTest.java
@@ -1,7 +1,6 @@
 package com.dataliquid.asciidoc.linter.validator.block;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Refactors all block validators to use a centralized `BlockAttributes` class for attribute names instead of hardcoded string literals.

**Changes:**
- Created `BlockAttributes.java` with 30 attribute constants
- Updated 12 validators + BlockTypeDetector
- Replaced 59 string literals

**Benefits:**
- Type safety - no more typos
- Single source of truth
- Better IDE support

Closes #39