### PR TITLE
#77 Improve error highlighting for paragraph sentence validation

### DIFF
--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidator.java
@@ -240,10 +240,14 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
         Severity severity = resolveSeverity(occurrenceConfig.severity(), blockConfig.getSeverity());
         
         if (sentenceCount < occurrenceConfig.min()) {
+            SourcePosition pos = findSourcePositionAtEndOfContent(block, context);
             messages.add(ValidationMessage.builder()
                 .severity(severity)
                 .ruleId(SENTENCE_OCCURRENCE_MIN)
-                .location(context.createLocation(block))
+                .location(SourceLocation.builder()
+                    .filename(context.getFilename())
+                    .fromPosition(pos)
+                    .build())
                 .message("Paragraph has too few sentences")
                 .actualValue(String.valueOf(sentenceCount))
                 .expectedValue("At least " + occurrenceConfig.min() + " sentences")
@@ -263,10 +267,11 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
         }
         
         if (sentenceCount > occurrenceConfig.max()) {
+            SourceLocation location = createParagraphLocation(block, context);
             messages.add(ValidationMessage.builder()
                 .severity(severity)
                 .ruleId(SENTENCE_OCCURRENCE_MAX)
-                .location(context.createLocation(block))
+                .location(location)
                 .message("Paragraph has too many sentences")
                 .actualValue(String.valueOf(sentenceCount))
                 .expectedValue("At most " + occurrenceConfig.max() + " sentences")
@@ -289,19 +294,29 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
                                         List<ValidationMessage> messages) {
         
         Severity severity = resolveSeverity(wordsConfig.getSeverity(), blockConfig.getSeverity());
+        String fullContent = getBlockContent(block);
         
         for (int i = 0; i < sentences.size(); i++) {
             String sentence = sentences.get(i);
             int wordCount = countWords(sentence);
             
             if (wordsConfig.getMin() != null && wordCount < wordsConfig.getMin()) {
+                SourcePosition pos = findSentenceEndPosition(block, context, sentence, i);
                 messages.add(ValidationMessage.builder()
                     .severity(severity)
                     .ruleId(SENTENCE_WORDS_MIN)
-                    .location(context.createLocation(block))
+                    .location(SourceLocation.builder()
+                        .filename(context.getFilename())
+                        .fromPosition(pos)
+                        .build())
                     .message("Sentence " + (i + 1) + " has too few words")
                     .actualValue(wordCount + " words")
                     .expectedValue("At least " + wordsConfig.getMin() + " words")
+                    .errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("add more words")
+                    .placeholderContext(PlaceholderContext.builder()
+                        .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
+                        .build())
                     .addSuggestion(Suggestion.builder()
                         .description("Expand sentence with more detail")
                         .addExample("Add descriptive adjectives")
@@ -313,10 +328,11 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
             }
             
             if (wordsConfig.getMax() != null && wordCount > wordsConfig.getMax()) {
+                SourceLocation location = createSentenceLocation(block, context, fullContent, sentence, i);
                 messages.add(ValidationMessage.builder()
                     .severity(severity)
                     .ruleId(SENTENCE_WORDS_MAX)
-                    .location(context.createLocation(block))
+                    .location(location)
                     .message("Sentence " + (i + 1) + " has too many words")
                     .actualValue(wordCount + " words")
                     .expectedValue("At most " + wordsConfig.getMax() + " words")
@@ -340,6 +356,156 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
         // Split by whitespace and count non-empty parts
         String[] words = text.trim().split("\\s+");
         return words.length;
+    }
+    
+    /**
+     * Creates a source location for the entire paragraph block with proper column positions.
+     */
+    private SourceLocation createParagraphLocation(StructuralNode block, BlockValidationContext context) {
+        List<String> fileLines = fileCache.getFileLines(context.getFilename());
+        if (fileLines.isEmpty() || block.getSourceLocation() == null) {
+            return context.createLocation(block);
+        }
+        
+        int startLine = block.getSourceLocation().getLineNumber();
+        if (startLine <= 0 || startLine > fileLines.size()) {
+            return context.createLocation(block);
+        }
+        
+        // Get the paragraph content
+        String content = getBlockContent(block);
+        if (content == null || content.isEmpty()) {
+            return context.createLocation(block);
+        }
+        
+        // For paragraphs, find the actual text position
+        String firstLine = fileLines.get(startLine - 1);
+        
+        // Create location with full line span
+        return SourceLocation.builder()
+            .filename(context.getFilename())
+            .startLine(startLine)
+            .endLine(startLine)
+            .startColumn(1)
+            .endColumn(firstLine.length())
+            .build();
+    }
+    
+    /**
+     * Creates a source location for a specific sentence within a paragraph.
+     */
+    private SourceLocation createSentenceLocation(StructuralNode block, BlockValidationContext context, 
+                                                  String fullContent, String sentence, int sentenceIndex) {
+        List<String> fileLines = fileCache.getFileLines(context.getFilename());
+        if (fileLines.isEmpty() || block.getSourceLocation() == null) {
+            return context.createLocation(block);
+        }
+        
+        int startLine = block.getSourceLocation().getLineNumber();
+        if (startLine <= 0 || startLine > fileLines.size()) {
+            return context.createLocation(block);
+        }
+        
+        // For simplicity, if it's a single-line paragraph, highlight the whole line
+        // In real scenarios, we could find the exact position of the sentence
+        String paragraphLine = fileLines.get(startLine - 1);
+        
+        // Try to find the sentence in the paragraph
+        int sentenceStart = paragraphLine.indexOf(sentence.trim());
+        if (sentenceStart == -1) {
+            // If not found, return the whole paragraph location
+            return createParagraphLocation(block, context);
+        }
+        
+        // Create location for the specific sentence
+        return SourceLocation.builder()
+            .filename(context.getFilename())
+            .startLine(startLine)
+            .endLine(startLine)
+            .startColumn(sentenceStart + 1)  // 1-based indexing
+            .endColumn(sentenceStart + sentence.trim().length())  // Exclusive end position
+            .build();
+    }
+    
+    /**
+     * Finds the position before the punctuation mark at the end of a sentence.
+     */
+    private SourcePosition findSentenceEndPosition(StructuralNode block, BlockValidationContext context, 
+                                                   String sentence, int sentenceIndex) {
+        List<String> fileLines = fileCache.getFileLines(context.getFilename());
+        if (fileLines.isEmpty() || block.getSourceLocation() == null) {
+            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+        }
+        
+        int startLine = block.getSourceLocation().getLineNumber();
+        if (startLine <= 0 || startLine > fileLines.size()) {
+            return new SourcePosition(1, 1, startLine);
+        }
+        
+        // Get the paragraph line
+        String paragraphLine = fileLines.get(startLine - 1);
+        
+        // Find the sentence in the paragraph
+        String trimmedSentence = sentence.trim();
+        int sentenceStart = paragraphLine.indexOf(trimmedSentence);
+        
+        if (sentenceStart == -1) {
+            // If not found, try to find without the punctuation
+            String sentenceWithoutPunctuation = trimmedSentence.replaceAll("[.!?]+$", "");
+            sentenceStart = paragraphLine.indexOf(sentenceWithoutPunctuation);
+        }
+        
+        if (sentenceStart != -1) {
+            // Find position before punctuation
+            int endPos = sentenceStart + trimmedSentence.length();
+            
+            // Check if there's punctuation at the end
+            if (trimmedSentence.matches(".*[.!?]+$")) {
+                // Find where the punctuation starts
+                int punctuationStart = trimmedSentence.length() - 1;
+                while (punctuationStart > 0 && ".!?".indexOf(trimmedSentence.charAt(punctuationStart)) != -1) {
+                    punctuationStart--;
+                }
+                punctuationStart++; // Move to first punctuation character
+                
+                // Position should be before the punctuation
+                endPos = sentenceStart + punctuationStart + 1; // +1 for 1-based column
+                return new SourcePosition(endPos, endPos, startLine);
+            } else {
+                // No punctuation, position at end of sentence
+                endPos = sentenceStart + trimmedSentence.length() + 1; // +1 for 1-based column
+                return new SourcePosition(endPos, endPos, startLine);
+            }
+        }
+        
+        // Fallback: position at end of line
+        return new SourcePosition(paragraphLine.length() + 1, paragraphLine.length() + 1, startLine);
+    }
+    
+    /**
+     * Finds the position at the end of the paragraph content for appending.
+     */
+    private SourcePosition findSourcePositionAtEndOfContent(StructuralNode block, BlockValidationContext context) {
+        List<String> fileLines = fileCache.getFileLines(context.getFilename());
+        if (fileLines.isEmpty() || block.getSourceLocation() == null) {
+            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+        }
+        
+        int startLine = block.getSourceLocation().getLineNumber();
+        if (startLine <= 0 || startLine > fileLines.size()) {
+            return new SourcePosition(1, 1, startLine);
+        }
+        
+        // For paragraphs, we want to position at the end of the content
+        String content = getBlockContent(block);
+        if (content != null && !content.isEmpty()) {
+            // For single-line paragraphs, position at the end of the line
+            String paragraphLine = fileLines.get(startLine - 1);
+            int endColumn = paragraphLine.length() + 1;
+            return new SourcePosition(endColumn, endColumn, startLine);
+        }
+        
+        return new SourcePosition(1, 1, startLine);
     }
     
     /**

--- a/src/test/java/com/dataliquid/asciidoc/linter/highlight/PlaceholderHighlightIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/highlight/PlaceholderHighlightIntegrationTest.java
@@ -371,6 +371,321 @@ class PlaceholderHighlightIntegrationTest {
     }
     
     @Test
+    @DisplayName("should show placeholder for paragraph with too few sentences")
+    void shouldShowPlaceholderForParagraphWithTooFewSentences(@TempDir Path tempDir) throws IOException {
+        // Given - YAML rules requiring minimum 3 sentences for paragraphs
+        String rules = """
+            document:
+              sections:
+                - level: 0
+                  allowedBlocks:
+                    - paragraph:
+                        severity: error
+                        sentence:
+                          occurrence:
+                            min: 3
+                            severity: error
+            """;
+        
+        // Given - AsciiDoc content with paragraph having only 2 sentences
+        String adocContent = """
+            = Test Document
+            
+            This is the first sentence. This is the second sentence.
+            """;
+        
+        // When - Validate and format output
+        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+        
+        // Then - Verify exact console output with placeholder
+        Path testFile = tempDir.resolve("test.adoc");
+        String expectedOutput = String.format("""
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
+            
+            %s:
+            
+            [ERROR]: Paragraph has too few sentences [paragraph.sentence.occurrence.min]
+              File: %s:3:57
+              Actual: 2
+              Expected: At least 3 sentences
+            
+               1 | = Test Document
+               2 |\s
+               3 | This is the first sentence. This is the second sentence. «Add more sentences.»
+            
+            
+            """, testFile.toString(), testFile.toString());
+        
+        assertEquals(expectedOutput, actualOutput);
+    }
+    
+    @Test
+    @DisplayName("should show placeholder for paragraph with only one sentence when three required")
+    void shouldShowPlaceholderForParagraphWithOneSentenceWhenThreeRequired(@TempDir Path tempDir) throws IOException {
+        // Given - YAML rules requiring minimum 3 sentences for paragraphs
+        String rules = """
+            document:
+              sections:
+                - level: 0
+                  allowedBlocks:
+                    - paragraph:
+                        severity: warn
+                        sentence:
+                          occurrence:
+                            min: 3
+                            severity: warn
+            """;
+        
+        // Given - AsciiDoc content with paragraph having only 1 sentence
+        String adocContent = """
+            = Test Document
+            
+            This is only one sentence.
+            """;
+        
+        // When - Validate and format output
+        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+        
+        // Then - Verify exact console output with placeholder
+        Path testFile = tempDir.resolve("test.adoc");
+        String expectedOutput = String.format("""
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
+            
+            %s:
+            
+            [WARN]: Paragraph has too few sentences [paragraph.sentence.occurrence.min]
+              File: %s:3:27
+              Actual: 1
+              Expected: At least 3 sentences
+            
+               1 | = Test Document
+               2 |\s
+               3 | This is only one sentence. «Add more sentences.»
+            
+            
+            """, testFile.toString(), testFile.toString());
+        
+        assertEquals(expectedOutput, actualOutput);
+    }
+    
+    @Test
+    @DisplayName("should show placeholder for sentence with too few words")
+    void shouldShowPlaceholderForSentenceWithTooFewWords(@TempDir Path tempDir) throws IOException {
+        // Given - YAML rules requiring minimum 5 words per sentence
+        String rules = """
+            document:
+              sections:
+                - level: 0
+                  allowedBlocks:
+                    - paragraph:
+                        severity: error
+                        sentence:
+                          words:
+                            min: 5
+                            severity: error
+            """;
+        
+        // Given - AsciiDoc content with sentence having only 3 words
+        String adocContent = """
+            = Test Document
+            
+            This is short.
+            """;
+        
+        // When - Validate and format output
+        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+        
+        // Then - Verify exact console output with placeholder before punctuation
+        Path testFile = tempDir.resolve("test.adoc");
+        String expectedOutput = String.format("""
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
+            
+            %s:
+            
+            [ERROR]: Sentence 1 has too few words [paragraph.sentence.words.min]
+              File: %s:3:14
+              Actual: 3 words
+              Expected: At least 5 words
+            
+               1 | = Test Document
+               2 |\s
+               3 | This is short «add more words».
+            
+            
+            """, testFile.toString(), testFile.toString());
+        
+        assertEquals(expectedOutput, actualOutput);
+    }
+    
+    @Test
+    @DisplayName("should show placeholder for sentence with question mark")
+    void shouldShowPlaceholderForSentenceWithQuestionMark(@TempDir Path tempDir) throws IOException {
+        // Given - YAML rules requiring minimum 4 words per sentence
+        String rules = """
+            document:
+              sections:
+                - level: 0
+                  allowedBlocks:
+                    - paragraph:
+                        severity: warn
+                        sentence:
+                          words:
+                            min: 4
+                            severity: warn
+            """;
+        
+        // Given - AsciiDoc content with question having only 3 words
+        String adocContent = """
+            = Test Document
+            
+            How are you?
+            """;
+        
+        // When - Validate and format output
+        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+        
+        // Then - Verify exact console output with placeholder before question mark
+        Path testFile = tempDir.resolve("test.adoc");
+        String expectedOutput = String.format("""
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
+            
+            %s:
+            
+            [WARN]: Sentence 1 has too few words [paragraph.sentence.words.min]
+              File: %s:3:12
+              Actual: 3 words
+              Expected: At least 4 words
+            
+               1 | = Test Document
+               2 |\s
+               3 | How are you «add more words»?
+            
+            
+            """, testFile.toString(), testFile.toString());
+        
+        assertEquals(expectedOutput, actualOutput);
+    }
+    
+    @Test
+    @DisplayName("should show placeholder for sentence with exclamation mark")
+    void shouldShowPlaceholderForSentenceWithExclamationMark(@TempDir Path tempDir) throws IOException {
+        // Given - YAML rules requiring minimum 3 words per sentence
+        String rules = """
+            document:
+              sections:
+                - level: 0
+                  allowedBlocks:
+                    - paragraph:
+                        severity: error
+                        sentence:
+                          words:
+                            min: 3
+                            severity: error
+            """;
+        
+        // Given - AsciiDoc content with exclamation having only 2 words
+        String adocContent = """
+            = Test Document
+            
+            Too short!
+            """;
+        
+        // When - Validate and format output
+        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+        
+        // Then - Verify exact console output with placeholder before exclamation mark
+        Path testFile = tempDir.resolve("test.adoc");
+        String expectedOutput = String.format("""
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
+            
+            %s:
+            
+            [ERROR]: Sentence 1 has too few words [paragraph.sentence.words.min]
+              File: %s:3:10
+              Actual: 2 words
+              Expected: At least 3 words
+            
+               1 | = Test Document
+               2 |\s
+               3 | Too short «add more words»!
+            
+            
+            """, testFile.toString(), testFile.toString());
+        
+        assertEquals(expectedOutput, actualOutput);
+    }
+    
+    @Test
+    @DisplayName("should show placeholder for multiple sentences with too few words")
+    void shouldShowPlaceholderForMultipleSentencesWithTooFewWords(@TempDir Path tempDir) throws IOException {
+        // Given - YAML rules requiring minimum 5 words per sentence
+        String rules = """
+            document:
+              sections:
+                - level: 0
+                  allowedBlocks:
+                    - paragraph:
+                        severity: warn
+                        sentence:
+                          words:
+                            min: 5
+                            severity: warn
+            """;
+        
+        // Given - AsciiDoc content with multiple short sentences
+        String adocContent = """
+            = Test Document
+            
+            Too short. This sentence has exactly five words. Also short!
+            """;
+        
+        // When - Validate and format output
+        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+        
+        // Then - Verify exact console output with placeholders for each short sentence
+        Path testFile = tempDir.resolve("test.adoc");
+        String expectedOutput = String.format("""
+            +----------------------------------------------------------------------------------------------------------------------+
+            |                                                  Validation Report                                                   |
+            +----------------------------------------------------------------------------------------------------------------------+
+            
+            %s:
+            
+            [WARN]: Sentence 1 has too few words [paragraph.sentence.words.min]
+              File: %s:3:10
+              Actual: 2 words
+              Expected: At least 5 words
+            
+               1 | = Test Document
+               2 |\s
+               3 | Too short «add more words». This sentence has exactly five words. Also short!
+            
+            [WARN]: Sentence 3 has too few words [paragraph.sentence.words.min]
+              File: %s:3:60
+              Actual: 2 words
+              Expected: At least 5 words
+            
+               1 | = Test Document
+               2 |\s
+               3 | Too short. This sentence has exactly five words. Also short «add more words»!
+            
+            
+            """, testFile.toString(), testFile.toString(), testFile.toString());
+        
+        assertEquals(expectedOutput, actualOutput);
+    }
+    
+    @Test
     @DisplayName("should show placeholder for paragraph with too few lines")
     void shouldShowPlaceholderForParagraphWithTooFewLines(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 2 lines for paragraphs


### PR DESCRIPTION
## Summary
- Improved placeholder positioning for paragraph validation errors
- Enhanced visual feedback when sentences don't meet requirements
- Added specialized handling for sentence-level error indicators

## Changes
- Modified `HighlightRenderer` to position placeholders more intuitively:
  - For missing sentences: placeholder appears at end of paragraph with space
  - For sentences with too few words: placeholder inserted before punctuation marks
- Updated `ParagraphBlockValidator` to provide precise source locations for errors
- Added comprehensive test coverage for new placeholder positioning behavior
- Added underline tests for sentences exceeding maximum limits

Closes #77