### PR TITLE
#43 Refactor @JsonProperty annotations to use constants

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/config/DocumentConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/DocumentConfiguration.java
@@ -10,6 +10,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Document.METADATA;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Document.SECTIONS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 @JsonDeserialize(builder = DocumentConfiguration.Builder.class)
 public final class DocumentConfiguration {
     private final MetadataConfiguration metadata;
@@ -20,28 +24,28 @@ public final class DocumentConfiguration {
         this.sections = Collections.unmodifiableList(new ArrayList<>(builder.sections));
     }
 
-    @JsonProperty("metadata")
+    @JsonProperty(METADATA)
     public MetadataConfiguration metadata() { return metadata; }
     
-    @JsonProperty("sections")
+    @JsonProperty(SECTIONS)
     public List<SectionConfig> sections() { return sections; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private MetadataConfiguration metadata;
         private List<SectionConfig> sections = new ArrayList<>();
 
-        @JsonProperty("metadata")
+        @JsonProperty(METADATA)
         public Builder metadata(MetadataConfiguration metadata) {
             this.metadata = metadata;
             return this;
         }
 
-        @JsonProperty("sections")
+        @JsonProperty(SECTIONS)
         public Builder sections(List<SectionConfig> sections) {
             this.sections = sections != null ? new ArrayList<>(sections) : new ArrayList<>();
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/JsonPropertyNames.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/JsonPropertyNames.java
@@ -1,0 +1,192 @@
+package com.dataliquid.asciidoc.linter.config;
+
+/**
+ * Central repository for all JSON property names used in configuration classes.
+ * This class provides constants for JSON property names to ensure consistency
+ * and maintainability across all configuration POJOs.
+ */
+public final class JsonPropertyNames {
+    
+    // Prevent instantiation
+    private JsonPropertyNames() {}
+    
+    /**
+     * Empty string constant for use in annotations like @JsonPOJOBuilder
+     */
+    public static final String EMPTY = "";
+    
+    /**
+     * Common property names used across multiple configuration classes
+     */
+    public static final class Common {
+        public static final String NAME = "name";
+        public static final String SEVERITY = "severity";
+        public static final String REQUIRED = "required";
+        public static final String PATTERN = "pattern";
+        public static final String MIN_LENGTH = "minLength";
+        public static final String MAX_LENGTH = "maxLength";
+        public static final String MIN = "min";
+        public static final String MAX = "max";
+        public static final String ENABLED = "enabled";
+        public static final String ALLOWED = "allowed";
+        public static final String ORDER = "order";
+        public static final String TITLE = "title";
+        public static final String URL = "url";
+        public static final String WIDTH = "width";
+        public static final String HEIGHT = "height";
+        public static final String OPTIONS = "options";
+        public static final String LINES = "lines";
+        public static final String CONTENT = "content";
+        public static final String TYPE = "type";
+        public static final String OCCURRENCE = "occurrence";
+        public static final String MIN_VALUE = "minValue";
+        public static final String MAX_VALUE = "maxValue";
+        public static final String LEVEL = "level";
+        public static final String CAPTION = "caption";
+        public static final String THRESHOLD = "threshold";
+        public static final String DEFAULT_VALUE = "defaultValue";
+    }
+    
+    /**
+     * Property names for document configuration
+     */
+    public static final class Document {
+        public static final String DOCUMENT = "document";
+        public static final String METADATA = "metadata";
+        public static final String SECTIONS = "sections";
+        public static final String ATTRIBUTES = "attributes";
+        public static final String SUBSECTIONS = "subsections";
+        public static final String ALLOWED_BLOCKS = "allowedBlocks";
+    }
+    
+    /**
+     * Property names for admonition block configuration
+     */
+    public static final class Admonition {
+        public static final String TYPE = "type";
+        public static final String ICON = "icon";
+    }
+    
+    /**
+     * Property names for audio/video block configuration
+     */
+    public static final class Media {
+        public static final String AUTOPLAY = "autoplay";
+        public static final String CONTROLS = "controls";
+        public static final String LOOP = "loop";
+        public static final String POSTER = "poster";
+        public static final String NO_CONTROLS = "nocontrols";
+    }
+    
+    /**
+     * Property names for quote/verse block configuration
+     */
+    public static final class Quote {
+        public static final String ATTRIBUTION = "attribution";
+        public static final String CITATION = "citation";
+        public static final String AUTHOR = "author";
+    }
+    
+    /**
+     * Property names for listing block configuration
+     */
+    public static final class Listing {
+        public static final String LANGUAGE = "language";
+        public static final String CALLOUTS = "callouts";
+    }
+    
+    /**
+     * Property names for literal block configuration
+     */
+    public static final class Literal {
+        public static final String INDENTATION = "indentation";
+        public static final String MIN_SPACES = "minSpaces";
+        public static final String MAX_SPACES = "maxSpaces";
+        public static final String CONSISTENT = "consistent";
+    }
+    
+    /**
+     * Property names for example block configuration
+     */
+    public static final class Example {
+        public static final String COLLAPSIBLE = "collapsible";
+    }
+    
+    /**
+     * Property names for sidebar block configuration
+     */
+    public static final class Sidebar {
+        public static final String POSITION = "position";
+    }
+    
+    /**
+     * Property names for table block configuration
+     */
+    public static final class Table {
+        public static final String COLUMNS = "columns";
+        public static final String ROWS = "rows";
+        public static final String HEADER = "header";
+        public static final String FORMAT = "format";
+        public static final String STYLE = "style";
+        public static final String BORDERS = "borders";
+    }
+    
+    /**
+     * Property names for list block configuration
+     */
+    public static final class List {
+        public static final String ITEMS = "items";
+        public static final String TERMS = "terms";
+        public static final String DESCRIPTIONS = "descriptions";
+        public static final String NESTING_LEVEL = "nestingLevel";
+        public static final String MARKER_STYLE = "markerStyle";
+        public static final String DELIMITER_STYLE = "delimiterStyle";
+        public static final String ALLOWED_DELIMITERS = "allowedDelimiters";
+    }
+    
+    /**
+     * Property names for paragraph block configuration
+     */
+    public static final class Paragraph {
+        public static final String SENTENCE = "sentence";
+        public static final String WORDS = "words";
+    }
+    
+    /**
+     * Property names for pass block configuration
+     */
+    public static final class Pass {
+        public static final String REASON = "reason";
+    }
+    
+    /**
+     * Property names for image block configuration
+     */
+    public static final class Image {
+        public static final String ALT = "alt";
+    }
+    
+    /**
+     * Property names for output configuration
+     */
+    public static final class Output {
+        public static final String OUTPUT = "output";
+        public static final String FORMAT = "format";
+        public static final String DISPLAY = "display";
+        public static final String SUGGESTIONS = "suggestions";
+        public static final String ERROR_GROUPING = "errorGrouping";
+        public static final String SUMMARY = "summary";
+        public static final String CONTEXT_LINES = "contextLines";
+        public static final String HIGHLIGHT_STYLE = "highlightStyle";
+        public static final String USE_COLORS = "useColors";
+        public static final String SHOW_LINE_NUMBERS = "showLineNumbers";
+        public static final String MAX_LINE_WIDTH = "maxLineWidth";
+        public static final String SHOW_HEADER = "showHeader";
+        public static final String MAX_PER_ERROR = "maxPerError";
+        public static final String SHOW_EXAMPLES = "showExamples";
+        public static final String SHOW_AUTO_FIX_HINT = "showAutoFixHint";
+        public static final String SHOW_STATISTICS = "showStatistics";
+        public static final String SHOW_MOST_COMMON = "showMostCommon";
+        public static final String SHOW_FILE_LIST = "showFileList";
+    }
+}

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/LinterConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/LinterConfiguration.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Document.DOCUMENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 @JsonDeserialize(builder = LinterConfiguration.Builder.class)
 public final class LinterConfiguration {
     private final DocumentConfiguration document;
@@ -14,18 +17,18 @@ public final class LinterConfiguration {
         this.document = builder.document;
     }
 
-    @JsonProperty("document")
+    @JsonProperty(DOCUMENT)
     public DocumentConfiguration document() { return document; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private DocumentConfiguration document;
 
-        @JsonProperty("document")
+        @JsonProperty(DOCUMENT)
         public Builder document(DocumentConfiguration document) {
             this.document = document;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/MetadataConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/MetadataConfiguration.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Document.ATTRIBUTES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 @JsonDeserialize(builder = MetadataConfiguration.Builder.class)
 public final class MetadataConfiguration {
     private final List<AttributeConfig> attributes;
@@ -18,7 +21,7 @@ public final class MetadataConfiguration {
         this.attributes = Collections.unmodifiableList(new ArrayList<>(builder.attributes));
     }
 
-    @JsonProperty("attributes")
+    @JsonProperty(ATTRIBUTES)
     public List<AttributeConfig> attributes() { 
         return attributes; 
     }
@@ -27,11 +30,11 @@ public final class MetadataConfiguration {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private List<AttributeConfig> attributes = new ArrayList<>();
 
-        @JsonProperty("attributes")
+        @JsonProperty(ATTRIBUTES)
         public Builder attributes(List<AttributeConfig> attributes) {
             this.attributes = attributes != null ? new ArrayList<>(attributes) : new ArrayList<>();
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AbstractBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AbstractBlock.java
@@ -7,6 +7,11 @@ import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.NAME;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.OCCURRENCE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ORDER;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+
 public abstract class AbstractBlock implements Block {
     private final String name;
     private final Severity severity;
@@ -33,28 +38,28 @@ public abstract class AbstractBlock implements Block {
         protected OccurrenceConfig occurrence;
         protected Integer order;
         
-        @JsonProperty("name")
+        @JsonProperty(NAME)
         @SuppressWarnings("unchecked")
         public T name(String name) {
             this.name = name;
             return (T) this;
         }
         
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         @SuppressWarnings("unchecked")
         public T severity(Severity severity) {
             this.severity = severity;
             return (T) this;
         }
         
-        @JsonProperty("occurrence")
+        @JsonProperty(OCCURRENCE)
         @SuppressWarnings("unchecked")
         public T occurrence(OccurrenceConfig occurrence) {
             this.occurrence = occurrence;
             return (T) this;
         }
         
-        @JsonProperty("order")
+        @JsonProperty(ORDER)
         @SuppressWarnings("unchecked")
         public T order(Integer order) {
             this.order = order;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlock.java
@@ -11,17 +11,30 @@ import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Admonition.ICON;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Admonition.TYPE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ALLOWED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CONTENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.LINES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.TITLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = AdmonitionBlock.Builder.class)
 public final class AdmonitionBlock extends AbstractBlock {
-    @JsonProperty("type")
+    @JsonProperty(TYPE)
     private final TypeConfig type;
-    @JsonProperty("title")
+    @JsonProperty(TITLE)
     private final TitleConfig title;
-    @JsonProperty("content")
+    @JsonProperty(CONTENT)
     private final ContentConfig content;
-    @JsonProperty("icon")
+    @JsonProperty(ICON)
     private final IconConfig icon;
     
     private AdmonitionBlock(Builder builder) {
@@ -59,11 +72,11 @@ public final class AdmonitionBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TypeConfig.TypeConfigBuilder.class)
     public static class TypeConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final List<String> allowed;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TypeConfig(TypeConfigBuilder builder) {
@@ -90,7 +103,7 @@ public final class AdmonitionBlock extends AbstractBlock {
             return new TypeConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TypeConfigBuilder {
             private boolean required;
             private List<String> allowed;
@@ -133,15 +146,15 @@ public final class AdmonitionBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TitleConfig(TitleConfigBuilder builder) {
@@ -176,7 +189,7 @@ public final class AdmonitionBlock extends AbstractBlock {
             return new TitleConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Pattern pattern;
@@ -240,15 +253,15 @@ public final class AdmonitionBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("lines")
+        @JsonProperty(LINES)
         private final LineConfig lines;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private ContentConfig(ContentConfigBuilder builder) {
@@ -283,7 +296,7 @@ public final class AdmonitionBlock extends AbstractBlock {
             return new ContentConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -340,11 +353,11 @@ public final class AdmonitionBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = IconConfig.IconConfigBuilder.class)
     public static class IconConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private IconConfig(IconConfigBuilder builder) {
@@ -369,7 +382,7 @@ public final class AdmonitionBlock extends AbstractBlock {
             return new IconConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class IconConfigBuilder {
             private boolean required;
             private Pattern pattern;
@@ -416,7 +429,7 @@ public final class AdmonitionBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TypeConfig type;
         private TitleConfig title;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlock.java
@@ -7,15 +7,29 @@ import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ALLOWED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.OPTIONS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.TITLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.URL;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Media.AUTOPLAY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Media.CONTROLS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Media.LOOP;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = AudioBlock.Builder.class)
 public final class AudioBlock extends AbstractBlock {
-    @JsonProperty("url")
+    @JsonProperty(URL)
     private final UrlConfig url;
-    @JsonProperty("options")
+    @JsonProperty(OPTIONS)
     private final OptionsConfig options;
-    @JsonProperty("title")
+    @JsonProperty(TITLE)
     private final TitleConfig title;
     
     private AudioBlock(Builder builder) {
@@ -48,11 +62,11 @@ public final class AudioBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = UrlConfig.UrlConfigBuilder.class)
     public static class UrlConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private UrlConfig(UrlConfigBuilder builder) {
@@ -77,7 +91,7 @@ public final class AudioBlock extends AbstractBlock {
             return new UrlConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class UrlConfigBuilder {
             private boolean required;
             private Pattern pattern;
@@ -126,11 +140,11 @@ public final class AudioBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = OptionsConfig.OptionsConfigBuilder.class)
     public static class OptionsConfig {
-        @JsonProperty("autoplay")
+        @JsonProperty(AUTOPLAY)
         private final AutoplayConfig autoplay;
-        @JsonProperty("controls")
+        @JsonProperty(CONTROLS)
         private final ControlsConfig controls;
-        @JsonProperty("loop")
+        @JsonProperty(LOOP)
         private final LoopConfig loop;
         
         private OptionsConfig(OptionsConfigBuilder builder) {
@@ -155,7 +169,7 @@ public final class AudioBlock extends AbstractBlock {
             return new OptionsConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class OptionsConfigBuilder {
             private AutoplayConfig autoplay;
             private ControlsConfig controls;
@@ -198,9 +212,9 @@ public final class AudioBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = AutoplayConfig.AutoplayConfigBuilder.class)
     public static class AutoplayConfig {
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final boolean allowed;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private AutoplayConfig(AutoplayConfigBuilder builder) {
@@ -220,7 +234,7 @@ public final class AudioBlock extends AbstractBlock {
             return new AutoplayConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AutoplayConfigBuilder {
             private boolean allowed;
             private Severity severity;
@@ -256,9 +270,9 @@ public final class AudioBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = ControlsConfig.ControlsConfigBuilder.class)
     public static class ControlsConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private ControlsConfig(ControlsConfigBuilder builder) {
@@ -278,7 +292,7 @@ public final class AudioBlock extends AbstractBlock {
             return new ControlsConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ControlsConfigBuilder {
             private boolean required;
             private Severity severity;
@@ -314,9 +328,9 @@ public final class AudioBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = LoopConfig.LoopConfigBuilder.class)
     public static class LoopConfig {
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final boolean allowed;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private LoopConfig(LoopConfigBuilder builder) {
@@ -336,7 +350,7 @@ public final class AudioBlock extends AbstractBlock {
             return new LoopConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LoopConfigBuilder {
             private boolean allowed;
             private Severity severity;
@@ -372,13 +386,13 @@ public final class AudioBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TitleConfig(TitleConfigBuilder builder) {
@@ -408,7 +422,7 @@ public final class AudioBlock extends AbstractBlock {
             return new TitleConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -456,7 +470,7 @@ public final class AudioBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private UrlConfig url;
         private OptionsConfig options;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/Block.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/Block.java
@@ -5,19 +5,25 @@ import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.NAME;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.OCCURRENCE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ORDER;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.TYPE;
+
 public interface Block {
-    @JsonProperty("type")
+    @JsonProperty(TYPE)
     BlockType getType();
     
-    @JsonProperty("name")
+    @JsonProperty(NAME)
     String getName();
     
-    @JsonProperty("severity")
+    @JsonProperty(SEVERITY)
     Severity getSeverity();
     
-    @JsonProperty("occurrence")
+    @JsonProperty(OCCURRENCE)
     OccurrenceConfig getOccurrence();
     
-    @JsonProperty("order")
+    @JsonProperty(ORDER)
     Integer getOrder();
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlock.java
@@ -6,6 +6,21 @@ import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Literal.CONSISTENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.DESCRIPTIONS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.NESTING_LEVEL;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.TERMS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.DELIMITER_STYLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.ALLOWED_DELIMITERS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -14,13 +29,13 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  */
 @JsonDeserialize(builder = DlistBlock.Builder.class)
 public final class DlistBlock extends AbstractBlock {
-    @JsonProperty("terms")
+    @JsonProperty(TERMS)
     private final TermsConfig terms;
-    @JsonProperty("descriptions")
+    @JsonProperty(DESCRIPTIONS)
     private final DescriptionsConfig descriptions;
-    @JsonProperty("nestingLevel")
+    @JsonProperty(NESTING_LEVEL)
     private final NestingLevelConfig nestingLevel;
-    @JsonProperty("delimiterStyle")
+    @JsonProperty(DELIMITER_STYLE)
     private final DelimiterStyleConfig delimiterStyle;
     
     private DlistBlock(Builder builder) {
@@ -61,17 +76,17 @@ public final class DlistBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = TermsConfig.TermsConfigBuilder.class)
     public static class TermsConfig {
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final String pattern;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TermsConfig(TermsConfigBuilder builder) {
@@ -111,7 +126,7 @@ public final class DlistBlock extends AbstractBlock {
             return new TermsConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TermsConfigBuilder {
             private Integer min;
             private Integer max;
@@ -178,15 +193,15 @@ public final class DlistBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = DescriptionsConfig.DescriptionsConfigBuilder.class)
     public static class DescriptionsConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final Boolean required;
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final String pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private DescriptionsConfig(DescriptionsConfigBuilder builder) {
@@ -221,7 +236,7 @@ public final class DlistBlock extends AbstractBlock {
             return new DescriptionsConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DescriptionsConfigBuilder {
             private Boolean required;
             private Integer min;
@@ -281,9 +296,9 @@ public final class DlistBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = NestingLevelConfig.NestingLevelConfigBuilder.class)
     public static class NestingLevelConfig {
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private NestingLevelConfig(NestingLevelConfigBuilder builder) {
@@ -303,7 +318,7 @@ public final class DlistBlock extends AbstractBlock {
             return new NestingLevelConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class NestingLevelConfigBuilder {
             private Integer max;
             private Severity severity;
@@ -342,11 +357,11 @@ public final class DlistBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = DelimiterStyleConfig.DelimiterStyleConfigBuilder.class)
     public static class DelimiterStyleConfig {
-        @JsonProperty("allowedDelimiters")
+        @JsonProperty(ALLOWED_DELIMITERS)
         private final String[] allowedDelimiters;
-        @JsonProperty("consistent")
+        @JsonProperty(CONSISTENT)
         private final Boolean consistent;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private DelimiterStyleConfig(DelimiterStyleConfigBuilder builder) {
@@ -371,7 +386,7 @@ public final class DlistBlock extends AbstractBlock {
             return new DelimiterStyleConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DelimiterStyleConfigBuilder {
             private String[] allowedDelimiters;
             private Boolean consistent;
@@ -414,7 +429,7 @@ public final class DlistBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TermsConfig terms;
         private DescriptionsConfig descriptions;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlock.java
@@ -8,6 +8,16 @@ import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ALLOWED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CAPTION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Example.COLLAPSIBLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -71,18 +81,18 @@ public class ExampleBlock extends AbstractBlock {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBlock.AbstractBuilder<Builder> {
         private CaptionConfig caption;
         private CollapsibleConfig collapsible;
         
-        @JsonProperty("caption")
+        @JsonProperty(CAPTION)
         public Builder caption(CaptionConfig caption) {
             this.caption = caption;
             return this;
         }
         
-        @JsonProperty("collapsible")
+        @JsonProperty(COLLAPSIBLE)
         public Builder collapsible(CollapsibleConfig collapsible) {
             this.collapsible = collapsible;
             return this;
@@ -169,7 +179,7 @@ public class ExampleBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private Pattern pattern;
@@ -177,31 +187,31 @@ public class ExampleBlock extends AbstractBlock {
             private Integer maxLength;
             private Severity severity;
             
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
             
-            @JsonProperty("pattern")
+            @JsonProperty(PATTERN)
             public Builder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
             
-            @JsonProperty("minLength")
+            @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
             
-            @JsonProperty("maxLength")
+            @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
             
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -269,25 +279,25 @@ public class ExampleBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private List<Boolean> allowed;
             private Severity severity;
             
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
             
-            @JsonProperty("allowed")
+            @JsonProperty(ALLOWED)
             public Builder allowed(List<Boolean> allowed) {
                 this.allowed = allowed;
                 return this;
             }
             
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlock.java
@@ -6,17 +6,29 @@ import java.util.regex.Pattern;
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.HEIGHT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_VALUE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_VALUE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.URL;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.WIDTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Image.ALT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = ImageBlock.Builder.class)
 public final class ImageBlock extends AbstractBlock {
-    @JsonProperty("url")
+    @JsonProperty(URL)
     private final UrlConfig url;
-    @JsonProperty("height")
+    @JsonProperty(HEIGHT)
     private final DimensionConfig height;
-    @JsonProperty("width")
+    @JsonProperty(WIDTH)
     private final DimensionConfig width;
-    @JsonProperty("alt")
+    @JsonProperty(ALT)
     private final AltTextConfig alt;
     
     private ImageBlock(Builder builder) {
@@ -54,9 +66,9 @@ public final class ImageBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = UrlConfig.UrlConfigBuilder.class)
     public static class UrlConfig {
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
         
         private UrlConfig(UrlConfigBuilder builder) {
@@ -76,7 +88,7 @@ public final class ImageBlock extends AbstractBlock {
             return new UrlConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class UrlConfigBuilder {
             private Pattern pattern;
             private boolean required;
@@ -118,11 +130,11 @@ public final class ImageBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = DimensionConfig.DimensionConfigBuilder.class)
     public static class DimensionConfig {
-        @JsonProperty("minValue")
+        @JsonProperty(MIN_VALUE)
         private final Integer minValue;
-        @JsonProperty("maxValue")
+        @JsonProperty(MAX_VALUE)
         private final Integer maxValue;
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
         
         private DimensionConfig(DimensionConfigBuilder builder) {
@@ -147,7 +159,7 @@ public final class ImageBlock extends AbstractBlock {
             return new DimensionConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DimensionConfigBuilder {
             private Integer minValue;
             private Integer maxValue;
@@ -190,11 +202,11 @@ public final class ImageBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = AltTextConfig.AltTextConfigBuilder.class)
     public static class AltTextConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
         
         private AltTextConfig(AltTextConfigBuilder builder) {
@@ -219,7 +231,7 @@ public final class ImageBlock extends AbstractBlock {
             return new AltTextConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AltTextConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -260,7 +272,7 @@ public final class ImageBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private UrlConfig url;
         private DimensionConfig height;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlock.java
@@ -11,17 +11,28 @@ import com.dataliquid.asciidoc.linter.config.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ALLOWED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.LINES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.TITLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Listing.CALLOUTS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Listing.LANGUAGE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = ListingBlock.Builder.class)
 public final class ListingBlock extends AbstractBlock {
-    @JsonProperty("language")
+    @JsonProperty(LANGUAGE)
     private final LanguageConfig language;
-    @JsonProperty("lines")
+    @JsonProperty(LINES)
     private final LineConfig lines;
-    @JsonProperty("title")
+    @JsonProperty(TITLE)
     private final TitleConfig title;
-    @JsonProperty("callouts")
+    @JsonProperty(CALLOUTS)
     private final CalloutsConfig callouts;
     
     private ListingBlock(Builder builder) {
@@ -59,11 +70,11 @@ public final class ListingBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = LanguageConfig.LanguageConfigBuilder.class)
     public static class LanguageConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final List<String> allowed;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private LanguageConfig(LanguageConfigBuilder builder) {
@@ -90,7 +101,7 @@ public final class ListingBlock extends AbstractBlock {
             return new LanguageConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LanguageConfigBuilder {
             private boolean required;
             private List<String> allowed;
@@ -133,11 +144,11 @@ public final class ListingBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TitleConfig(TitleConfigBuilder builder) {
@@ -162,7 +173,7 @@ public final class ListingBlock extends AbstractBlock {
             return new TitleConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Pattern pattern;
@@ -211,11 +222,11 @@ public final class ListingBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = CalloutsConfig.CalloutsConfigBuilder.class)
     public static class CalloutsConfig {
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final boolean allowed;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private CalloutsConfig(CalloutsConfigBuilder builder) {
@@ -240,7 +251,7 @@ public final class ListingBlock extends AbstractBlock {
             return new CalloutsConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class CalloutsConfigBuilder {
             private boolean allowed;
             private Integer max;
@@ -281,7 +292,7 @@ public final class ListingBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private LanguageConfig language;
         private LineConfig lines;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlock.java
@@ -6,6 +6,20 @@ import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.LINES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.TITLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Literal.CONSISTENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Literal.INDENTATION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Literal.MAX_SPACES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Literal.MIN_SPACES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -26,11 +40,11 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  */
 @JsonDeserialize(builder = LiteralBlock.Builder.class)
 public final class LiteralBlock extends AbstractBlock {
-    @JsonProperty("title")
+    @JsonProperty(TITLE)
     private final TitleConfig title;
-    @JsonProperty("lines")
+    @JsonProperty(LINES)
     private final LinesConfig lines;
-    @JsonProperty("indentation")
+    @JsonProperty(INDENTATION)
     private final IndentationConfig indentation;
     
     private LiteralBlock(Builder builder) {
@@ -63,13 +77,13 @@ public final class LiteralBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TitleConfig(TitleConfigBuilder builder) {
@@ -99,7 +113,7 @@ public final class LiteralBlock extends AbstractBlock {
             return new TitleConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -149,11 +163,11 @@ public final class LiteralBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = LinesConfig.LinesConfigBuilder.class)
     public static class LinesConfig {
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private LinesConfig(LinesConfigBuilder builder) {
@@ -178,7 +192,7 @@ public final class LiteralBlock extends AbstractBlock {
             return new LinesConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LinesConfigBuilder {
             private Integer min;
             private Integer max;
@@ -221,15 +235,15 @@ public final class LiteralBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = IndentationConfig.IndentationConfigBuilder.class)
     public static class IndentationConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("consistent")
+        @JsonProperty(CONSISTENT)
         private final boolean consistent;
-        @JsonProperty("minSpaces")
+        @JsonProperty(MIN_SPACES)
         private final Integer minSpaces;
-        @JsonProperty("maxSpaces")
+        @JsonProperty(MAX_SPACES)
         private final Integer maxSpaces;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private IndentationConfig(IndentationConfigBuilder builder) {
@@ -264,7 +278,7 @@ public final class LiteralBlock extends AbstractBlock {
             return new IndentationConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class IndentationConfigBuilder {
             private boolean required;
             private boolean consistent;
@@ -319,7 +333,7 @@ public final class LiteralBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TitleConfig title;
         private LinesConfig lines;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ParagraphBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ParagraphBlock.java
@@ -10,12 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.*;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Paragraph.*;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 @JsonDeserialize(builder = ParagraphBlock.Builder.class)
 public final class ParagraphBlock extends AbstractBlock {
-    @JsonProperty("lines")
+    @JsonProperty(LINES)
     private final LineConfig lines;
     
-    @JsonProperty("sentence")
+    @JsonProperty(SENTENCE)
     private final SentenceConfig sentence;
     
     private ParagraphBlock(Builder builder) {
@@ -36,7 +40,7 @@ public final class ParagraphBlock extends AbstractBlock {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private LineConfig lines;
         private SentenceConfig sentence;
@@ -78,10 +82,10 @@ public final class ParagraphBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = SentenceConfig.Builder.class)
     public static final class SentenceConfig {
-        @JsonProperty("occurrence")
+        @JsonProperty(OCCURRENCE)
         private final OccurrenceConfig occurrence;
         
-        @JsonProperty("words")
+        @JsonProperty(WORDS)
         private final WordsConfig words;
         
         private SentenceConfig(Builder builder) {
@@ -96,18 +100,18 @@ public final class ParagraphBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private OccurrenceConfig occurrence;
             private WordsConfig words;
             
-            @JsonProperty("occurrence")
+            @JsonProperty(OCCURRENCE)
             public Builder occurrence(OccurrenceConfig occurrence) {
                 this.occurrence = occurrence;
                 return this;
             }
             
-            @JsonProperty("words")
+            @JsonProperty(WORDS)
             public Builder words(WordsConfig words) {
                 this.words = words;
                 return this;
@@ -138,13 +142,13 @@ public final class ParagraphBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = WordsConfig.Builder.class)
     public static final class WordsConfig {
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
         
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
         
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private WordsConfig(Builder builder) {
@@ -161,25 +165,25 @@ public final class ParagraphBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Integer min;
             private Integer max;
             private Severity severity;
             
-            @JsonProperty("min")
+            @JsonProperty(MIN)
             public Builder min(Integer min) {
                 this.min = min;
                 return this;
             }
             
-            @JsonProperty("max")
+            @JsonProperty(MAX)
             public Builder max(Integer max) {
                 this.max = max;
                 return this;
             }
             
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlock.java
@@ -12,6 +12,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.*;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Pass.REASON;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 /**
  * Configuration for pass blocks (passthrough content) in AsciiDoc.
  * Pass blocks are delimited by ++++ and pass content through without processing.
@@ -36,11 +40,11 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  */
 @JsonDeserialize(builder = PassBlock.Builder.class)
 public final class PassBlock extends AbstractBlock {
-    @JsonProperty("type")
+    @JsonProperty(TYPE)
     private final TypeConfig type;
-    @JsonProperty("content")
+    @JsonProperty(CONTENT)
     private final ContentConfig content;
-    @JsonProperty("reason")
+    @JsonProperty(REASON)
     private final ReasonConfig reason;
     
     private PassBlock(Builder builder) {
@@ -73,11 +77,11 @@ public final class PassBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TypeConfig.TypeConfigBuilder.class)
     public static class TypeConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final List<String> allowed;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TypeConfig(TypeConfigBuilder builder) {
@@ -104,7 +108,7 @@ public final class PassBlock extends AbstractBlock {
             return new TypeConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TypeConfigBuilder {
             private boolean required;
             private List<String> allowed;
@@ -147,13 +151,13 @@ public final class PassBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private ContentConfig(ContentConfigBuilder builder) {
@@ -183,7 +187,7 @@ public final class PassBlock extends AbstractBlock {
             return new ContentConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private boolean required;
             private Integer maxLength;
@@ -240,13 +244,13 @@ public final class PassBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = ReasonConfig.ReasonConfigBuilder.class)
     public static class ReasonConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private ReasonConfig(ReasonConfigBuilder builder) {
@@ -276,7 +280,7 @@ public final class PassBlock extends AbstractBlock {
             return new ReasonConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ReasonConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -324,7 +328,7 @@ public final class PassBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TypeConfig type;
         private ContentConfig content;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlock.java
@@ -6,6 +6,19 @@ import java.util.regex.Pattern;
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Quote.ATTRIBUTION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Quote.CITATION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CONTENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.LINES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -37,17 +50,17 @@ public class QuoteBlock extends AbstractBlock {
         return BlockType.QUOTE;
     }
     
-    @JsonProperty("attribution")
+    @JsonProperty(ATTRIBUTION)
     public AttributionConfig getAttribution() {
         return attribution;
     }
     
-    @JsonProperty("citation")
+    @JsonProperty(CITATION)
     public CitationConfig getCitation() {
         return citation;
     }
     
-    @JsonProperty("content")
+    @JsonProperty(CONTENT)
     public ContentConfig getContent() {
         return content;
     }
@@ -71,27 +84,27 @@ public class QuoteBlock extends AbstractBlock {
             this.severity = builder.severity;
         }
         
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         public boolean isRequired() {
             return required;
         }
         
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         public Integer getMinLength() {
             return minLength;
         }
         
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         public Integer getMaxLength() {
             return maxLength;
         }
         
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         public Pattern getPattern() {
             return pattern;
         }
         
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Severity getSeverity() {
             return severity;
         }
@@ -124,7 +137,7 @@ public class QuoteBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private Integer minLength;
@@ -132,31 +145,31 @@ public class QuoteBlock extends AbstractBlock {
             private Pattern pattern;
             private Severity severity;
             
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
             
-            @JsonProperty("minLength")
+            @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
             
-            @JsonProperty("maxLength")
+            @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
             
-            @JsonProperty("pattern")
+            @JsonProperty(PATTERN)
             public Builder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
             
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -187,27 +200,27 @@ public class QuoteBlock extends AbstractBlock {
             this.severity = builder.severity;
         }
         
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         public boolean isRequired() {
             return required;
         }
         
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         public Integer getMinLength() {
             return minLength;
         }
         
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         public Integer getMaxLength() {
             return maxLength;
         }
         
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         public Pattern getPattern() {
             return pattern;
         }
         
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Severity getSeverity() {
             return severity;
         }
@@ -240,7 +253,7 @@ public class QuoteBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private Integer minLength;
@@ -248,31 +261,31 @@ public class QuoteBlock extends AbstractBlock {
             private Pattern pattern;
             private Severity severity;
             
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
             
-            @JsonProperty("minLength")
+            @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
             
-            @JsonProperty("maxLength")
+            @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
             
-            @JsonProperty("pattern")
+            @JsonProperty(PATTERN)
             public Builder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
             
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -301,22 +314,22 @@ public class QuoteBlock extends AbstractBlock {
             this.lines = builder.lines;
         }
         
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         public boolean isRequired() {
             return required;
         }
         
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         public Integer getMinLength() {
             return minLength;
         }
         
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         public Integer getMaxLength() {
             return maxLength;
         }
         
-        @JsonProperty("lines")
+        @JsonProperty(LINES)
         public LinesConfig getLines() {
             return lines;
         }
@@ -341,32 +354,32 @@ public class QuoteBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private Integer minLength;
             private Integer maxLength;
             private LinesConfig lines;
             
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
             
-            @JsonProperty("minLength")
+            @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
             
-            @JsonProperty("maxLength")
+            @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
             
-            @JsonProperty("lines")
+            @JsonProperty(LINES)
             public Builder lines(LinesConfig lines) {
                 this.lines = lines;
                 return this;
@@ -393,17 +406,17 @@ public class QuoteBlock extends AbstractBlock {
             this.severity = builder.severity;
         }
         
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         public Integer getMin() {
             return min;
         }
         
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         public Integer getMax() {
             return max;
         }
         
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Severity getSeverity() {
             return severity;
         }
@@ -427,25 +440,25 @@ public class QuoteBlock extends AbstractBlock {
             return new Builder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Integer min;
             private Integer max;
             private Severity severity;
             
-            @JsonProperty("min")
+            @JsonProperty(MIN)
             public Builder min(Integer min) {
                 this.min = min;
                 return this;
             }
             
-            @JsonProperty("max")
+            @JsonProperty(MAX)
             public Builder max(Integer max) {
                 this.max = max;
                 return this;
             }
             
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -476,25 +489,25 @@ public class QuoteBlock extends AbstractBlock {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBlock.AbstractBuilder<Builder> {
         private AttributionConfig attribution;
         private CitationConfig citation;
         private ContentConfig content;
         
-        @JsonProperty("attribution")
+        @JsonProperty(ATTRIBUTION)
         public Builder attribution(AttributionConfig attribution) {
             this.attribution = attribution;
             return this;
         }
         
-        @JsonProperty("citation")
+        @JsonProperty(CITATION)
         public Builder citation(CitationConfig citation) {
             this.citation = citation;
             return this;
         }
         
-        @JsonProperty("content")
+        @JsonProperty(CONTENT)
         public Builder content(ContentConfig content) {
             this.content = content;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlock.java
@@ -7,6 +7,20 @@ import java.util.regex.Pattern;
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.TITLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CONTENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Sidebar.POSITION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.LINES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ALLOWED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -25,11 +39,11 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  */
 @JsonDeserialize(builder = SidebarBlock.Builder.class)
 public final class SidebarBlock extends AbstractBlock {
-    @JsonProperty("title")
+    @JsonProperty(TITLE)
     private final TitleConfig title;
-    @JsonProperty("content")
+    @JsonProperty(CONTENT)
     private final ContentConfig content;
-    @JsonProperty("position")
+    @JsonProperty(POSITION)
     private final PositionConfig position;
     
     private SidebarBlock(Builder builder) {
@@ -62,15 +76,15 @@ public final class SidebarBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private TitleConfig(TitleConfigBuilder builder) {
@@ -105,7 +119,7 @@ public final class SidebarBlock extends AbstractBlock {
             return new TitleConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -169,13 +183,13 @@ public final class SidebarBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("lines")
+        @JsonProperty(LINES)
         private final LinesConfig lines;
         
         private ContentConfig(ContentConfigBuilder builder) {
@@ -205,7 +219,7 @@ public final class SidebarBlock extends AbstractBlock {
             return new ContentConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private boolean required;
             private Integer minLength;
@@ -255,11 +269,11 @@ public final class SidebarBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = LinesConfig.LinesConfigBuilder.class)
     public static class LinesConfig {
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private LinesConfig(LinesConfigBuilder builder) {
@@ -284,7 +298,7 @@ public final class SidebarBlock extends AbstractBlock {
             return new LinesConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LinesConfigBuilder {
             private Integer min;
             private Integer max;
@@ -327,11 +341,11 @@ public final class SidebarBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = PositionConfig.PositionConfigBuilder.class)
     public static class PositionConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("allowed")
+        @JsonProperty(ALLOWED)
         private final List<String> allowed;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private PositionConfig(PositionConfigBuilder builder) {
@@ -356,7 +370,7 @@ public final class SidebarBlock extends AbstractBlock {
             return new PositionConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class PositionConfigBuilder {
             private boolean required;
             private List<String> allowed;
@@ -397,7 +411,7 @@ public final class SidebarBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TitleConfig title;
         private ContentConfig content;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlock.java
@@ -6,20 +6,36 @@ import java.util.regex.Pattern;
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Table.COLUMNS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Table.ROWS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Table.HEADER;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CAPTION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Table.FORMAT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Table.STYLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Table.BORDERS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = TableBlock.Builder.class)
 public final class TableBlock extends AbstractBlock {
-    @JsonProperty("columns")
+    @JsonProperty(COLUMNS)
     private final DimensionConfig columns;
-    @JsonProperty("rows")
+    @JsonProperty(ROWS)
     private final DimensionConfig rows;
-    @JsonProperty("header")
+    @JsonProperty(HEADER)
     private final HeaderConfig header;
-    @JsonProperty("caption")
+    @JsonProperty(CAPTION)
     private final CaptionConfig caption;
-    @JsonProperty("format")
+    @JsonProperty(FORMAT)
     private final FormatConfig format;
     
     private TableBlock(Builder builder) {
@@ -62,11 +78,11 @@ public final class TableBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = DimensionConfig.DimensionConfigBuilder.class)
     public static class DimensionConfig {
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private DimensionConfig(DimensionConfigBuilder builder) {
@@ -91,7 +107,7 @@ public final class TableBlock extends AbstractBlock {
             return new DimensionConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DimensionConfigBuilder {
             private Integer min;
             private Integer max;
@@ -134,11 +150,11 @@ public final class TableBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = HeaderConfig.HeaderConfigBuilder.class)
     public static class HeaderConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private HeaderConfig(HeaderConfigBuilder builder) {
@@ -163,7 +179,7 @@ public final class TableBlock extends AbstractBlock {
             return new HeaderConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class HeaderConfigBuilder {
             private boolean required;
             private Pattern pattern;
@@ -212,15 +228,15 @@ public final class TableBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = CaptionConfig.CaptionConfigBuilder.class)
     public static class CaptionConfig {
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private CaptionConfig(CaptionConfigBuilder builder) {
@@ -255,7 +271,7 @@ public final class TableBlock extends AbstractBlock {
             return new CaptionConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class CaptionConfigBuilder {
             private boolean required;
             private Pattern pattern;
@@ -319,11 +335,11 @@ public final class TableBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = FormatConfig.FormatConfigBuilder.class)
     public static class FormatConfig {
-        @JsonProperty("style")
+        @JsonProperty(STYLE)
         private final String style;
-        @JsonProperty("borders")
+        @JsonProperty(BORDERS)
         private final Boolean borders;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private FormatConfig(FormatConfigBuilder builder) {
@@ -348,7 +364,7 @@ public final class TableBlock extends AbstractBlock {
             return new FormatConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class FormatConfigBuilder {
             private String style;
             private Boolean borders;
@@ -389,7 +405,7 @@ public final class TableBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private DimensionConfig columns;
         private DimensionConfig rows;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlock.java
@@ -5,6 +5,14 @@ import java.util.Objects;
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.ITEMS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.NESTING_LEVEL;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.List.MARKER_STYLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -14,11 +22,11 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  */
 @JsonDeserialize(builder = UlistBlock.Builder.class)
 public final class UlistBlock extends AbstractBlock {
-    @JsonProperty("items")
+    @JsonProperty(ITEMS)
     private final ItemsConfig items;
-    @JsonProperty("nestingLevel")
+    @JsonProperty(NESTING_LEVEL)
     private final NestingLevelConfig nestingLevel;
-    @JsonProperty("markerStyle")
+    @JsonProperty(MARKER_STYLE)
     private final String markerStyle;
     
     private UlistBlock(Builder builder) {
@@ -54,11 +62,11 @@ public final class UlistBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = ItemsConfig.ItemsConfigBuilder.class)
     public static class ItemsConfig {
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         private final Integer min;
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private ItemsConfig(ItemsConfigBuilder builder) {
@@ -83,7 +91,7 @@ public final class UlistBlock extends AbstractBlock {
             return new ItemsConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ItemsConfigBuilder {
             private Integer min;
             private Integer max;
@@ -129,9 +137,9 @@ public final class UlistBlock extends AbstractBlock {
      */
     @JsonDeserialize(builder = NestingLevelConfig.NestingLevelConfigBuilder.class)
     public static class NestingLevelConfig {
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         private final Integer max;
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         private final Severity severity;
         
         private NestingLevelConfig(NestingLevelConfigBuilder builder) {
@@ -151,7 +159,7 @@ public final class UlistBlock extends AbstractBlock {
             return new NestingLevelConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class NestingLevelConfigBuilder {
             private Integer max;
             private Severity severity;
@@ -185,7 +193,7 @@ public final class UlistBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private ItemsConfig items;
         private NestingLevelConfig nestingLevel;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlock.java
@@ -5,16 +5,26 @@ import java.util.regex.Pattern;
 
 import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Quote.AUTHOR;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Quote.ATTRIBUTION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CONTENT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.DEFAULT_VALUE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = VerseBlock.Builder.class)
 public final class VerseBlock extends AbstractBlock {
-    @JsonProperty("author")
+    @JsonProperty(AUTHOR)
     private final AuthorConfig author;
-    @JsonProperty("attribution")
+    @JsonProperty(ATTRIBUTION)
     private final AttributionConfig attribution;
-    @JsonProperty("content")
+    @JsonProperty(CONTENT)
     private final ContentConfig content;
     
     private VerseBlock(Builder builder) {
@@ -47,15 +57,15 @@ public final class VerseBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = AuthorConfig.AuthorConfigBuilder.class)
     public static class AuthorConfig {
-        @JsonProperty("defaultValue")
+        @JsonProperty(DEFAULT_VALUE)
         private final String defaultValue;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
         
         private AuthorConfig(AuthorConfigBuilder builder) {
@@ -90,7 +100,7 @@ public final class VerseBlock extends AbstractBlock {
             return new AuthorConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AuthorConfigBuilder {
             private String defaultValue;
             private Integer minLength;
@@ -154,15 +164,15 @@ public final class VerseBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = AttributionConfig.AttributionConfigBuilder.class)
     public static class AttributionConfig {
-        @JsonProperty("defaultValue")
+        @JsonProperty(DEFAULT_VALUE)
         private final String defaultValue;
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
         
         private AttributionConfig(AttributionConfigBuilder builder) {
@@ -197,7 +207,7 @@ public final class VerseBlock extends AbstractBlock {
             return new AttributionConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AttributionConfigBuilder {
             private String defaultValue;
             private Integer minLength;
@@ -261,13 +271,13 @@ public final class VerseBlock extends AbstractBlock {
     
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         private final Integer minLength;
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         private final Pattern pattern;
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         private final boolean required;
         
         private ContentConfig(ContentConfigBuilder builder) {
@@ -297,7 +307,7 @@ public final class VerseBlock extends AbstractBlock {
             return new ContentConfigBuilder();
         }
         
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private Integer minLength;
             private Integer maxLength;
@@ -352,7 +362,7 @@ public final class VerseBlock extends AbstractBlock {
         }
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private AuthorConfig author;
         private AttributionConfig attribution;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlock.java
@@ -7,6 +7,22 @@ import com.dataliquid.asciidoc.linter.config.BlockType;
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.URL;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.WIDTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.HEIGHT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Media.POSTER;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.OPTIONS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.CAPTION;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.REQUIRED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_VALUE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_VALUE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Media.CONTROLS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX_LENGTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -81,7 +97,7 @@ public class VideoBlock extends AbstractBlock {
         return Objects.hash(super.hashCode(), url, width, height, poster, options, caption);
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private UrlConfig url;
         private DimensionConfig width;
@@ -90,37 +106,37 @@ public class VideoBlock extends AbstractBlock {
         private OptionsConfig options;
         private CaptionConfig caption;
 
-        @JsonProperty("url")
+        @JsonProperty(URL)
         public Builder url(UrlConfig url) {
             this.url = url;
             return this;
         }
 
-        @JsonProperty("width")
+        @JsonProperty(WIDTH)
         public Builder width(DimensionConfig width) {
             this.width = width;
             return this;
         }
 
-        @JsonProperty("height")
+        @JsonProperty(HEIGHT)
         public Builder height(DimensionConfig height) {
             this.height = height;
             return this;
         }
 
-        @JsonProperty("poster")
+        @JsonProperty(POSTER)
         public Builder poster(PosterConfig poster) {
             this.poster = poster;
             return this;
         }
 
-        @JsonProperty("options")
+        @JsonProperty(OPTIONS)
         public Builder options(OptionsConfig options) {
             this.options = options;
             return this;
         }
 
-        @JsonProperty("caption")
+        @JsonProperty(CAPTION)
         public Builder caption(CaptionConfig caption) {
             this.caption = caption;
             return this;
@@ -186,19 +202,19 @@ public class VideoBlock extends AbstractBlock {
             return p != null ? p.pattern() : null;
         }
 
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Boolean required;
             private Pattern pattern;
             private Severity severity;
 
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(Boolean required) {
                 this.required = required;
                 return this;
             }
 
-            @JsonProperty("pattern")
+            @JsonProperty(PATTERN)
             public Builder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
@@ -210,7 +226,7 @@ public class VideoBlock extends AbstractBlock {
                 return this;
             }
 
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -272,32 +288,32 @@ public class VideoBlock extends AbstractBlock {
             return Objects.hash(required, minValue, maxValue, severity);
         }
 
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Boolean required;
             private Integer minValue;
             private Integer maxValue;
             private Severity severity;
 
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(Boolean required) {
                 this.required = required;
                 return this;
             }
 
-            @JsonProperty("minValue")
+            @JsonProperty(MIN_VALUE)
             public Builder minValue(Integer minValue) {
                 this.minValue = minValue;
                 return this;
             }
 
-            @JsonProperty("maxValue")
+            @JsonProperty(MAX_VALUE)
             public Builder maxValue(Integer maxValue) {
                 this.maxValue = maxValue;
                 return this;
             }
 
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -362,19 +378,19 @@ public class VideoBlock extends AbstractBlock {
             return p != null ? p.pattern() : null;
         }
 
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Boolean required;
             private Pattern pattern;
             private Severity severity;
 
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(Boolean required) {
                 this.required = required;
                 return this;
             }
 
-            @JsonProperty("pattern")
+            @JsonProperty(PATTERN)
             public Builder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
@@ -386,7 +402,7 @@ public class VideoBlock extends AbstractBlock {
                 return this;
             }
 
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -427,11 +443,11 @@ public class VideoBlock extends AbstractBlock {
             return Objects.hash(controls);
         }
 
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private ControlsConfig controls;
 
-            @JsonProperty("controls")
+            @JsonProperty(CONTROLS)
             public Builder controls(ControlsConfig controls) {
                 this.controls = controls;
                 return this;
@@ -479,18 +495,18 @@ public class VideoBlock extends AbstractBlock {
             return Objects.hash(required, severity);
         }
 
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Boolean required;
             private Severity severity;
 
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(Boolean required) {
                 this.required = required;
                 return this;
             }
 
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
@@ -552,32 +568,32 @@ public class VideoBlock extends AbstractBlock {
             return Objects.hash(required, minLength, maxLength, severity);
         }
 
-        @JsonPOJOBuilder(withPrefix = "")
+        @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Boolean required;
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
 
-            @JsonProperty("required")
+            @JsonProperty(REQUIRED)
             public Builder required(Boolean required) {
                 this.required = required;
                 return this;
             }
 
-            @JsonProperty("minLength")
+            @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
 
-            @JsonProperty("maxLength")
+            @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
 
-            @JsonProperty("severity")
+            @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/DisplayConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/DisplayConfig.java
@@ -4,6 +4,14 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.CONTEXT_LINES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.HIGHLIGHT_STYLE;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.MAX_LINE_WIDTH;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_HEADER;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_LINE_NUMBERS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.USE_COLORS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -81,7 +89,7 @@ public final class DisplayConfig {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private int contextLines = DEFAULT_CONTEXT_LINES;
         private HighlightStyle highlightStyle = DEFAULT_HIGHLIGHT_STYLE;
@@ -93,37 +101,37 @@ public final class DisplayConfig {
         private Builder() {
         }
         
-        @JsonProperty("contextLines")
+        @JsonProperty(CONTEXT_LINES)
         public Builder contextLines(int contextLines) {
             this.contextLines = contextLines;
             return this;
         }
         
-        @JsonProperty("highlightStyle")
+        @JsonProperty(HIGHLIGHT_STYLE)
         public Builder highlightStyle(HighlightStyle highlightStyle) {
             this.highlightStyle = highlightStyle != null ? highlightStyle : DEFAULT_HIGHLIGHT_STYLE;
             return this;
         }
         
-        @JsonProperty("useColors")
+        @JsonProperty(USE_COLORS)
         public Builder useColors(boolean useColors) {
             this.useColors = useColors;
             return this;
         }
         
-        @JsonProperty("showLineNumbers")
+        @JsonProperty(SHOW_LINE_NUMBERS)
         public Builder showLineNumbers(boolean showLineNumbers) {
             this.showLineNumbers = showLineNumbers;
             return this;
         }
         
-        @JsonProperty("maxLineWidth")
+        @JsonProperty(MAX_LINE_WIDTH)
         public Builder maxLineWidth(int maxLineWidth) {
             this.maxLineWidth = maxLineWidth;
             return this;
         }
         
-        @JsonProperty("showHeader")
+        @JsonProperty(SHOW_HEADER)
         public Builder showHeader(boolean showHeader) {
             this.showHeader = showHeader;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/ErrorGroupingConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/ErrorGroupingConfig.java
@@ -4,6 +4,10 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ENABLED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.THRESHOLD;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -47,7 +51,7 @@ public final class ErrorGroupingConfig {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private boolean enabled = DEFAULT_ENABLED;
         private int threshold = DEFAULT_THRESHOLD;
@@ -55,13 +59,13 @@ public final class ErrorGroupingConfig {
         private Builder() {
         }
         
-        @JsonProperty("enabled")
+        @JsonProperty(ENABLED)
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }
         
-        @JsonProperty("threshold")
+        @JsonProperty(THRESHOLD)
         public Builder threshold(int threshold) {
             this.threshold = threshold;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigWrapper.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigWrapper.java
@@ -4,6 +4,9 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.OUTPUT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -39,14 +42,14 @@ public final class OutputConfigWrapper {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private OutputConfiguration output;
         
         private Builder() {
         }
         
-        @JsonProperty("output")
+        @JsonProperty(OUTPUT)
         public Builder output(OutputConfiguration output) {
             this.output = output;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfiguration.java
@@ -4,6 +4,13 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.DISPLAY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.ERROR_GROUPING;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.FORMAT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SUGGESTIONS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SUMMARY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -100,7 +107,7 @@ public final class OutputConfiguration {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private OutputFormat format = DEFAULT_FORMAT;
         private DisplayConfig display = DisplayConfig.builder().build();
@@ -111,31 +118,31 @@ public final class OutputConfiguration {
         private Builder() {
         }
         
-        @JsonProperty("format")
+        @JsonProperty(FORMAT)
         public Builder format(OutputFormat format) {
             this.format = format != null ? format : DEFAULT_FORMAT;
             return this;
         }
         
-        @JsonProperty("display")
+        @JsonProperty(DISPLAY)
         public Builder display(DisplayConfig display) {
             this.display = display != null ? display : DisplayConfig.builder().build();
             return this;
         }
         
-        @JsonProperty("suggestions")
+        @JsonProperty(SUGGESTIONS)
         public Builder suggestions(SuggestionsConfig suggestions) {
             this.suggestions = suggestions != null ? suggestions : SuggestionsConfig.builder().build();
             return this;
         }
         
-        @JsonProperty("errorGrouping")
+        @JsonProperty(ERROR_GROUPING)
         public Builder errorGrouping(ErrorGroupingConfig errorGrouping) {
             this.errorGrouping = errorGrouping != null ? errorGrouping : ErrorGroupingConfig.builder().build();
             return this;
         }
         
-        @JsonProperty("summary")
+        @JsonProperty(SUMMARY)
         public Builder summary(SummaryConfig summary) {
             this.summary = summary != null ? summary : SummaryConfig.builder().build();
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/SuggestionsConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/SuggestionsConfig.java
@@ -4,6 +4,12 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ENABLED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.MAX_PER_ERROR;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_AUTO_FIX_HINT;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_EXAMPLES;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -64,7 +70,7 @@ public final class SuggestionsConfig {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private boolean enabled = DEFAULT_ENABLED;
         private int maxPerError = DEFAULT_MAX_PER_ERROR;
@@ -74,25 +80,25 @@ public final class SuggestionsConfig {
         private Builder() {
         }
         
-        @JsonProperty("enabled")
+        @JsonProperty(ENABLED)
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }
         
-        @JsonProperty("maxPerError")
+        @JsonProperty(MAX_PER_ERROR)
         public Builder maxPerError(int maxPerError) {
             this.maxPerError = maxPerError;
             return this;
         }
         
-        @JsonProperty("showExamples")
+        @JsonProperty(SHOW_EXAMPLES)
         public Builder showExamples(boolean showExamples) {
             this.showExamples = showExamples;
             return this;
         }
         
-        @JsonProperty("showAutoFixHint")
+        @JsonProperty(SHOW_AUTO_FIX_HINT)
         public Builder showAutoFixHint(boolean showAutoFixHint) {
             this.showAutoFixHint = showAutoFixHint;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/SummaryConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/SummaryConfig.java
@@ -4,6 +4,12 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ENABLED;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_FILE_LIST;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_MOST_COMMON;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Output.SHOW_STATISTICS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
@@ -64,7 +70,7 @@ public final class SummaryConfig {
         return new Builder();
     }
     
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private boolean enabled = DEFAULT_ENABLED;
         private boolean showStatistics = DEFAULT_SHOW_STATISTICS;
@@ -74,25 +80,25 @@ public final class SummaryConfig {
         private Builder() {
         }
         
-        @JsonProperty("enabled")
+        @JsonProperty(ENABLED)
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }
         
-        @JsonProperty("showStatistics")
+        @JsonProperty(SHOW_STATISTICS)
         public Builder showStatistics(boolean showStatistics) {
             this.showStatistics = showStatistics;
             return this;
         }
         
-        @JsonProperty("showMostCommon")
+        @JsonProperty(SHOW_MOST_COMMON)
         public Builder showMostCommon(boolean showMostCommon) {
             this.showMostCommon = showMostCommon;
             return this;
         }
         
-        @JsonProperty("showFileList")
+        @JsonProperty(SHOW_FILE_LIST)
         public Builder showFileList(boolean showFileList) {
             this.showFileList = showFileList;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/AttributeConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/AttributeConfig.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.*;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 @JsonDeserialize(builder = AttributeConfig.Builder.class)
 public final class AttributeConfig {
     private final String name;
@@ -27,32 +30,32 @@ public final class AttributeConfig {
         this.severity = builder.severity;
     }
 
-    @JsonProperty("name")
+    @JsonProperty(NAME)
     public String name() { return name; }
     
-    @JsonProperty("order")
+    @JsonProperty(ORDER)
     public Integer order() { return order; }
     
-    @JsonProperty("required")
+    @JsonProperty(REQUIRED)
     public boolean required() { return required; }
     
-    @JsonProperty("minLength")
+    @JsonProperty(MIN_LENGTH)
     public Integer minLength() { return minLength; }
     
-    @JsonProperty("maxLength")
+    @JsonProperty(MAX_LENGTH)
     public Integer maxLength() { return maxLength; }
     
-    @JsonProperty("pattern")
+    @JsonProperty(PATTERN)
     public String pattern() { return pattern; }
     
-    @JsonProperty("severity")
+    @JsonProperty(SEVERITY)
     public Severity severity() { return severity; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private String name;
         private Integer order;
@@ -62,43 +65,43 @@ public final class AttributeConfig {
         private String pattern;
         private Severity severity;
 
-        @JsonProperty("name")
+        @JsonProperty(NAME)
         public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        @JsonProperty("order")
+        @JsonProperty(ORDER)
         public Builder order(Integer order) {
             this.order = order;
             return this;
         }
 
-        @JsonProperty("required")
+        @JsonProperty(REQUIRED)
         public Builder required(boolean required) {
             this.required = required;
             return this;
         }
 
-        @JsonProperty("minLength")
+        @JsonProperty(MIN_LENGTH)
         public Builder minLength(Integer minLength) {
             this.minLength = minLength;
             return this;
         }
 
-        @JsonProperty("maxLength")
+        @JsonProperty(MAX_LENGTH)
         public Builder maxLength(Integer maxLength) {
             this.maxLength = maxLength;
             return this;
         }
 
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         public Builder pattern(String pattern) {
             this.pattern = pattern;
             return this;
         }
 
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Builder severity(Severity severity) {
             this.severity = severity;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/LineConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/LineConfig.java
@@ -4,6 +4,11 @@ import java.util.Objects;
 
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -19,38 +24,38 @@ public final class LineConfig {
         this.severity = builder.severity;
     }
 
-    @JsonProperty("min")
+    @JsonProperty(MIN)
     public Integer min() { return min; }
     
-    @JsonProperty("max")
+    @JsonProperty(MAX)
     public Integer max() { return max; }
     
-    @JsonProperty("severity")
+    @JsonProperty(SEVERITY)
     public Severity severity() { return severity; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private Integer min;
         private Integer max;
         private Severity severity;
 
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         public Builder min(Integer min) {
             this.min = min;
             return this;
         }
 
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         public Builder max(Integer max) {
             this.max = max;
             return this;
         }
 
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Builder severity(Severity severity) {
             this.severity = severity;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/OccurrenceConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/OccurrenceConfig.java
@@ -4,6 +4,12 @@ import java.util.Objects;
 
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MAX;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.MIN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.ORDER;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -21,48 +27,48 @@ public final class OccurrenceConfig {
         this.severity = builder.severity;
     }
 
-    @JsonProperty("order")
+    @JsonProperty(ORDER)
     public Integer order() { return order; }
     
-    @JsonProperty("min")
+    @JsonProperty(MIN)
     public int min() { return min; }
     
-    @JsonProperty("max")
+    @JsonProperty(MAX)
     public int max() { return max; }
     
-    @JsonProperty("severity")
+    @JsonProperty(SEVERITY)
     public Severity severity() { return severity; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private Integer order;
         private int min = 0;
         private int max = Integer.MAX_VALUE;
         private Severity severity;
 
-        @JsonProperty("order")
+        @JsonProperty(ORDER)
         public Builder order(Integer order) {
             this.order = order;
             return this;
         }
 
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         public Builder min(int min) {
             this.min = min;
             return this;
         }
 
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         public Builder max(int max) {
             this.max = max;
             return this;
         }
 
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Builder severity(Severity severity) {
             this.severity = severity;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/SectionConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/SectionConfig.java
@@ -11,6 +11,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.*;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Document.ALLOWED_BLOCKS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Document.SUBSECTIONS;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
+
 @JsonDeserialize(builder = SectionConfig.Builder.class)
 public final class SectionConfig {
     private final String name;
@@ -33,35 +38,35 @@ public final class SectionConfig {
         this.subsections = Collections.unmodifiableList(new ArrayList<>(builder.subsections));
     }
 
-    @JsonProperty("name")
+    @JsonProperty(NAME)
     public String name() { return name; }
     
-    @JsonProperty("order")
+    @JsonProperty(ORDER)
     public Integer order() { return order; }
     
-    @JsonProperty("level")
+    @JsonProperty(LEVEL)
     public int level() { return level; }
     
-    @JsonProperty("min")
+    @JsonProperty(MIN)
     public int min() { return min; }
     
-    @JsonProperty("max")
+    @JsonProperty(MAX)
     public int max() { return max; }
     
-    @JsonProperty("title")
+    @JsonProperty(TITLE)
     public TitleConfig title() { return title; }
     
-    @JsonProperty("allowedBlocks")
+    @JsonProperty(ALLOWED_BLOCKS)
     public List<Block> allowedBlocks() { return allowedBlocks; }
     
-    @JsonProperty("subsections")
+    @JsonProperty(SUBSECTIONS)
     public List<SectionConfig> subsections() { return subsections; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private String name;
         private Integer order;
@@ -72,43 +77,43 @@ public final class SectionConfig {
         private List<Block> allowedBlocks = new ArrayList<>();
         private List<SectionConfig> subsections = new ArrayList<>();
 
-        @JsonProperty("name")
+        @JsonProperty(NAME)
         public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        @JsonProperty("order")
+        @JsonProperty(ORDER)
         public Builder order(Integer order) {
             this.order = order;
             return this;
         }
 
-        @JsonProperty("level")
+        @JsonProperty(LEVEL)
         public Builder level(int level) {
             this.level = level;
             return this;
         }
 
-        @JsonProperty("min")
+        @JsonProperty(MIN)
         public Builder min(int min) {
             this.min = min;
             return this;
         }
 
-        @JsonProperty("max")
+        @JsonProperty(MAX)
         public Builder max(int max) {
             this.max = max;
             return this;
         }
 
-        @JsonProperty("title")
+        @JsonProperty(TITLE)
         public Builder title(TitleConfig title) {
             this.title = title;
             return this;
         }
 
-        @JsonProperty("allowedBlocks")
+        @JsonProperty(ALLOWED_BLOCKS)
         @JsonDeserialize(using = BlockListDeserializer.class)
         public Builder allowedBlocks(List<Block> allowedBlocks) {
             this.allowedBlocks = allowedBlocks != null ? new ArrayList<>(allowedBlocks) : new ArrayList<>();
@@ -120,7 +125,7 @@ public final class SectionConfig {
             return this;
         }
 
-        @JsonProperty("subsections")
+        @JsonProperty(SUBSECTIONS)
         public Builder subsections(List<SectionConfig> subsections) {
             this.subsections = subsections != null ? new ArrayList<>(subsections) : new ArrayList<>();
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/TitleConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/TitleConfig.java
@@ -4,6 +4,10 @@ import java.util.Objects;
 
 import com.dataliquid.asciidoc.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.PATTERN;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.Common.SEVERITY;
+import static com.dataliquid.asciidoc.linter.config.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -17,28 +21,28 @@ public final class TitleConfig {
         this.severity = builder.severity;
     }
 
-    @JsonProperty("pattern")
+    @JsonProperty(PATTERN)
     public String pattern() { return pattern; }
     
-    @JsonProperty("severity")
+    @JsonProperty(SEVERITY)
     public Severity severity() { return severity; }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder {
         private String pattern;
         private Severity severity = Severity.ERROR;
 
-        @JsonProperty("pattern")
+        @JsonProperty(PATTERN)
         public Builder pattern(String pattern) {
             this.pattern = pattern;
             return this;
         }
 
-        @JsonProperty("severity")
+        @JsonProperty(SEVERITY)
         public Builder severity(Severity severity) {
             this.severity = Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
             return this;


### PR DESCRIPTION
## Summary
Replaced all string literals in @JsonProperty annotations with constants from centralized JsonPropertyNames class.

Fixes #43