### PR TITLE
#49 Use static constants for metadata rule IDs

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/RuleIds.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/RuleIds.java
@@ -39,6 +39,18 @@ public final class RuleIds {
     }
     
     /**
+     * Rule IDs for metadata validation
+     */
+    public static final class Metadata {
+        public static final String REQUIRED = "metadata.required";
+        public static final String PATTERN = "metadata.pattern";
+        public static final String LENGTH = "metadata.length";
+        public static final String LENGTH_MIN = "metadata.length.min";
+        public static final String LENGTH_MAX = "metadata.length.max";
+        public static final String ORDER = "metadata.order";
+    }
+    
+    /**
      * Rule IDs for admonition block validation
      */
     public static final class Admonition {

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/LengthRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/LengthRule.java
@@ -12,6 +12,10 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ErrorType;
 
+import static com.dataliquid.asciidoc.linter.validator.RuleIds.Metadata.LENGTH;
+import static com.dataliquid.asciidoc.linter.validator.RuleIds.Metadata.LENGTH_MIN;
+import static com.dataliquid.asciidoc.linter.validator.RuleIds.Metadata.LENGTH_MAX;
+
 public final class LengthRule implements AttributeRule {
     private final Map<String, LengthConfig> lengthConfigs;
 
@@ -21,7 +25,7 @@ public final class LengthRule implements AttributeRule {
 
     @Override
     public String getRuleId() {
-        return "metadata.length";
+        return LENGTH;
     }
 
     @Override
@@ -35,7 +39,7 @@ public final class LengthRule implements AttributeRule {
             if (config.hasMinLength() && length < config.getMinLength()) {
                 messages.add(ValidationMessage.builder()
                     .severity(config.getSeverity())
-                    .ruleId(getRuleId() + ".min")
+                    .ruleId(LENGTH_MIN)
                     .message("Attribute '" + attributeName + "' is too short: actual '" + value + "' (" + length + " characters), expected minimum " + config.getMinLength() + " characters")
                     .location(location)
                     .attributeName(attributeName)
@@ -48,7 +52,7 @@ public final class LengthRule implements AttributeRule {
             if (config.hasMaxLength() && length > config.getMaxLength()) {
                 messages.add(ValidationMessage.builder()
                     .severity(config.getSeverity())
-                    .ruleId(getRuleId() + ".max")
+                    .ruleId(LENGTH_MAX)
                     .message("Attribute '" + attributeName + "' is too long: actual '" + value + "' (" + length + " characters), expected maximum " + config.getMaxLength() + " characters")
                     .location(location)
                     .attributeName(attributeName)

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/OrderRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/OrderRule.java
@@ -11,6 +11,8 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
+import static com.dataliquid.asciidoc.linter.validator.RuleIds.Metadata.ORDER;
+
 public final class OrderRule implements AttributeRule {
     private final Map<String, OrderConfig> orderConfigs;
     private final Map<String, AttributePosition> actualPositions = new HashMap<>();
@@ -21,7 +23,7 @@ public final class OrderRule implements AttributeRule {
 
     @Override
     public String getRuleId() {
-        return "metadata.order";
+        return ORDER;
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/PatternRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/PatternRule.java
@@ -14,6 +14,8 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ErrorType;
 
+import static com.dataliquid.asciidoc.linter.validator.RuleIds.Metadata.PATTERN;
+
 public final class PatternRule implements AttributeRule {
     private final Map<String, PatternConfig> patternConfigs;
 
@@ -23,7 +25,7 @@ public final class PatternRule implements AttributeRule {
 
     @Override
     public String getRuleId() {
-        return "metadata.pattern";
+        return PATTERN;
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/RequiredRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/RequiredRule.java
@@ -13,6 +13,8 @@ import com.dataliquid.asciidoc.linter.validator.ErrorType;
 import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
+import static com.dataliquid.asciidoc.linter.validator.RuleIds.Metadata.REQUIRED;
+
 public final class RequiredRule implements AttributeRule {
     private final Map<String, RequiredAttribute> requiredAttributes;
 
@@ -22,7 +24,7 @@ public final class RequiredRule implements AttributeRule {
 
     @Override
     public String getRuleId() {
-        return "metadata.required";
+        return REQUIRED;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Add Metadata inner class to RuleIds with rule ID constants
- Update metadata validator rules to use static constants

## Test plan
- [ ] Run mvn test - all tests pass
- [ ] Build project successfully
- [ ] Verify rule validation still works correctly