### PR TITLE
#63 Remove unimplemented auto-fix functionality

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/config/common/JsonPropertyNames.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/common/JsonPropertyNames.java
@@ -184,7 +184,6 @@ public final class JsonPropertyNames {
         public static final String SHOW_HEADER = "showHeader";
         public static final String MAX_PER_ERROR = "maxPerError";
         public static final String SHOW_EXAMPLES = "showExamples";
-        public static final String SHOW_AUTO_FIX_HINT = "showAutoFixHint";
         public static final String SHOW_STATISTICS = "showStatistics";
         public static final String SHOW_MOST_COMMON = "showMostCommon";
         public static final String SHOW_FILE_LIST = "showFileList";

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/SuggestionsConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/SuggestionsConfig.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.ENABLED;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Output.MAX_PER_ERROR;
-import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Output.SHOW_AUTO_FIX_HINT;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Output.SHOW_EXAMPLES;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMPTY;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -20,18 +19,15 @@ public final class SuggestionsConfig {
     private static final boolean DEFAULT_ENABLED = true;
     private static final int DEFAULT_MAX_PER_ERROR = 3;
     private static final boolean DEFAULT_SHOW_EXAMPLES = true;
-    private static final boolean DEFAULT_SHOW_AUTO_FIX_HINT = true;
     
     private final boolean enabled;
     private final int maxPerError;
     private final boolean showExamples;
-    private final boolean showAutoFixHint;
     
     private SuggestionsConfig(Builder builder) {
         this.enabled = builder.enabled;
         this.maxPerError = builder.maxPerError;
         this.showExamples = builder.showExamples;
-        this.showAutoFixHint = builder.showAutoFixHint;
     }
     
     public boolean isEnabled() {
@@ -46,10 +42,6 @@ public final class SuggestionsConfig {
         return showExamples;
     }
     
-    public boolean isShowAutoFixHint() {
-        return showAutoFixHint;
-    }
-    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,13 +49,12 @@ public final class SuggestionsConfig {
         SuggestionsConfig that = (SuggestionsConfig) o;
         return enabled == that.enabled &&
                 maxPerError == that.maxPerError &&
-                showExamples == that.showExamples &&
-                showAutoFixHint == that.showAutoFixHint;
+                showExamples == that.showExamples;
     }
     
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, maxPerError, showExamples, showAutoFixHint);
+        return Objects.hash(enabled, maxPerError, showExamples);
     }
     
     public static Builder builder() {
@@ -75,7 +66,6 @@ public final class SuggestionsConfig {
         private boolean enabled = DEFAULT_ENABLED;
         private int maxPerError = DEFAULT_MAX_PER_ERROR;
         private boolean showExamples = DEFAULT_SHOW_EXAMPLES;
-        private boolean showAutoFixHint = DEFAULT_SHOW_AUTO_FIX_HINT;
         
         private Builder() {
         }
@@ -95,12 +85,6 @@ public final class SuggestionsConfig {
         @JsonProperty(SHOW_EXAMPLES)
         public Builder showExamples(boolean showExamples) {
             this.showExamples = showExamples;
-            return this;
-        }
-        
-        @JsonProperty(SHOW_AUTO_FIX_HINT)
-        public Builder showAutoFixHint(boolean showAutoFixHint) {
-            this.showAutoFixHint = showAutoFixHint;
             return this;
         }
         

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatter.java
@@ -174,10 +174,6 @@ public class ConsoleFormatter implements ReportFormatter {
             writer.println();
             writer.println("💡 Common fix: " + 
                 group.getMessages().get(0).getSuggestions().get(0).getDescription());
-            
-            if (group.getMessages().get(0).hasAutoFixableSuggestions()) {
-                writer.println("🔧 Auto-fixable: Use --fix to apply suggested changes");
-            }
         }
     }
     

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/ColorScheme.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/ColorScheme.java
@@ -78,10 +78,6 @@ public class ColorScheme {
         return useColors ? ANSI_YELLOW + icon + ANSI_RESET : icon;
     }
     
-    public String autoFixHint(String text) {
-        return useColors ? ANSI_GREEN + text + ANSI_RESET : text;
-    }
-    
     public String separator(String separator) {
         return useColors ? ANSI_GRAY + separator + ANSI_RESET : separator;
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SuggestionRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SuggestionRenderer.java
@@ -41,13 +41,6 @@ public class SuggestionRenderer {
             
             renderSuggestion(suggestion, count, suggestions.size(), writer);
         }
-        
-        // Auto-fix hint
-        if (config.isShowAutoFixHint() && hasAutoFixable(suggestions)) {
-            writer.println("  " + colorScheme.autoFixHint(
-                "🔧 Auto-fixable: Use --fix to apply suggested changes"
-            ));
-        }
     }
     
     private void renderSuggestion(Suggestion suggestion, int index, int total, PrintWriter writer) {
@@ -82,9 +75,5 @@ public class SuggestionRenderer {
         for (String example : examples) {
             writer.println(indent + "- " + colorScheme.code(example));
         }
-    }
-    
-    private boolean hasAutoFixable(List<Suggestion> suggestions) {
-        return suggestions.stream().anyMatch(Suggestion::isAutoFixable);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
@@ -117,18 +117,6 @@ public class SummaryRenderer {
             });
         
         writer.println();
-        
-        // Auto-fix hint
-        long autoFixableCount = result.getMessages().stream()
-            .filter(ValidationMessage::hasAutoFixableSuggestions)
-            .count();
-        
-        if (autoFixableCount > 0) {
-            writer.println(colorScheme.suggestionIcon("  💡 ") + 
-                autoFixableCount + " error" + (autoFixableCount == 1 ? " is" : "s are") + 
-                " auto-fixable. Run with --fix");
-            writer.println();
-        }
     }
     
     private void renderFileList(ValidationResult result, PrintWriter writer) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/Suggestion.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/Suggestion.java
@@ -13,7 +13,6 @@ public final class Suggestion {
     private final String explanation;
     private final boolean preferred;
     private final List<String> examples;
-    private final boolean autoFixable;
     
     private Suggestion(Builder builder) {
         this.description = Objects.requireNonNull(builder.description, "[" + getClass().getName() + "] description must not be null");
@@ -21,7 +20,6 @@ public final class Suggestion {
         this.explanation = builder.explanation;
         this.preferred = builder.preferred;
         this.examples = new ArrayList<>(builder.examples);
-        this.autoFixable = builder.autoFixable;
     }
     
     public String getDescription() {
@@ -52,17 +50,12 @@ public final class Suggestion {
         return !examples.isEmpty();
     }
     
-    public boolean isAutoFixable() {
-        return autoFixable;
-    }
-    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Suggestion that = (Suggestion) o;
         return preferred == that.preferred &&
-                autoFixable == that.autoFixable &&
                 Objects.equals(description, that.description) &&
                 Objects.equals(fixedValue, that.fixedValue) &&
                 Objects.equals(explanation, that.explanation) &&
@@ -71,7 +64,7 @@ public final class Suggestion {
     
     @Override
     public int hashCode() {
-        return Objects.hash(description, fixedValue, explanation, preferred, examples, autoFixable);
+        return Objects.hash(description, fixedValue, explanation, preferred, examples);
     }
     
     public static Builder builder() {
@@ -84,7 +77,6 @@ public final class Suggestion {
         private String explanation;
         private boolean preferred;
         private final List<String> examples = new ArrayList<>();
-        private boolean autoFixable;
         
         private Builder() {
         }
@@ -119,11 +111,6 @@ public final class Suggestion {
             if (examples != null) {
                 this.examples.addAll(examples);
             }
-            return this;
-        }
-        
-        public Builder autoFixable(boolean autoFixable) {
-            this.autoFixable = autoFixable;
             return this;
         }
         

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/ValidationMessage.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/ValidationMessage.java
@@ -88,10 +88,6 @@ public final class ValidationMessage {
         return !suggestions.isEmpty();
     }
     
-    public boolean hasAutoFixableSuggestions() {
-        return suggestions.stream().anyMatch(Suggestion::isAutoFixable);
-    }
-    
     public List<String> getContextLines() {
         return new ArrayList<>(contextLines);
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidator.java
@@ -348,7 +348,6 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                             .description("Enable video player controls")
                             .addExample("video::video.mp4[options=controls]")
                             .addExample("video::video.mp4[opts=controls]")
-                            .autoFixable(true)
                             .build())
                         .build());
             }

--- a/src/main/resources/output-configs/compact.yaml
+++ b/src/main/resources/output-configs/compact.yaml
@@ -14,7 +14,6 @@ output:
     enabled: false
     maxPerError: 1
     showExamples: false
-    showAutoFixHint: false
   
   errorGrouping:
     enabled: false

--- a/src/main/resources/output-configs/enhanced.yaml
+++ b/src/main/resources/output-configs/enhanced.yaml
@@ -14,7 +14,6 @@ output:
     enabled: true
     maxPerError: 3
     showExamples: true
-    showAutoFixHint: true
   
   errorGrouping:
     enabled: true

--- a/src/main/resources/output-configs/simple.yaml
+++ b/src/main/resources/output-configs/simple.yaml
@@ -14,7 +14,6 @@ output:
     enabled: false
     maxPerError: 1
     showExamples: false
-    showAutoFixHint: false
   
   errorGrouping:
     enabled: false

--- a/src/main/resources/schemas/output/output-config-schema.yaml
+++ b/src/main/resources/schemas/output/output-config-schema.yaml
@@ -75,11 +75,6 @@ properties:
             type: boolean
             default: true
             description: Show examples in suggestions
-          
-          showAutoFixHint:
-            type: boolean
-            default: true
-            description: Show hint about auto-fixable errors
         
         additionalProperties: false
       

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/EnhancedValidationMessageTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/EnhancedValidationMessageTest.java
@@ -34,7 +34,6 @@ class EnhancedValidationMessageTest {
                 Suggestion.builder()
                     .description("Fix suggestion 1")
                     .addExample("Example code")
-                    .autoFixable(true)
                     .build()
             );
             
@@ -70,7 +69,6 @@ class EnhancedValidationMessageTest {
             assertEquals(suggestions, message.getSuggestions());
             assertEquals(contextLines, message.getContextLines());
             assertTrue(message.hasSuggestions());
-            assertTrue(message.hasAutoFixableSuggestions());
         }
         
         @Test
@@ -95,7 +93,6 @@ class EnhancedValidationMessageTest {
             assertTrue(message.getSuggestions().isEmpty());
             assertTrue(message.getContextLines().isEmpty());
             assertFalse(message.hasSuggestions());
-            assertFalse(message.hasAutoFixableSuggestions());
         }
     }
     
@@ -103,69 +100,6 @@ class EnhancedValidationMessageTest {
     @DisplayName("Suggestion Tests")
     class SuggestionTests {
         
-        @Test
-        @DisplayName("should detect auto-fixable suggestions")
-        void shouldDetectAutoFixableSuggestions() {
-            // Given
-            List<Suggestion> suggestions = Arrays.asList(
-                Suggestion.builder()
-                    .description("Manual fix")
-                    .autoFixable(false)
-                    .build(),
-                Suggestion.builder()
-                    .description("Auto fix")
-                    .autoFixable(true)
-                    .build()
-            );
-            
-            // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .suggestions(suggestions)
-                .build();
-            
-            // Then
-            assertTrue(message.hasSuggestions());
-            assertTrue(message.hasAutoFixableSuggestions());
-        }
-        
-        @Test
-        @DisplayName("should handle only manual suggestions")
-        void shouldHandleOnlyManualSuggestions() {
-            // Given
-            List<Suggestion> suggestions = Arrays.asList(
-                Suggestion.builder()
-                    .description("Manual fix 1")
-                    .autoFixable(false)
-                    .build(),
-                Suggestion.builder()
-                    .description("Manual fix 2")
-                    .autoFixable(false)
-                    .build()
-            );
-            
-            // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .suggestions(suggestions)
-                .build();
-            
-            // Then
-            assertTrue(message.hasSuggestions());
-            assertFalse(message.hasAutoFixableSuggestions());
-        }
     }
     
     @Nested

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidatorTest.java
@@ -287,7 +287,6 @@ class VideoBlockValidatorTest {
             assertEquals("autoplay", msg.getActualValue().orElse(null));
             assertEquals("controls", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
-            assertTrue(msg.hasAutoFixableSuggestions());
         }
         
         @Test


### PR DESCRIPTION
## Summary
- Removed non-functional auto-fix feature that only displayed hints without implementation
- Cleaned up all related code, configuration, and tests
- Feature can be properly implemented in the future if needed

## Changes
- Removed `autoFixable` field from Suggestion class
- Removed `showAutoFixHint` configuration option  
- Removed auto-fix hint messages from console output
- Removed related test assertions
- Updated all YAML configuration files

## Test Plan
- [x] Build compiles successfully
- [x] All tests pass
- [x] No auto-fix references remain in codebase

Closes #63