### PR TITLE
#51 Refactor config CLI parameter to rule parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,13 +84,13 @@ The linter processes AsciiDoc files using AsciidoctorJ and applies configurable 
 java -jar asciidoc-linter.jar -i "**/*.adoc"
 
 # With custom configuration
-java -jar asciidoc-linter.jar -i "docs/**/*.adoc" -c .linter-config.yaml
+java -jar asciidoc-linter.jar -i "docs/**/*.adoc" -r .linter-rule-config.yaml
 
 # JSON output for CI/CD
 java -jar asciidoc-linter.jar -i "**/*.adoc" -f json -o report.json
 
 # Generate documentation for your configuration
-java -jar asciidoc-linter.jar -c my-rules.yaml --generate-docs
+java -jar asciidoc-linter.jar -r my-rules.yaml --generate-docs
 ----
 
 === Configuration Example

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOptions.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOptions.java
@@ -25,11 +25,11 @@ public class CLIOptions {
             .build());
         
         // Configuration file
-        options.addOption(Option.builder("c")
-            .longOpt("config")
+        options.addOption(Option.builder("r")
+            .longOpt("rule")
             .hasArg()
             .argName("file")
-            .desc("YAML configuration file (default: .linter-config.yaml)")
+            .desc("YAML rule configuration file (default: .linter-rule-config.yaml)")
             .build());
         
         // Report format

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIRunner.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIRunner.java
@@ -26,7 +26,7 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 public class CLIRunner {
     
     private static final Logger logger = LogManager.getLogger(CLIRunner.class);
-    private static final String DEFAULT_CONFIG_FILE = ".linter-config.yaml";
+    private static final String DEFAULT_CONFIG_FILE = ".linter-rule-config.yaml";
     
     private final FileDiscoveryService fileDiscoveryService;
     private final CLIOutputHandler outputHandler;

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/DocumentationGenerator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/DocumentationGenerator.java
@@ -36,7 +36,7 @@ public class DocumentationGenerator {
     public int run(CommandLine cmd) {
         try {
             // Load configuration
-            String configPath = cmd.getOptionValue("config", ".linter-config.yaml");
+            String configPath = cmd.getOptionValue("rule", ".linter-rule-config.yaml");
             LinterConfiguration config = loadConfiguration(configPath);
             
             // Parse visualization styles

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/LinterCLI.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/LinterCLI.java
@@ -64,8 +64,8 @@ public class LinterCLI {
             // Handle documentation generation
             if (cmd.hasOption("generate-docs")) {
                 // Input is not required for doc generation
-                if (!cmd.hasOption("config")) {
-                    System.err.println("Error: --config is required when using --generate-docs");
+                if (!cmd.hasOption("rule")) {
+                    System.err.println("Error: --rule is required when using --generate-docs");
                     return 2;
                 }
                 
@@ -123,8 +123,8 @@ public class LinterCLI {
         builder.inputPatterns(patterns);
         
         // Config file
-        if (cmd.hasOption("config")) {
-            builder.configFile(Paths.get(cmd.getOptionValue("config")));
+        if (cmd.hasOption("rule")) {
+            builder.configFile(Paths.get(cmd.getOptionValue("rule")));
         }
         
         // Output configuration
@@ -186,7 +186,7 @@ public class LinterCLI {
         String footer = "\nExamples:\n" +
             "  " + programName + " -i \"**/*.adoc\"\n" +
             "  " + programName + " -i \"docs/**/*.adoc,examples/**/*.asciidoc\" -f json -o report.json\n" +
-            "  " + programName + " --input \"src/*/docs/**/*.adoc,README.adoc\" --config strict.yaml --fail-level warn\n" +
+            "  " + programName + " --input \"src/*/docs/**/*.adoc,README.adoc\" --rule strict.yaml --fail-level warn\n" +
             "  " + programName + " -i \"**/*.adoc\" --output-config simple\n" +
             "  " + programName + " -i \"**/*.adoc\" --output-config-file my-output.yaml\n" +
             "\nAnt Pattern Syntax:\n" +

--- a/src/test/java/com/dataliquid/linter/cli/CLIOptionsTest.java
+++ b/src/test/java/com/dataliquid/linter/cli/CLIOptionsTest.java
@@ -30,7 +30,7 @@ class CLIOptionsTest {
     @DisplayName("should parse short form arguments")
     void shouldParseShortFormArguments() throws ParseException {
         // Given
-        String[] args = {"-i", "**/*.adoc", "-c", "config.yaml", "-f", "json", "-o", "report.json"};
+        String[] args = {"-i", "**/*.adoc", "-r", "config.yaml", "-f", "json", "-o", "report.json"};
         
         // When
         CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
@@ -38,7 +38,7 @@ class CLIOptionsTest {
         // Then
         assertTrue(cmd.hasOption("i"));
         assertEquals("**/*.adoc", cmd.getOptionValue("i"));
-        assertEquals("config.yaml", cmd.getOptionValue("c"));
+        assertEquals("config.yaml", cmd.getOptionValue("r"));
         assertEquals("json", cmd.getOptionValue("f"));
         assertEquals("report.json", cmd.getOptionValue("o"));
     }
@@ -47,7 +47,7 @@ class CLIOptionsTest {
     @DisplayName("should parse long form arguments")
     void shouldParseLongFormArguments() throws ParseException {
         // Given
-        String[] args = {"--input", "docs/**/*.adoc,examples/**/*.asciidoc", "--config", "config.yaml", 
+        String[] args = {"--input", "docs/**/*.adoc,examples/**/*.asciidoc", "--rule", "config.yaml", 
                         "--report-format", "json", "--report-output", "report.json"};
         
         // When
@@ -56,7 +56,7 @@ class CLIOptionsTest {
         // Then
         assertTrue(cmd.hasOption("input"));
         assertEquals("docs/**/*.adoc,examples/**/*.asciidoc", cmd.getOptionValue("input"));
-        assertEquals("config.yaml", cmd.getOptionValue("config"));
+        assertEquals("config.yaml", cmd.getOptionValue("rule"));
         assertEquals("json", cmd.getOptionValue("report-format"));
         assertEquals("report.json", cmd.getOptionValue("report-output"));
     }
@@ -65,14 +65,14 @@ class CLIOptionsTest {
     @DisplayName("should parse without input when using generate-docs")
     void shouldParseWithoutInputWhenUsingGenerateDocs() throws ParseException {
         // Given
-        String[] args = {"--generate-docs", "-c", "config.yaml"};
+        String[] args = {"--generate-docs", "-r", "config.yaml"};
         
         // When
         CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
         
         // Then
         assertTrue(cmd.hasOption("generate-docs"));
-        assertTrue(cmd.hasOption("config"));
+        assertTrue(cmd.hasOption("rule"));
         assertFalse(cmd.hasOption("input"));
     }
     


### PR DESCRIPTION
## Summary
- Changed CLI parameter from `-c/--config` to `-r/--rule`
- Updated default config filename to `.linter-rule-config.yaml`

## Test plan
- [x] Run build: `mvn clean compile`
- [x] Run tests: `mvn test`
- [x] Test CLI with new parameter: `java -jar asciidoc-linter.jar -i "**/*.adoc" -r .linter-rule-config.yaml`
- [x] Verify help text shows updated parameter