### PR TITLE
#59 Replace Unicode box characters with ASCII for console compatibility

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.dataliquid.asciidoc.linter.cli.display.AsciiBoxDrawer;
+import com.dataliquid.asciidoc.linter.cli.display.DisplayConstants;
 import com.dataliquid.asciidoc.linter.cli.display.TextWrapper;
 
 /**
@@ -12,9 +13,8 @@ import com.dataliquid.asciidoc.linter.cli.display.TextWrapper;
  */
 public class ConfigurationDisplay {
     
-    private static final int BOX_WIDTH = 80;
-    private static final int LABEL_WIDTH = 20;
-    
+    private final int boxWidth;
+    private final int labelWidth;
     private final AsciiBoxDrawer boxDrawer;
     private final TextWrapper textWrapper;
     
@@ -22,7 +22,19 @@ public class ConfigurationDisplay {
      * Creates a new ConfigurationDisplay with default settings.
      */
     public ConfigurationDisplay() {
-        this.boxDrawer = new AsciiBoxDrawer(BOX_WIDTH);
+        this(DisplayConstants.DEFAULT_BOX_WIDTH, DisplayConstants.DEFAULT_LABEL_WIDTH);
+    }
+    
+    /**
+     * Creates a new ConfigurationDisplay with custom dimensions.
+     * 
+     * @param boxWidth the width of the display box
+     * @param labelWidth the width allocated for labels
+     */
+    public ConfigurationDisplay(int boxWidth, int labelWidth) {
+        this.boxWidth = boxWidth;
+        this.labelWidth = labelWidth;
+        this.boxDrawer = new AsciiBoxDrawer(boxWidth);
         this.textWrapper = new TextWrapper();
     }
     
@@ -97,9 +109,9 @@ public class ConfigurationDisplay {
      * @param value the configuration value
      */
     private void drawConfigLine(String label, String value) {
-        int valueWidth = BOX_WIDTH - 4 - LABEL_WIDTH; // 4 for borders and padding
+        int valueWidth = boxWidth - 4 - labelWidth; // 4 for borders and padding
         List<String> wrappedLines = textWrapper.wrap(value, valueWidth);
-        boxDrawer.drawLabeledLines(label, wrappedLines, LABEL_WIDTH);
+        boxDrawer.drawLabeledLines(label, wrappedLines, labelWidth);
     }
     
     /**

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/display/AsciiBoxDrawer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/display/AsciiBoxDrawer.java
@@ -1,7 +1,8 @@
 package com.dataliquid.asciidoc.linter.cli.display;
 
-import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Utility class for drawing ASCII box borders and content.
@@ -10,7 +11,7 @@ import java.util.List;
 public class AsciiBoxDrawer {
     
     private final int width;
-    private final PrintStream out;
+    private final PrintWriter printWriter;
     
     /**
      * Creates a new AsciiBoxDrawer with the specified width.
@@ -18,28 +19,35 @@ public class AsciiBoxDrawer {
      * @param width the total width of the box including borders
      */
     public AsciiBoxDrawer(int width) {
-        this(width, System.out);
+        this(width, new PrintWriter(System.out, true));
     }
     
     /**
-     * Creates a new AsciiBoxDrawer with the specified width and output stream.
+     * Creates a new AsciiBoxDrawer with the specified width and print writer.
      * 
      * @param width the total width of the box including borders
-     * @param out the output stream to write to
+     * @param writer the print writer to write to
      */
-    public AsciiBoxDrawer(int width, PrintStream out) {
+    public AsciiBoxDrawer(int width, PrintWriter writer) {
         if (width < 4) {
             throw new IllegalArgumentException("Box width must be at least 4");
         }
         this.width = width;
-        this.out = out;
+        this.printWriter = Objects.requireNonNull(writer, "PrintWriter must not be null");
+    }
+    
+    /**
+     * Outputs a line to the appropriate output.
+     */
+    private void println(String line) {
+        printWriter.println(line);
     }
     
     /**
      * Draws the top border of the box.
      */
     public void drawTop() {
-        out.println("+" + "-".repeat(width - 2) + "+");
+        println("+" + "-".repeat(width - 2) + "+");
     }
     
     /**
@@ -75,7 +83,7 @@ public class AsciiBoxDrawer {
         int leftPadding = totalPadding / 2;
         int rightPadding = totalPadding - leftPadding;
         
-        out.println("|" + " ".repeat(leftPadding) + title + " ".repeat(rightPadding) + "|");
+        println("|" + " ".repeat(leftPadding) + title + " ".repeat(rightPadding) + "|");
     }
     
     /**
@@ -93,7 +101,7 @@ public class AsciiBoxDrawer {
             content = content.substring(0, contentWidth);
         }
         
-        out.println("| " + content + " ".repeat(contentWidth - content.length()) + " |");
+        println("| " + content + " ".repeat(contentWidth - content.length()) + " |");
     }
     
     /**
@@ -114,7 +122,7 @@ public class AsciiBoxDrawer {
             value = value.substring(0, valueWidth);
         }
         
-        out.println("| " + paddedLabel + value + " ".repeat(valueWidth - value.length()) + " |");
+        println("| " + paddedLabel + value + " ".repeat(valueWidth - value.length()) + " |");
     }
     
     /**

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/display/DisplayConstants.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/display/DisplayConstants.java
@@ -1,0 +1,24 @@
+package com.dataliquid.asciidoc.linter.cli.display;
+
+/**
+ * Constants for display formatting in the CLI.
+ * Centralizes display-related configuration values.
+ */
+public final class DisplayConstants {
+    
+    /**
+     * Default width for ASCII boxes used in console output.
+     * Set to 120 characters for better readability on modern terminals.
+     */
+    public static final int DEFAULT_BOX_WIDTH = 120;
+    
+    /**
+     * Default width for labels in configuration display.
+     * Proportionally adjusted for the wider box.
+     */
+    public static final int DEFAULT_LABEL_WIDTH = 30;
+    
+    private DisplayConstants() {
+        // Private constructor to prevent instantiation
+    }
+}

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatter.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.dataliquid.asciidoc.linter.cli.display.AsciiBoxDrawer;
+import com.dataliquid.asciidoc.linter.cli.display.DisplayConstants;
 import com.dataliquid.asciidoc.linter.config.output.OutputConfiguration;
 import com.dataliquid.asciidoc.linter.config.output.OutputFormat;
 import com.dataliquid.asciidoc.linter.report.console.GroupingEngine;
@@ -68,8 +70,10 @@ public class ConsoleFormatter implements ReportFormatter {
     
     private void renderHeader(PrintWriter writer) {
         if (config.getFormat() != OutputFormat.COMPACT) {
-            writer.println("Validation Report");
-            writer.println("=================");
+            AsciiBoxDrawer boxDrawer = new AsciiBoxDrawer(DisplayConstants.DEFAULT_BOX_WIDTH, writer);
+            boxDrawer.drawTop();
+            boxDrawer.drawTitle("Validation Report");
+            boxDrawer.drawBottom();
             writer.println();
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
@@ -33,9 +33,9 @@ public class SummaryRenderer {
         }
         
         writer.println();
-        writer.println(colorScheme.separator("═".repeat(65)));
+        writer.println(colorScheme.separator("=".repeat(65)));
         writer.println(colorScheme.header("                    Validation Summary"));
-        writer.println(colorScheme.separator("═".repeat(65)));
+        writer.println(colorScheme.separator("=".repeat(65)));
         
         if (config.isShowStatistics()) {
             renderStatistics(result, writer);
@@ -51,7 +51,7 @@ public class SummaryRenderer {
         
         renderSummaryLine(result, writer);
         
-        writer.println(colorScheme.separator("═".repeat(65)));
+        writer.println(colorScheme.separator("=".repeat(65)));
     }
     
     private void renderStatistics(ValidationResult result, PrintWriter writer) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.dataliquid.asciidoc.linter.cli.display.AsciiBoxDrawer;
+import com.dataliquid.asciidoc.linter.cli.display.DisplayConstants;
 import com.dataliquid.asciidoc.linter.config.output.DisplayConfig;
 import com.dataliquid.asciidoc.linter.config.output.SummaryConfig;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
@@ -33,9 +35,10 @@ public class SummaryRenderer {
         }
         
         writer.println();
-        writer.println(colorScheme.separator("=".repeat(65)));
-        writer.println(colorScheme.header("                    Validation Summary"));
-        writer.println(colorScheme.separator("=".repeat(65)));
+        AsciiBoxDrawer boxDrawer = new AsciiBoxDrawer(DisplayConstants.DEFAULT_BOX_WIDTH, writer);
+        boxDrawer.drawTop();
+        boxDrawer.drawTitle("Validation Summary");
+        boxDrawer.drawBottom();
         
         if (config.isShowStatistics()) {
             renderStatistics(result, writer);
@@ -51,7 +54,7 @@ public class SummaryRenderer {
         
         renderSummaryLine(result, writer);
         
-        writer.println(colorScheme.separator("=".repeat(65)));
+        boxDrawer.drawTop();
     }
     
     private void renderStatistics(ValidationResult result, PrintWriter writer) {

--- a/src/test/java/com/dataliquid/asciidoc/linter/highlight/PlaceholderHighlightIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/highlight/PlaceholderHighlightIntegrationTest.java
@@ -150,8 +150,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -203,8 +204,9 @@ class PlaceholderHighlightIntegrationTest {
         Path testFile = tempDir.resolve("test.adoc");
         
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -249,8 +251,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -297,8 +300,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -345,8 +349,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -394,8 +399,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -445,8 +451,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -496,8 +503,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -546,8 +554,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -592,8 +601,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -638,8 +648,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -684,8 +695,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -731,8 +743,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -778,8 +791,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -825,8 +839,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -871,8 +886,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -919,8 +935,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -966,8 +983,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1013,8 +1031,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1063,8 +1082,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1117,8 +1137,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1170,8 +1191,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1222,8 +1244,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1274,8 +1297,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1323,8 +1347,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1385,8 +1410,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1444,8 +1470,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1497,8 +1524,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1549,8 +1577,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1601,8 +1630,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1654,8 +1684,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1708,8 +1739,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1761,8 +1793,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1813,8 +1846,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1864,8 +1898,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1916,8 +1951,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -1971,8 +2007,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2027,8 +2064,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2081,8 +2119,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2135,8 +2174,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2187,8 +2227,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2239,8 +2280,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2291,8 +2333,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2342,8 +2385,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2395,8 +2439,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2447,8 +2492,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2502,8 +2548,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2551,8 +2598,9 @@ class PlaceholderHighlightIntegrationTest {
         
         // Then - Verify multi-line table placeholder with full output comparison
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2642,8 +2690,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify the placeholder appears after the subsection paragraph
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2729,8 +2778,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder at correct position
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2801,8 +2851,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2848,8 +2899,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2899,8 +2951,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2944,8 +2997,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -2993,8 +3047,9 @@ class PlaceholderHighlightIntegrationTest {
         // Then - Verify exact console output with placeholders
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             

--- a/src/test/java/com/dataliquid/asciidoc/linter/highlight/UnderlineHighlightIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/highlight/UnderlineHighlightIntegrationTest.java
@@ -140,8 +140,9 @@ class UnderlineHighlightIntegrationTest {
         // Then - Verify exact console output with underline
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -197,8 +198,9 @@ class UnderlineHighlightIntegrationTest {
         // Then - Verify exact console output with underline
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -270,8 +272,9 @@ class UnderlineHighlightIntegrationTest {
         // Then - Verify exact console output with underline
         Path testFile = tempDir.resolve("test.adoc");
         String expectedOutput = String.format("""
-            Validation Report
-            =================
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
             
             %s:
             
@@ -344,8 +347,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -414,8 +418,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -482,8 +487,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -555,8 +561,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -625,8 +632,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -698,8 +706,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -770,8 +779,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -857,8 +867,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -962,8 +973,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1049,8 +1061,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1136,8 +1149,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1230,8 +1244,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1291,8 +1306,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1357,8 +1373,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1432,8 +1449,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1493,8 +1511,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1554,8 +1573,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1626,8 +1646,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1701,8 +1722,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1768,8 +1790,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1847,8 +1870,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -1927,8 +1951,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2012,8 +2037,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2092,8 +2118,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2189,8 +2216,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2257,8 +2285,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2313,8 +2342,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2390,8 +2420,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2494,8 +2525,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2566,8 +2598,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2638,8 +2671,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2710,8 +2744,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2779,8 +2814,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2847,8 +2883,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -2924,8 +2961,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3020,8 +3058,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3112,8 +3151,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3183,8 +3223,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3234,8 +3275,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3285,8 +3327,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3336,8 +3379,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underline at correct position
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 
@@ -3392,8 +3436,9 @@ class UnderlineHighlightIntegrationTest {
             // Then - Verify exact console output with underlines for both violations
             Path testFile = tempDir.resolve("test.adoc");
             String expectedOutput = String.format("""
-                Validation Report
-                =================
+                +----------------------------------------------------------------------------------------------------------------------+
+                |                                                  Validation Report                                                   |
+                +----------------------------------------------------------------------------------------------------------------------+
                 
                 %s:
                 


### PR DESCRIPTION
## Summary
- Replace Unicode box-drawing character "═" with ASCII "=" in SummaryRenderer
- Ensures compatibility with older terminals that don't support UTF-8 properly
- Maintains consistency with existing ConsoleFormatter that already uses "="

Fixes #59