### PR TITLE
#81 Update parent-oss to version 2.2.0 and apply code formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.dataliquid</groupId>
         <artifactId>parent-oss</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
     
     <groupId>com.dataliquid</groupId>

--- a/src/main/java/com/dataliquid/asciidoc/linter/Linter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/Linter.java
@@ -34,55 +34,59 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 /**
- * Main entry point for the AsciiDoc linter.
- * Provides methods to validate AsciiDoc files against a configuration.
+ * Main entry point for the AsciiDoc linter. Provides methods to validate AsciiDoc files against a configuration.
  */
 public class Linter {
-    
+
     private static final Logger logger = LogManager.getLogger(Linter.class);
-    
+
     private final Asciidoctor asciidoctor;
-    
+
     public Linter() {
         this.asciidoctor = Asciidoctor.Factory.create();
     }
-    
+
     /**
      * Validates a single AsciiDoc file.
-     * 
-     * @param file the file to validate
-     * @param config the linter configuration
+     *
+     * @param file
+     *            the file to validate
+     * @param config
+     *            the linter configuration
      * @return validation result
-     * @throws IOException if the file cannot be read
+     * @throws IOException
+     *             if the file cannot be read
      */
     public ValidationResult validateFile(Path file, LinterConfiguration config) throws IOException {
         Objects.requireNonNull(file, "[" + getClass().getName() + "] file must not be null");
         Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
-        
+
         if (!Files.exists(file)) {
             throw new IOException("File does not exist: " + file);
         }
-        
+
         if (!Files.isRegularFile(file)) {
             throw new IOException("Not a regular file: " + file);
         }
-        
+
         return performValidation(file, config);
     }
-    
+
     /**
      * Validates multiple AsciiDoc files.
-     * 
-     * @param files the files to validate
-     * @param config the linter configuration
+     *
+     * @param files
+     *            the files to validate
+     * @param config
+     *            the linter configuration
      * @return map of file to validation result
      */
     public Map<Path, ValidationResult> validateFiles(List<Path> files, LinterConfiguration config) {
         Objects.requireNonNull(files, "[" + getClass().getName() + "] files must not be null");
         Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
-        
+
         Map<Path, ValidationResult> results = new LinkedHashMap<>();
-        
+
         for (Path file : files) {
             try {
                 ValidationResult result = validateFile(file, config);
@@ -93,77 +97,77 @@ public class Linter {
                 results.put(file, errorResult);
             }
         }
-        
+
         return results;
     }
-    
+
     /**
      * Validates all matching files in a directory.
-     * 
-     * @param directory the directory to scan
-     * @param pattern file pattern (e.g., "*.adoc")
-     * @param recursive whether to scan subdirectories
-     * @param config the linter configuration
+     *
+     * @param directory
+     *            the directory to scan
+     * @param pattern
+     *            file pattern (e.g., "*.adoc")
+     * @param recursive
+     *            whether to scan subdirectories
+     * @param config
+     *            the linter configuration
      * @return map of file to validation result
-     * @throws IOException if the directory cannot be read
+     * @throws IOException
+     *             if the directory cannot be read
      */
-    public Map<Path, ValidationResult> validateDirectory(Path directory, String pattern, 
-                                                       boolean recursive, LinterConfiguration config) throws IOException {
+    public Map<Path, ValidationResult> validateDirectory(Path directory, String pattern, boolean recursive,
+            LinterConfiguration config) throws IOException {
         Objects.requireNonNull(directory, "[" + getClass().getName() + "] directory must not be null");
         Objects.requireNonNull(pattern, "[" + getClass().getName() + "] pattern must not be null");
         Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
-        
+
         if (!Files.isDirectory(directory)) {
             throw new IOException("Not a directory: " + directory);
         }
-        
+
         List<Path> files = findMatchingFiles(directory, pattern, recursive);
         return validateFiles(files, config);
     }
-    
+
     /**
      * Validates AsciiDoc content from a string.
-     * 
-     * @param content the AsciiDoc content to validate
-     * @param config the linter configuration
+     *
+     * @param content
+     *            the AsciiDoc content to validate
+     * @param config
+     *            the linter configuration
      * @return validation result
      */
     public ValidationResult validateContent(String content, LinterConfiguration config) {
         Objects.requireNonNull(content, "[" + getClass().getName() + "] content must not be null");
         Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
-        
+
         String filename = "inline-content";
-        
+
         try {
             // Parse the document from string
             // Enable AsciidoctorJ's built-in front matter handling
-            Attributes documentAttributes = Attributes.builder()
-                .skipFrontMatter(true)
-                .build();
-            
-            Options options = Options.builder()
-                .sourcemap(true)  // Enable source location tracking
-                .toFile(false)    // Don't write output file
-                .attributes(documentAttributes)
-                .build();
+            Attributes documentAttributes = Attributes.builder().skipFrontMatter(true).build();
+
+            Options options = Options.builder().sourcemap(true) // Enable source location tracking
+                    .toFile(false) // Don't write output file
+                    .attributes(documentAttributes).build();
             Document document = asciidoctor.load(content, options);
-            
+
             // Extract filename from document title if available
             if (document.getTitle() != null && !document.getTitle().isEmpty()) {
                 filename = document.getTitle().replaceAll("[^a-zA-Z0-9-_]", "_").toLowerCase() + ".adoc";
             }
-            
+
             return performValidation(document, filename, config);
         } catch (Exception e) {
             // Create error result for parse failure
-            return ValidationResult.builder()
-                .addScannedFile(filename)
-                .addMessage(createParseErrorMessage(filename, e))
-                .complete()
-                .build();
+            return ValidationResult.builder().addScannedFile(filename).addMessage(createParseErrorMessage(filename, e))
+                    .complete().build();
         }
     }
-    
+
     /**
      * Closes the linter and releases resources.
      */
@@ -172,100 +176,88 @@ public class Linter {
             asciidoctor.close();
         }
     }
-    
+
     private ValidationResult performValidation(Path file, LinterConfiguration config) {
         try {
             // Parse the document
             // Enable AsciidoctorJ's built-in front matter handling
-            Attributes documentAttributes = Attributes.builder()
-                .skipFrontMatter(true)
-                .build();
-            
-            Options options = Options.builder()
-                .sourcemap(true)  // Enable source location tracking
-                .toFile(false)    // Don't write output file
-                .attributes(documentAttributes)
-                .build();
+            Attributes documentAttributes = Attributes.builder().skipFrontMatter(true).build();
+
+            Options options = Options.builder().sourcemap(true) // Enable source location tracking
+                    .toFile(false) // Don't write output file
+                    .attributes(documentAttributes).build();
             Document document = asciidoctor.loadFile(file.toFile(), options);
-            
+
             return performValidation(document, file.toString(), config);
         } catch (Exception e) {
             // Create error result for parse failure
-            return ValidationResult.builder()
-                .addScannedFile(file.toString())
-                .addMessage(createParseErrorMessage(file, e))
-                .complete()
-                .build();
+            return ValidationResult.builder().addScannedFile(file.toString())
+                    .addMessage(createParseErrorMessage(file, e)).complete().build();
         }
     }
-    
+
     private ValidationResult performValidation(Document document, String filename, LinterConfiguration config) {
-        ValidationResult.Builder resultBuilder = ValidationResult.builder()
-                .addScannedFile(filename);
-        
+        ValidationResult.Builder resultBuilder = ValidationResult.builder().addScannedFile(filename);
+
         // Run validators
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         if (config.document() != null) {
             // Metadata validation
             if (config.document().metadata() != null) {
-                MetadataValidator metadataValidator = MetadataValidator
-                    .fromConfiguration(config.document().metadata())
-                    .build();
+                MetadataValidator metadataValidator = MetadataValidator.fromConfiguration(config.document().metadata())
+                        .build();
                 ValidationResult metadataResult = metadataValidator.validate(document, filename);
                 messages.addAll(metadataResult.getMessages());
             }
-            
+
             // Section validation
             if (config.document().sections() != null) {
-                SectionValidator sectionValidator = SectionValidator.builder()
-                    .configuration(config.document())
-                    .build();
+                SectionValidator sectionValidator = SectionValidator.builder().configuration(config.document()).build();
                 ValidationResult sectionResult = sectionValidator.validate(document, filename);
                 messages.addAll(sectionResult.getMessages());
-                
+
                 // Block validation within sections
                 messages.addAll(validateBlocks(document, config.document().sections(), filename));
             }
         }
-        
+
         // Add all messages to result
         messages.forEach(resultBuilder::addMessage);
-        
+
         return resultBuilder.complete().build();
     }
-    
-    private List<ValidationMessage> validateBlocks(Document document, List<SectionConfig> sectionConfigs, String filename) {
+
+    private List<ValidationMessage> validateBlocks(Document document, List<SectionConfig> sectionConfigs,
+            String filename) {
         List<ValidationMessage> messages = new ArrayList<>();
         BlockValidator blockValidator = new BlockValidator();
-        
+
         // Process level 0 (document title) configurations
         List<SectionConfig> level0Configs = extractLevel0Configs(sectionConfigs);
         List<SectionConfig> configsForLevel1Sections = determineConfigsForLevel1Sections(level0Configs, sectionConfigs);
-        
+
         // Debug logging
-        logger.debug("validateBlocks: level0Configs.size()={}, configsForLevel1Sections.size()={}", 
-            level0Configs.size(), configsForLevel1Sections.size());
-        
+        logger.debug("validateBlocks: level0Configs.size()={}, configsForLevel1Sections.size()={}",
+                level0Configs.size(), configsForLevel1Sections.size());
+
         // Validate document-level blocks (only if Level 0 config exists)
         if (!level0Configs.isEmpty()) {
             validateDocumentLevelBlocks(document, level0Configs, blockValidator, filename, messages);
         }
-        
+
         // Validate sections and their blocks
         validateDocumentSections(document, configsForLevel1Sections, blockValidator, filename, messages);
-        
+
         return messages;
     }
-    
+
     private List<SectionConfig> extractLevel0Configs(List<SectionConfig> sectionConfigs) {
-        return sectionConfigs.stream()
-            .filter(config -> config.level() == 0)
-            .collect(Collectors.toList());
+        return sectionConfigs.stream().filter(config -> config.level() == 0).collect(Collectors.toList());
     }
-    
-    private List<SectionConfig> determineConfigsForLevel1Sections(List<SectionConfig> level0Configs, 
-                                                                   List<SectionConfig> allConfigs) {
+
+    private List<SectionConfig> determineConfigsForLevel1Sections(List<SectionConfig> level0Configs,
+            List<SectionConfig> allConfigs) {
         // If level 0 config has subsections, use those for level 1 sections
         // Otherwise, use all non-level-0 configs from the top level
         for (SectionConfig level0Config : level0Configs) {
@@ -273,16 +265,13 @@ public class Linter {
                 return level0Config.subsections();
             }
         }
-        
+
         // Fallback: use all non-level-0 configs
-        return allConfigs.stream()
-            .filter(config -> config.level() != 0)
-            .collect(Collectors.toList());
+        return allConfigs.stream().filter(config -> config.level() != 0).collect(Collectors.toList());
     }
-    
+
     private void validateDocumentLevelBlocks(Document document, List<SectionConfig> level0Configs,
-                                           BlockValidator blockValidator, String filename,
-                                           List<ValidationMessage> messages) {
+            BlockValidator blockValidator, String filename, List<ValidationMessage> messages) {
         for (SectionConfig level0Config : level0Configs) {
             // Only validate document-level blocks if level 0 config has allowedBlocks
             if (level0Config.allowedBlocks() != null && !level0Config.allowedBlocks().isEmpty()) {
@@ -291,10 +280,9 @@ public class Linter {
             }
         }
     }
-    
+
     private void validateDocumentSections(Document document, List<SectionConfig> sectionConfigs,
-                                        BlockValidator blockValidator, String filename,
-                                        List<ValidationMessage> messages) {
+            BlockValidator blockValidator, String filename, List<ValidationMessage> messages) {
         for (StructuralNode node : document.getBlocks()) {
             // Only process sections, skip preamble and other document-level blocks
             if (node instanceof org.asciidoctor.ast.Section) {
@@ -302,27 +290,24 @@ public class Linter {
                 validateSectionBlocks(section, sectionConfigs, blockValidator, filename, messages);
             } else {
                 // Debug: Log what we're skipping
-                logger.debug("validateDocumentSections: Skipping non-section node: context={}, nodeName={}", 
-                    node.getContext(), node.getNodeName());
+                logger.debug("validateDocumentSections: Skipping non-section node: context={}, nodeName={}",
+                        node.getContext(), node.getNodeName());
             }
             // Note: Document-level blocks (preamble) are handled by validateDocumentLevelBlocks
         }
     }
-    
-    private void validateSectionBlocks(org.asciidoctor.ast.Section section, 
-                                     List<SectionConfig> sectionConfigs,
-                                     BlockValidator blockValidator,
-                                     String filename,
-                                     List<ValidationMessage> messages) {
-        
+
+    private void validateSectionBlocks(org.asciidoctor.ast.Section section, List<SectionConfig> sectionConfigs,
+            BlockValidator blockValidator, String filename, List<ValidationMessage> messages) {
+
         Optional<SectionConfig> matchingConfig = findMatchingSectionConfig(section, sectionConfigs);
-        
+
         if (matchingConfig.isPresent()) {
             SectionConfig config = matchingConfig.get();
-            
+
             // Validate blocks in this section
             validateSectionContent(section, config, blockValidator, filename, messages);
-            
+
             // Process subsections with appropriate configs
             List<SectionConfig> subsectionConfigs = determineSubsectionConfigs(config, sectionConfigs);
             processSubsections(section, subsectionConfigs, blockValidator, filename, messages);
@@ -331,33 +316,29 @@ public class Linter {
             processSubsections(section, sectionConfigs, blockValidator, filename, messages);
         }
     }
-    
-    private Optional<SectionConfig> findMatchingSectionConfig(org.asciidoctor.ast.Section section, 
-                                                            List<SectionConfig> sectionConfigs) {
-        return sectionConfigs.stream()
-            .filter(config -> config.level() != 0 && matchesSection(section, config))
-            .findFirst();
+
+    private Optional<SectionConfig> findMatchingSectionConfig(org.asciidoctor.ast.Section section,
+            List<SectionConfig> sectionConfigs) {
+        return sectionConfigs.stream().filter(config -> config.level() != 0 && matchesSection(section, config))
+                .findFirst();
     }
-    
+
     private void validateSectionContent(org.asciidoctor.ast.Section section, SectionConfig config,
-                                      BlockValidator blockValidator, String filename,
-                                      List<ValidationMessage> messages) {
+            BlockValidator blockValidator, String filename, List<ValidationMessage> messages) {
         ValidationResult blockResult = blockValidator.validate(section, config, filename);
         messages.addAll(blockResult.getMessages());
     }
-    
-    private List<SectionConfig> determineSubsectionConfigs(SectionConfig parentConfig, 
-                                                          List<SectionConfig> fallbackConfigs) {
+
+    private List<SectionConfig> determineSubsectionConfigs(SectionConfig parentConfig,
+            List<SectionConfig> fallbackConfigs) {
         if (parentConfig.subsections() != null && !parentConfig.subsections().isEmpty()) {
             return parentConfig.subsections();
         }
         return fallbackConfigs;
     }
-    
-    private void processSubsections(org.asciidoctor.ast.Section section, 
-                                  List<SectionConfig> subsectionConfigs,
-                                  BlockValidator blockValidator, String filename,
-                                  List<ValidationMessage> messages) {
+
+    private void processSubsections(org.asciidoctor.ast.Section section, List<SectionConfig> subsectionConfigs,
+            BlockValidator blockValidator, String filename, List<ValidationMessage> messages) {
         for (StructuralNode node : section.getBlocks()) {
             if (node instanceof org.asciidoctor.ast.Section) {
                 org.asciidoctor.ast.Section subsection = (org.asciidoctor.ast.Section) node;
@@ -365,12 +346,12 @@ public class Linter {
             }
         }
     }
-    
+
     private List<Path> findMatchingFiles(Path directory, String pattern, boolean recursive) throws IOException {
         List<Path> matchingFiles = new ArrayList<>();
         PathMatcher pathMatcher = directory.getFileSystem().getPathMatcher("glob:" + pattern);
         int maxDepth = recursive ? Integer.MAX_VALUE : 1;
-        
+
         Files.walkFileTree(directory, new HashSet<>(), maxDepth, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
@@ -379,7 +360,7 @@ public class Linter {
                 }
                 return FileVisitResult.CONTINUE;
             }
-            
+
             @Override
             public FileVisitResult visitFileFailed(Path file, IOException exc) {
                 // Log warning but continue
@@ -387,62 +368,47 @@ public class Linter {
                 return FileVisitResult.CONTINUE;
             }
         });
-        
+
         return matchingFiles;
     }
-    
+
     private boolean matchesSection(org.asciidoctor.ast.Section section, SectionConfig config) {
         // First check level match
         if (config.level() != section.getLevel()) {
             return false;
         }
-        
+
         // Then check title constraints if configured
         if (config.title() != null && config.title().pattern() != null) {
             String title = section.getTitle();
             if (title == null) {
                 return false;
             }
-            
+
             // Check pattern match
             return title.matches(config.title().pattern());
         }
-        
+
         // Level matches and no title constraints
         return true;
     }
-    
+
     private ValidationResult createIOErrorResult(Path file, IOException e) {
-        return ValidationResult.builder()
-            .addScannedFile(file.toString())
-            .addMessage(ValidationMessage.builder()
-                .severity(com.dataliquid.asciidoc.linter.config.common.Severity.ERROR)
-                .ruleId("io-error")
-                .location(SourceLocation.builder()
-                    .filename(file.toString())
-                    .startLine(1)
-                    .build())
-                .message("I/O error: " + e.getMessage())
-                .cause(e)
-                .build())
-            .complete()
-            .build();
+        return ValidationResult.builder().addScannedFile(file.toString())
+                .addMessage(ValidationMessage.builder()
+                        .severity(com.dataliquid.asciidoc.linter.config.common.Severity.ERROR).ruleId("io-error")
+                        .location(SourceLocation.builder().filename(file.toString()).startLine(1).build())
+                        .message("I/O error: " + e.getMessage()).cause(e).build())
+                .complete().build();
     }
-    
+
     private ValidationMessage createParseErrorMessage(Path file, Exception e) {
         return createParseErrorMessage(file.toString(), e);
     }
-    
+
     private ValidationMessage createParseErrorMessage(String filename, Exception e) {
-        return ValidationMessage.builder()
-            .severity(com.dataliquid.asciidoc.linter.config.common.Severity.ERROR)
-            .ruleId("parse-error")
-            .location(SourceLocation.builder()
-                .filename(filename)
-                .startLine(1)
-                .build())
-            .message("Failed to parse AsciiDoc file: " + e.getMessage())
-            .cause(e)
-            .build();
+        return ValidationMessage.builder().severity(com.dataliquid.asciidoc.linter.config.common.Severity.ERROR)
+                .ruleId("parse-error").location(SourceLocation.builder().filename(filename).startLine(1).build())
+                .message("Failed to parse AsciiDoc file: " + e.getMessage()).cause(e).build();
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIConfig.java
@@ -12,7 +12,7 @@ import com.dataliquid.asciidoc.linter.config.output.OutputFormat;
  * Configuration object containing parsed CLI arguments.
  */
 public class CLIConfig {
-    
+
     private final List<String> inputPatterns;
     private final Path baseDirectory;
     private final Path configFile;
@@ -21,61 +21,65 @@ public class CLIConfig {
     private final String reportFormat;
     private final Path reportOutput;
     private final Severity failLevel;
-    
+
     private CLIConfig(Builder builder) {
-        this.inputPatterns = Objects.requireNonNull(builder.inputPatterns, "[" + getClass().getName() + "] inputPatterns must not be null");
+        this.inputPatterns = Objects.requireNonNull(builder.inputPatterns,
+                "[" + getClass().getName() + "] inputPatterns must not be null");
         if (this.inputPatterns.isEmpty()) {
             throw new IllegalArgumentException("inputPatterns must not be empty");
         }
-        this.baseDirectory = Objects.requireNonNull(builder.baseDirectory, "[" + getClass().getName() + "] baseDirectory must not be null");
+        this.baseDirectory = Objects.requireNonNull(builder.baseDirectory,
+                "[" + getClass().getName() + "] baseDirectory must not be null");
         this.configFile = builder.configFile;
         this.outputConfigFormat = builder.outputConfigFormat;
         this.outputConfigFile = builder.outputConfigFile;
-        this.reportFormat = Objects.requireNonNull(builder.reportFormat, "[" + getClass().getName() + "] reportFormat must not be null");
+        this.reportFormat = Objects.requireNonNull(builder.reportFormat,
+                "[" + getClass().getName() + "] reportFormat must not be null");
         this.reportOutput = builder.reportOutput;
-        this.failLevel = Objects.requireNonNull(builder.failLevel, "[" + getClass().getName() + "] failLevel must not be null");
+        this.failLevel = Objects.requireNonNull(builder.failLevel,
+                "[" + getClass().getName() + "] failLevel must not be null");
     }
-    
+
     public List<String> getInputPatterns() {
         return inputPatterns;
     }
-    
+
     public Path getBaseDirectory() {
         return baseDirectory;
     }
-    
+
     public Path getConfigFile() {
         return configFile;
     }
-    
+
     public OutputFormat getOutputConfigFormat() {
         return outputConfigFormat;
     }
-    
+
     public Path getOutputConfigFile() {
         return outputConfigFile;
     }
-    
+
     public String getReportFormat() {
         return reportFormat;
     }
-    
+
     public Path getReportOutput() {
         return reportOutput;
     }
-    
+
     public Severity getFailLevel() {
         return failLevel;
     }
-    
+
     public boolean isOutputToFile() {
         return reportOutput != null;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     public static class Builder {
         private List<String> inputPatterns;
         private Path baseDirectory = Paths.get(System.getProperty("user.dir"));
@@ -85,47 +89,47 @@ public class CLIConfig {
         private String reportFormat = "console";
         private Path reportOutput;
         private Severity failLevel = Severity.ERROR;
-        
+
         public Builder inputPatterns(List<String> inputPatterns) {
             this.inputPatterns = inputPatterns;
             return this;
         }
-        
+
         public Builder baseDirectory(Path baseDirectory) {
             this.baseDirectory = baseDirectory;
             return this;
         }
-        
+
         public Builder configFile(Path configFile) {
             this.configFile = configFile;
             return this;
         }
-        
+
         public Builder outputConfigFormat(OutputFormat outputConfigFormat) {
             this.outputConfigFormat = outputConfigFormat;
             return this;
         }
-        
+
         public Builder outputConfigFile(Path outputConfigFile) {
             this.outputConfigFile = outputConfigFile;
             return this;
         }
-        
+
         public Builder reportFormat(String reportFormat) {
             this.reportFormat = reportFormat;
             return this;
         }
-        
+
         public Builder reportOutput(Path reportOutput) {
             this.reportOutput = reportOutput;
             return this;
         }
-        
+
         public Builder failLevel(Severity failLevel) {
             this.failLevel = failLevel;
             return this;
         }
-        
+
         public CLIConfig build() {
             return new CLIConfig(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOutputHandler.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/CLIOutputHandler.java
@@ -15,22 +15,23 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
  * Handles output routing for CLI based on configuration.
  */
 public class CLIOutputHandler {
-    
+
     private final ReportWriter reportWriter;
-    
+
     public CLIOutputHandler() {
         this.reportWriter = new ReportWriter();
     }
-    
+
     /**
      * Writes a single validation result based on the CLI configuration.
      */
-    public void writeReport(ValidationResult result, CLIConfig config, OutputConfiguration outputConfig) throws IOException {
+    public void writeReport(ValidationResult result, CLIConfig config, OutputConfiguration outputConfig)
+            throws IOException {
         if (config.isOutputToFile()) {
             // Write to file
             Path outputFile = config.getReportOutput();
             ensureParentDirectoryExists(outputFile);
-            
+
             try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile.toFile()))) {
                 reportWriter.write(result, config.getReportFormat(), writer, outputConfig);
             }
@@ -39,20 +40,20 @@ public class CLIOutputHandler {
             reportWriter.writeToConsole(result, config.getReportFormat(), outputConfig);
         }
     }
-    
+
     /**
      * Writes multiple validation results for directory input.
      */
-    public void writeMultipleReports(Map<Path, ValidationResult> results, CLIConfig config, 
-                                   ValidationResult aggregated, OutputConfiguration outputConfig) throws IOException {
+    public void writeMultipleReports(Map<Path, ValidationResult> results, CLIConfig config, ValidationResult aggregated,
+            OutputConfiguration outputConfig) throws IOException {
         if (!config.isOutputToFile()) {
             // Write aggregated result to console
             reportWriter.writeToConsole(aggregated, config.getReportFormat(), outputConfig);
             return;
         }
-        
+
         Path output = config.getReportOutput();
-        
+
         if (Files.isDirectory(output) || output.toString().endsWith("/") || output.toString().endsWith("\\")) {
             // Write individual reports to directory
             writeIndividualReports(results, config, output, outputConfig);
@@ -61,41 +62,41 @@ public class CLIOutputHandler {
             writeReport(aggregated, config, outputConfig);
         }
     }
-    
-    private void writeIndividualReports(Map<Path, ValidationResult> results, CLIConfig config, 
-                                      Path outputDir, OutputConfiguration outputConfig) throws IOException {
+
+    private void writeIndividualReports(Map<Path, ValidationResult> results, CLIConfig config, Path outputDir,
+            OutputConfiguration outputConfig) throws IOException {
         // Ensure output directory exists
         if (!Files.exists(outputDir)) {
             Files.createDirectories(outputDir);
         }
-        
+
         for (Map.Entry<Path, ValidationResult> entry : results.entrySet()) {
             Path inputFile = entry.getKey();
             ValidationResult result = entry.getValue();
-            
+
             // Generate output filename based on input filename
             String outputFileName = generateOutputFileName(inputFile, config.getReportFormat());
             Path outputFile = outputDir.resolve(outputFileName);
-            
+
             try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile.toFile()))) {
                 reportWriter.write(result, config.getReportFormat(), writer, outputConfig);
             }
         }
     }
-    
+
     private String generateOutputFileName(Path inputFile, String format) {
         String baseName = inputFile.getFileName().toString();
-        
+
         // Remove .adoc extension if present
         if (baseName.endsWith(".adoc")) {
             baseName = baseName.substring(0, baseName.length() - 5);
         }
-        
+
         // Add format extension
         String extension = "json".equals(format) ? ".json" : ".txt";
         return baseName + "-report" + extension;
     }
-    
+
     private void ensureParentDirectoryExists(Path file) throws IOException {
         Path parent = file.getParent();
         if (parent != null && !Files.exists(parent)) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/ConfigurationDisplay.java
@@ -8,28 +8,30 @@ import com.dataliquid.asciidoc.linter.cli.display.DisplayConstants;
 import com.dataliquid.asciidoc.linter.cli.display.TextWrapper;
 
 /**
- * Handles the display of configuration information for the AsciiDoc linter.
- * Formats and presents the configuration in a visually appealing ASCII box.
+ * Handles the display of configuration information for the AsciiDoc linter. Formats and presents the configuration in a
+ * visually appealing ASCII box.
  */
 public class ConfigurationDisplay {
-    
+
     private final int boxWidth;
     private final int labelWidth;
     private final AsciiBoxDrawer boxDrawer;
     private final TextWrapper textWrapper;
-    
+
     /**
      * Creates a new ConfigurationDisplay with default settings.
      */
     public ConfigurationDisplay() {
         this(DisplayConstants.DEFAULT_BOX_WIDTH, DisplayConstants.DEFAULT_LABEL_WIDTH);
     }
-    
+
     /**
      * Creates a new ConfigurationDisplay with custom dimensions.
-     * 
-     * @param boxWidth the width of the display box
-     * @param labelWidth the width allocated for labels
+     *
+     * @param boxWidth
+     *            the width of the display box
+     * @param labelWidth
+     *            the width allocated for labels
      */
     public ConfigurationDisplay(int boxWidth, int labelWidth) {
         this.boxWidth = boxWidth;
@@ -37,141 +39,132 @@ public class ConfigurationDisplay {
         this.boxDrawer = new AsciiBoxDrawer(boxWidth);
         this.textWrapper = new TextWrapper();
     }
-    
+
     /**
      * Displays the configuration information in a formatted box.
-     * 
-     * @param config the CLI configuration to display
+     *
+     * @param config
+     *            the CLI configuration to display
      */
     public void display(CLIConfig config) {
         System.out.println(); // Empty line before box
-        
+
         boxDrawer.drawTop();
         boxDrawer.drawTitle("Configuration");
         boxDrawer.drawSeparator();
-        
+
         drawConfigurationLines(config);
-        
+
         boxDrawer.drawBottom();
-        
+
         System.out.println(); // Empty line after box
         System.out.println("Starting validation...");
         System.out.println();
     }
-    
+
     /**
      * Draws all configuration lines within the box.
-     * 
-     * @param config the CLI configuration
+     *
+     * @param config
+     *            the CLI configuration
      */
     private void drawConfigurationLines(CLIConfig config) {
         // Input patterns - always shown
-        drawConfigLine("Input patterns:", 
-            String.join(", ", config.getInputPatterns()));
-        
+        drawConfigLine("Input patterns:", String.join(", ", config.getInputPatterns()));
+
         // Base directory - always shown
-        drawConfigLine("Base directory:", 
-            config.getBaseDirectory().toString());
-        
+        drawConfigLine("Base directory:", config.getBaseDirectory().toString());
+
         // Configuration file - show "default" if not specified
-        String configFile = config.getConfigFile() != null ? 
-            config.getConfigFile().toString() : "default";
+        String configFile = config.getConfigFile() != null ? config.getConfigFile().toString() : "default";
         drawConfigLine("Configuration:", configFile);
-        
+
         // Output config - show name or file if specified
         if (config.getOutputConfigFormat() != null) {
-            drawConfigLine("Output config:", 
-                config.getOutputConfigFormat().getValue() + " (predefined)");
+            drawConfigLine("Output config:", config.getOutputConfigFormat().getValue() + " (predefined)");
         } else if (config.getOutputConfigFile() != null) {
-            drawConfigLine("Output config:", 
-                config.getOutputConfigFile().toString());
+            drawConfigLine("Output config:", config.getOutputConfigFile().toString());
         } else {
             drawConfigLine("Output config:", "enhanced (default)");
         }
-        
+
         // Report format - always shown
         drawConfigLine("Report format:", config.getReportFormat());
-        
+
         // Report output file - only shown if specified
         if (config.getReportOutput() != null) {
-            drawConfigLine("Report output:", 
-                config.getReportOutput().toString());
+            drawConfigLine("Report output:", config.getReportOutput().toString());
         }
-        
+
         // Fail level - always shown
         drawConfigLine("Fail level:", config.getFailLevel().toString());
     }
-    
+
     /**
      * Draws a single configuration line, handling text wrapping if necessary.
-     * 
-     * @param label the configuration label
-     * @param value the configuration value
+     *
+     * @param label
+     *            the configuration label
+     * @param value
+     *            the configuration value
      */
     private void drawConfigLine(String label, String value) {
         int valueWidth = boxWidth - 4 - labelWidth; // 4 for borders and padding
         List<String> wrappedLines = textWrapper.wrap(value, valueWidth);
         boxDrawer.drawLabeledLines(label, wrappedLines, labelWidth);
     }
-    
+
     /**
-     * Creates a list of configuration entries for display.
-     * This method can be used for alternative display formats.
-     * 
-     * @param config the CLI configuration
+     * Creates a list of configuration entries for display. This method can be used for alternative display formats.
+     *
+     * @param config
+     *            the CLI configuration
      * @return a list of configuration entries
      */
     public List<ConfigEntry> getConfigurationEntries(CLIConfig config) {
         List<ConfigEntry> entries = new ArrayList<>();
-        
-        entries.add(new ConfigEntry("Input patterns", 
-            String.join(", ", config.getInputPatterns())));
-        entries.add(new ConfigEntry("Base directory", 
-            config.getBaseDirectory().toString()));
-        
-        String configFile = config.getConfigFile() != null ? 
-            config.getConfigFile().toString() : "default";
+
+        entries.add(new ConfigEntry("Input patterns", String.join(", ", config.getInputPatterns())));
+        entries.add(new ConfigEntry("Base directory", config.getBaseDirectory().toString()));
+
+        String configFile = config.getConfigFile() != null ? config.getConfigFile().toString() : "default";
         entries.add(new ConfigEntry("Configuration", configFile));
-        
+
         if (config.getOutputConfigFormat() != null) {
-            entries.add(new ConfigEntry("Output config", 
-                config.getOutputConfigFormat().getValue() + " (predefined)"));
+            entries.add(new ConfigEntry("Output config", config.getOutputConfigFormat().getValue() + " (predefined)"));
         } else if (config.getOutputConfigFile() != null) {
-            entries.add(new ConfigEntry("Output config", 
-                config.getOutputConfigFile().toString()));
+            entries.add(new ConfigEntry("Output config", config.getOutputConfigFile().toString()));
         } else {
             entries.add(new ConfigEntry("Output config", "enhanced (default)"));
         }
-        
+
         entries.add(new ConfigEntry("Report format", config.getReportFormat()));
-        
+
         if (config.getReportOutput() != null) {
-            entries.add(new ConfigEntry("Report output", 
-                config.getReportOutput().toString()));
+            entries.add(new ConfigEntry("Report output", config.getReportOutput().toString()));
         }
-        
-        entries.add(new ConfigEntry("Fail level", 
-            config.getFailLevel().toString()));
-        
+
+        entries.add(new ConfigEntry("Fail level", config.getFailLevel().toString()));
+
         return entries;
     }
-    
+
     /**
      * Represents a single configuration entry.
      */
     public static class ConfigEntry {
         private final String label;
         private final String value;
-        
+
         public ConfigEntry(String label, String value) {
             this.label = label;
             this.value = value;
         }
-        
+
         public String getLabel() {
             return label;
         }
-        
+
         public String getValue() {
             return value;
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/FileDiscoveryService.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/FileDiscoveryService.java
@@ -22,34 +22,39 @@ import org.apache.logging.log4j.Logger;
  * Service for discovering AsciiDoc files based on Ant patterns.
  */
 public class FileDiscoveryService {
-    
+
     private static final Logger logger = LogManager.getLogger(FileDiscoveryService.class);
-    
+
     /**
      * Discovers files based on the CLI configuration.
-     * 
-     * @param config The CLI configuration
+     *
+     * @param config
+     *            The CLI configuration
      * @return List of paths to validate
-     * @throws IOException if an I/O error occurs
+     * @throws IOException
+     *             if an I/O error occurs
      */
     public List<Path> discoverFiles(CLIConfig config) throws IOException {
         return discoverFiles(config.getInputPatterns(), config.getBaseDirectory());
     }
-    
+
     /**
      * Discovers files matching the given Ant patterns.
-     * 
-     * @param patterns List of Ant patterns
-     * @param baseDir Base directory for relative patterns
+     *
+     * @param patterns
+     *            List of Ant patterns
+     * @param baseDir
+     *            Base directory for relative patterns
      * @return List of matching file paths (duplicates removed)
-     * @throws IOException if an I/O error occurs
+     * @throws IOException
+     *             if an I/O error occurs
      */
     public List<Path> discoverFiles(List<String> patterns, Path baseDir) throws IOException {
         Set<Path> matchedFiles = new LinkedHashSet<>(); // Use LinkedHashSet to maintain order and remove duplicates
-        
+
         for (String pattern : patterns) {
             logger.debug("Processing pattern: {}", pattern);
-            
+
             // Handle absolute paths and simple file names
             Path patternPath = Paths.get(pattern);
             if (patternPath.isAbsolute() && patternPath.toFile().exists()) {
@@ -58,30 +63,30 @@ public class FileDiscoveryService {
                     continue;
                 }
             }
-            
+
             // Check if it's a simple filename in the base directory
             Path simpleFile = baseDir.resolve(pattern);
             if (simpleFile.toFile().isFile()) {
                 matchedFiles.add(simpleFile.normalize());
                 continue;
             }
-            
+
             // Process as Ant pattern
             matchedFiles.addAll(findFilesMatchingAntPattern(pattern, baseDir));
         }
-        
+
         return new ArrayList<>(matchedFiles);
     }
-    
+
     private List<Path> findFilesMatchingAntPattern(String pattern, Path baseDir) throws IOException {
         List<Path> matchingFiles = new ArrayList<>();
-        
+
         // Convert Ant pattern to file filter
         AntPatternFileFilter antFilter = new AntPatternFileFilter(pattern, baseDir);
-        
+
         // Use all directories for traversal
         IOFileFilter dirFilter = TrueFileFilter.INSTANCE;
-        
+
         // Find matching files
         File baseDirFile = baseDir.toFile();
         if (baseDirFile.exists() && baseDirFile.isDirectory()) {
@@ -89,77 +94,75 @@ public class FileDiscoveryService {
                 matchingFiles.add(file.toPath().normalize());
             }
         }
-        
+
         return matchingFiles;
     }
-    
-    
+
     /**
      * Custom file filter for Ant patterns.
      */
     private static class AntPatternFileFilter implements IOFileFilter {
         private final String pattern;
         private final Path baseDir;
-        
+
         public AntPatternFileFilter(String pattern, Path baseDir) {
             this.pattern = pattern;
             this.baseDir = baseDir;
         }
-        
+
         @Override
         public boolean accept(File file) {
             if (!file.isFile()) {
                 return false;
             }
-            
+
             Path filePath = file.toPath().normalize();
             Path relativePath = baseDir.relativize(filePath);
             String pathStr = relativePath.toString().replace(File.separatorChar, '/');
-            
+
             return matchesAntPattern(pathStr, pattern);
         }
-        
+
         @Override
         public boolean accept(File dir, String name) {
             return accept(new File(dir, name));
         }
-        
+
         private boolean matchesAntPattern(String path, String pattern) {
             boolean result = AntPatternMatcher.match(pattern, path);
             logger.debug("Matching '{}' against pattern '{}': {}", path, pattern, result);
             return result;
         }
     }
-    
-    
+
     /**
      * Simple Ant pattern matcher implementation with pattern caching.
      */
     private static class AntPatternMatcher {
         // Cache for compiled regex patterns to improve performance
         private static final Map<String, Pattern> PATTERN_CACHE = new ConcurrentHashMap<>();
-        
+
         public static boolean match(String pattern, String path) {
             // Normalize paths
             pattern = pattern.replace(File.separatorChar, '/');
             path = path.replace(File.separatorChar, '/');
-            
+
             // Handle ** (matches any number of directories)
             if (pattern.contains("**")) {
                 return matchWithDoubleWildcard(pattern, path);
             }
-            
+
             // Simple pattern matching
             return matchSimplePattern(pattern, path);
         }
-        
+
         private static boolean matchWithDoubleWildcard(String pattern, String path) {
             String[] patternParts = pattern.split("/");
             String[] pathParts = path.split("/");
-            
+
             int patternIndex = 0;
             int pathIndex = 0;
-            
+
             while (patternIndex < patternParts.length) {
                 if (pathIndex >= pathParts.length) {
                     // Check if remaining pattern parts are all **
@@ -171,20 +174,20 @@ public class FileDiscoveryService {
                     }
                     return true;
                 }
-                
+
                 String patternPart = patternParts[patternIndex];
-                
+
                 if (patternPart.equals("**")) {
                     // Handle **
                     if (patternIndex == patternParts.length - 1) {
                         // ** at end matches everything
                         return true;
                     }
-                    
+
                     // Find next pattern part after **
                     patternIndex++;
                     String nextPattern = patternParts[patternIndex];
-                    
+
                     // Try to match nextPattern with any remaining path part
                     boolean found = false;
                     while (pathIndex < pathParts.length) {
@@ -196,7 +199,7 @@ public class FileDiscoveryService {
                         }
                         pathIndex++;
                     }
-                    
+
                     if (!found) {
                         return false;
                     }
@@ -209,28 +212,28 @@ public class FileDiscoveryService {
                     pathIndex++;
                 }
             }
-            
+
             // All pattern parts consumed, check if all path parts consumed
             return pathIndex == pathParts.length;
         }
-        
+
         private static boolean matchSimplePattern(String pattern, String path) {
             String[] patternParts = pattern.split("/");
             String[] pathParts = path.split("/");
-            
+
             if (patternParts.length != pathParts.length) {
                 return false;
             }
-            
+
             for (int i = 0; i < patternParts.length; i++) {
                 if (!matchPart(patternParts[i], pathParts[i])) {
                     return false;
                 }
             }
-            
+
             return true;
         }
-        
+
         private static boolean matchPart(String pattern, String text) {
             // Use cached pattern if available, otherwise compile and cache it
             Pattern compiledPattern = PATTERN_CACHE.computeIfAbsent(pattern, p -> {
@@ -239,35 +242,35 @@ public class FileDiscoveryService {
                 for (int i = 0; i < p.length(); i++) {
                     char c = p.charAt(i);
                     switch (c) {
-                        case '*':
+                        case '*' :
                             regex.append(".*");
                             break;
-                        case '?':
+                        case '?' :
                             regex.append(".");
                             break;
-                        case '.':
-                        case '\\':
-                        case '[':
-                        case ']':
-                        case '(':
-                        case ')':
-                        case '^':
-                        case '$':
-                        case '{':
-                        case '}':
-                        case '+':
-                        case '|':
+                        case '.' :
+                        case '\\' :
+                        case '[' :
+                        case ']' :
+                        case '(' :
+                        case ')' :
+                        case '^' :
+                        case '$' :
+                        case '{' :
+                        case '}' :
+                        case '+' :
+                        case '|' :
                             regex.append("\\").append(c);
                             break;
-                        default:
+                        default :
                             regex.append(c);
                     }
                 }
                 regex.append("$");
-                
+
                 return Pattern.compile(regex.toString());
             });
-            
+
             return compiledPattern.matcher(text).matches();
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/MainCLI.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/MainCLI.java
@@ -18,41 +18,41 @@ import com.dataliquid.asciidoc.linter.cli.display.SplashScreen;
  * Main CLI entry point for the AsciiDoc tools.
  */
 public class MainCLI {
-    
+
     private static final Logger logger = LogManager.getLogger(MainCLI.class);
     private final CommandRegistry commandRegistry;
-    
+
     public MainCLI() {
         this.commandRegistry = new CommandRegistry();
     }
-    
+
     public static void main(String[] args) {
         MainCLI cli = new MainCLI();
         int exitCode = cli.run(args);
         System.exit(exitCode);
     }
-    
+
     public int run(String[] args) {
         // Handle no arguments
         if (args.length == 0) {
             printMainHelp();
             return 0;
         }
-        
+
         // Check for global options first
         if (args[0].equals("--help") || args[0].equals("-h")) {
             printMainHelp();
             return 0;
         }
-        
+
         if (args[0].equals("--version") || args[0].equals("-v")) {
             printVersion();
             return 0;
         }
-        
+
         // Check if first argument is a command
         String potentialCommand = args[0];
-        
+
         // Check if command exists
         Command command = commandRegistry.getCommand(potentialCommand);
         if (command == null) {
@@ -60,16 +60,16 @@ public class MainCLI {
             printMainHelp();
             return 2;
         }
-        
+
         // Parse command-specific arguments
         String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
-        
+
         // Check for splash screen suppression in global args
         boolean showSplash = !containsNoSplash(args) && !potentialCommand.equals("guidelines");
         if (showSplash) {
             SplashScreen.display();
         }
-        
+
         try {
             CommandLineParser parser = new DefaultParser();
             CommandLine cmd = parser.parse(command.getOptions(), commandArgs);
@@ -86,7 +86,7 @@ public class MainCLI {
             return 2;
         }
     }
-    
+
     private boolean containsNoSplash(String[] args) {
         for (String arg : args) {
             if (arg.equals("--no-splash")) {
@@ -95,14 +95,14 @@ public class MainCLI {
         }
         return false;
     }
-    
+
     private void printMainHelp() {
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(100);
-        
+
         VersionInfo versionInfo = VersionInfo.getInstance();
         String programName = versionInfo.getArtifactId();
-        
+
         System.out.println("\n" + programName + " - AsciiDoc Linter");
         System.out.println("Version: " + versionInfo.getFullVersion());
         System.out.println("\nUsage: " + programName + " [global-options] <command> [command-options]");
@@ -110,14 +110,14 @@ public class MainCLI {
         System.out.println("  -h, --help       Show this help message");
         System.out.println("  -v, --version    Show version information");
         System.out.println("  --no-splash      Suppress splash screen");
-        
+
         commandRegistry.printCommandSummary();
-        
+
         System.out.println("\nExamples:");
         System.out.println("  " + programName + " lint -i \"**/*.adoc\"");
         System.out.println("  " + programName + " guidelines -r rules.yaml -o guide.adoc");
     }
-    
+
     private void printVersion() {
         System.out.println(VersionInfo.getInstance().getFullVersion());
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/VersionInfo.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/VersionInfo.java
@@ -5,22 +5,20 @@ import java.io.InputStream;
 import java.util.Properties;
 
 /**
- * Provides version information for the AsciiDoc Linter.
- * Reads version details from Maven-generated pom.properties file.
+ * Provides version information for the AsciiDoc Linter. Reads version details from Maven-generated pom.properties file.
  */
 public class VersionInfo {
-    private static final String POM_PROPERTIES_PATH = 
-        "/META-INF/maven/com.dataliquid/asciidoc-linter/pom.properties";
+    private static final String POM_PROPERTIES_PATH = "/META-INF/maven/com.dataliquid/asciidoc-linter/pom.properties";
     private static final String UNKNOWN = "<unknown>";
-    
+
     private static VersionInfo instance;
     private final String version;
     private final String artifactId;
     private final String groupId;
-    
+
     private VersionInfo() {
         Properties props = new Properties();
-        
+
         try (InputStream is = getClass().getResourceAsStream(POM_PROPERTIES_PATH)) {
             if (is != null) {
                 props.load(is);
@@ -28,15 +26,15 @@ public class VersionInfo {
         } catch (IOException e) {
             // Properties remain empty
         }
-        
+
         this.version = props.getProperty("version", UNKNOWN);
         this.artifactId = props.getProperty("artifactId", "asciidoc-linter");
         this.groupId = props.getProperty("groupId", "com.dataliquid");
     }
-    
+
     /**
      * Gets the singleton instance of VersionInfo.
-     * 
+     *
      * @return the VersionInfo instance
      */
     public static VersionInfo getInstance() {
@@ -45,37 +43,37 @@ public class VersionInfo {
         }
         return instance;
     }
-    
+
     /**
      * Gets the version string.
-     * 
+     *
      * @return the version, or "&lt;unknown&gt;" if not available
      */
     public String getVersion() {
         return version;
     }
-    
+
     /**
      * Gets the artifact ID.
-     * 
+     *
      * @return the artifact ID, or "&lt;unknown&gt;" if not available
      */
     public String getArtifactId() {
         return artifactId;
     }
-    
+
     /**
      * Gets the group ID.
-     * 
+     *
      * @return the group ID, or "&lt;unknown&gt;" if not available
      */
     public String getGroupId() {
         return groupId;
     }
-    
+
     /**
      * Gets the full version string including artifact ID and version.
-     * 
+     *
      * @return formatted version string
      */
     public String getFullVersion() {

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/command/Command.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/command/Command.java
@@ -4,43 +4,43 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
 /**
- * Interface for CLI commands following the command pattern.
- * Each command represents a specific operation mode of the linter.
+ * Interface for CLI commands following the command pattern. Each command represents a specific operation mode of the
+ * linter.
  */
 public interface Command {
-    
+
     /**
-     * Gets the name of the command.
-     * This is used as the subcommand in the CLI.
-     * 
+     * Gets the name of the command. This is used as the subcommand in the CLI.
+     *
      * @return the command name
      */
     String getName();
-    
+
     /**
-     * Gets a brief description of what this command does.
-     * Used in help text generation.
-     * 
+     * Gets a brief description of what this command does. Used in help text generation.
+     *
      * @return the command description
      */
     String getDescription();
-    
+
     /**
      * Gets the command-specific options.
-     * 
+     *
      * @return the options for this command
      */
     Options getOptions();
-    
+
     /**
      * Executes the command with the given parsed command line arguments.
-     * 
-     * @param cmd the parsed command line
+     *
+     * @param cmd
+     *            the parsed command line
      * @return exit code (0 for success, non-zero for error)
-     * @throws Exception if an error occurs during execution
+     * @throws Exception
+     *             if an error occurs during execution
      */
     int execute(CommandLine cmd) throws Exception;
-    
+
     /**
      * Prints help for this specific command.
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/command/CommandRegistry.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/command/CommandRegistry.java
@@ -5,18 +5,17 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Registry for all available CLI commands.
- * Manages command registration and lookup.
+ * Registry for all available CLI commands. Manages command registration and lookup.
  */
 public class CommandRegistry {
-    
+
     private final Map<String, Command> commands;
-    
+
     public CommandRegistry() {
         this.commands = new HashMap<>();
         registerDefaultCommands();
     }
-    
+
     /**
      * Registers the default commands.
      */
@@ -24,72 +23,72 @@ public class CommandRegistry {
         register(new LintCommand());
         register(new GuidelinesCommand());
     }
-    
+
     /**
      * Registers a command.
-     * 
-     * @param command the command to register
+     *
+     * @param command
+     *            the command to register
      */
     public void register(Command command) {
         commands.put(command.getName(), command);
     }
-    
+
     /**
      * Gets a command by name.
-     * 
-     * @param name the command name
+     *
+     * @param name
+     *            the command name
      * @return the command, or null if not found
      */
     public Command getCommand(String name) {
         return commands.get(name);
     }
-    
+
     /**
      * Checks if a command exists.
-     * 
-     * @param name the command name
+     *
+     * @param name
+     *            the command name
      * @return true if the command exists
      */
     public boolean hasCommand(String name) {
         return commands.containsKey(name);
     }
-    
+
     /**
      * Gets all registered command names.
-     * 
+     *
      * @return set of command names
      */
     public Set<String> getCommandNames() {
         return commands.keySet();
     }
-    
+
     /**
      * Gets all registered commands.
-     * 
+     *
      * @return map of commands
      */
     public Map<String, Command> getAllCommands() {
         return new HashMap<>(commands);
     }
-    
+
     /**
      * Prints a summary of all available commands.
      */
     public void printCommandSummary() {
         System.out.println("\nAvailable commands:");
-        
-        int maxNameLength = commands.keySet().stream()
-            .mapToInt(String::length)
-            .max()
-            .orElse(10);
-        
+
+        int maxNameLength = commands.keySet().stream().mapToInt(String::length).max().orElse(10);
+
         for (Map.Entry<String, Command> entry : commands.entrySet()) {
             String name = entry.getKey();
             String description = entry.getValue().getDescription();
             String padding = " ".repeat(maxNameLength - name.length() + 2);
             System.out.println("  " + name + padding + description);
         }
-        
+
         System.out.println("\nUse 'asciidoc-linter <command> --help' for more information about a command.");
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/command/GuidelinesCommand.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/command/GuidelinesCommand.java
@@ -26,61 +26,46 @@ import com.dataliquid.asciidoc.linter.documentation.VisualizationStyle;
  * Command for generating author guidelines from linter configuration.
  */
 public class GuidelinesCommand implements Command {
-    
+
     private static final Logger logger = LogManager.getLogger(GuidelinesCommand.class);
     private final ConfigurationLoader configLoader;
-    
+
     public GuidelinesCommand() {
         this.configLoader = new ConfigurationLoader();
     }
-    
+
     @Override
     public String getName() {
         return "guidelines";
     }
-    
+
     @Override
     public String getDescription() {
         return "Generate author guidelines showing all validation requirements";
     }
-    
+
     @Override
     public Options getOptions() {
         Options options = new Options();
-        
+
         // Configuration file (required for execution, but not for help)
-        options.addOption(Option.builder("r")
-            .longOpt("rule")
-            .hasArg()
-            .argName("file")
-            .desc("YAML rule configuration file (required)")
-            .build());
-        
+        options.addOption(Option.builder("r").longOpt("rule").hasArg().argName("file")
+                .desc("YAML rule configuration file (required)").build());
+
         // Output file
-        options.addOption(Option.builder("o")
-            .longOpt("output")
-            .hasArg()
-            .argName("file")
-            .desc("Output file for generated guidelines (default: stdout)")
-            .build());
-        
+        options.addOption(Option.builder("o").longOpt("output").hasArg().argName("file")
+                .desc("Output file for generated guidelines (default: stdout)").build());
+
         // Visualization style
-        options.addOption(Option.builder("s")
-            .longOpt("style")
-            .hasArg()
-            .argName("styles")
-            .desc("Comma-separated visualization styles: tree, nested, breadcrumb, table (default: tree)")
-            .build());
-        
+        options.addOption(Option.builder("s").longOpt("style").hasArg().argName("styles")
+                .desc("Comma-separated visualization styles: tree, nested, breadcrumb, table (default: tree)").build());
+
         // Help
-        options.addOption(Option.builder("h")
-            .longOpt("help")
-            .desc("Show help for guidelines command")
-            .build());
-        
+        options.addOption(Option.builder("h").longOpt("help").desc("Show help for guidelines command").build());
+
         return options;
     }
-    
+
     @Override
     public int execute(CommandLine cmd) throws Exception {
         // Handle help
@@ -88,28 +73,28 @@ public class GuidelinesCommand implements Command {
             printHelp();
             return 0;
         }
-        
+
         // Check required rule file
         if (!cmd.hasOption("rule")) {
             System.err.println("Error: --rule is required for guidelines command");
             printHelp();
             return 2;
         }
-        
+
         try {
             // Load configuration
             String configPath = cmd.getOptionValue("rule");
             LinterConfiguration config = loadConfiguration(configPath);
-            
+
             // Parse visualization styles
             Set<VisualizationStyle> styles = parseVisualizationStyles(cmd.getOptionValue("style"));
-            
+
             // Create generator
             RuleDocumentationGenerator generator = new AsciiDocAuthorGuidelineGenerator(styles);
-            
+
             // Determine output
             String outputPath = cmd.getOptionValue("output");
-            
+
             if (outputPath != null) {
                 // Write to file
                 generateToFile(generator, config, outputPath);
@@ -118,66 +103,58 @@ public class GuidelinesCommand implements Command {
                 // Write to stdout
                 generateToStdout(generator, config);
             }
-            
+
             return 0;
-            
+
         } catch (Exception e) {
             logger.error("Error generating guidelines: {}", e.getMessage());
             System.err.println("Error generating guidelines: " + e.getMessage());
             return 2;
         }
     }
-    
+
     @Override
     public void printHelp() {
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(100);
-        
+
         VersionInfo versionInfo = VersionInfo.getInstance();
         String programName = versionInfo.getArtifactId();
-        
+
         String header = "\nGenerates author guidelines from linter rule configuration.\n\n";
-        String footer = "\nExamples:\n" +
-            "  " + programName + " guidelines -r rules.yaml\n" +
-            "  " + programName + " guidelines -r rules.yaml -o guidelines.adoc\n" +
-            "  " + programName + " guidelines --rule strict.yaml --output guide.md --style tree,table\n" +
-            "\nVisualization Styles:\n" +
-            "  tree       - Hierarchical tree structure\n" +
-            "  nested     - Nested sections\n" +
-            "  breadcrumb - Breadcrumb navigation\n" +
-            "  table      - Tabular format\n";
-        
-        formatter.printHelp(programName + " guidelines -r <file> [options]", 
-            header, getOptions(), footer, false);
+        String footer = "\nExamples:\n" + "  " + programName + " guidelines -r rules.yaml\n" + "  " + programName
+                + " guidelines -r rules.yaml -o guidelines.adoc\n" + "  " + programName
+                + " guidelines --rule strict.yaml --output guide.md --style tree,table\n" + "\nVisualization Styles:\n"
+                + "  tree       - Hierarchical tree structure\n" + "  nested     - Nested sections\n"
+                + "  breadcrumb - Breadcrumb navigation\n" + "  table      - Tabular format\n";
+
+        formatter.printHelp(programName + " guidelines -r <file> [options]", header, getOptions(), footer, false);
     }
-    
+
     private LinterConfiguration loadConfiguration(String configPath) throws IOException {
         File configFile = new File(configPath);
         if (!configFile.exists()) {
             throw new IOException("Configuration file not found: " + configPath);
         }
-        
+
         return configLoader.loadConfiguration(configFile.toPath());
     }
-    
+
     private Set<VisualizationStyle> parseVisualizationStyles(String stylesArg) {
         if (stylesArg == null || stylesArg.trim().isEmpty()) {
             // Default to tree visualization
             return Set.of(VisualizationStyle.TREE);
         }
-        
-        return Arrays.stream(stylesArg.split(","))
-            .map(String::trim)
-            .map(VisualizationStyle::fromName)
-            .collect(Collectors.toSet());
+
+        return Arrays.stream(stylesArg.split(",")).map(String::trim).map(VisualizationStyle::fromName)
+                .collect(Collectors.toSet());
     }
-    
-    private void generateToFile(RuleDocumentationGenerator generator, 
-                               LinterConfiguration config, 
-                               String outputPath) throws IOException {
-        
+
+    private void generateToFile(RuleDocumentationGenerator generator, LinterConfiguration config, String outputPath)
+            throws IOException {
+
         File outputFile = new File(outputPath);
-        
+
         // Create parent directories if needed
         File parentDir = outputFile.getParentFile();
         if (parentDir != null && !parentDir.exists()) {
@@ -185,14 +162,13 @@ public class GuidelinesCommand implements Command {
                 throw new IOException("Failed to create output directory: " + parentDir);
             }
         }
-        
+
         try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile))) {
             generator.generate(config, writer);
         }
     }
-    
-    private void generateToStdout(RuleDocumentationGenerator generator, 
-                                 LinterConfiguration config) {
+
+    private void generateToStdout(RuleDocumentationGenerator generator, LinterConfiguration config) {
         PrintWriter writer = new PrintWriter(System.out);
         generator.generate(config, writer);
         writer.flush();

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/command/LintCommand.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/command/LintCommand.java
@@ -23,88 +23,57 @@ import com.dataliquid.asciidoc.linter.config.output.OutputFormat;
  * Command for linting AsciiDoc files.
  */
 public class LintCommand implements Command {
-    
+
     private static final Logger logger = LogManager.getLogger(LintCommand.class);
-    
+
     @Override
     public String getName() {
         return "lint";
     }
-    
+
     @Override
     public String getDescription() {
         return "Validate AsciiDoc files against configured rules";
     }
-    
+
     @Override
     public Options getOptions() {
         Options options = new Options();
-        
+
         // Input patterns (required for execution, but not for help)
-        options.addOption(Option.builder("i")
-            .longOpt("input")
-            .hasArg()
-            .argName("patterns")
-            .desc("Comma-separated Ant file patterns (e.g., '**/*.adoc,docs/**/*.asciidoc')")
-            .build());
-        
+        options.addOption(Option.builder("i").longOpt("input").hasArg().argName("patterns")
+                .desc("Comma-separated Ant file patterns (e.g., '**/*.adoc,docs/**/*.asciidoc')").build());
+
         // Configuration file
-        options.addOption(Option.builder("r")
-            .longOpt("rule")
-            .hasArg()
-            .argName("file")
-            .desc("YAML rule configuration file (default: .linter-rule-config.yaml)")
-            .build());
-        
+        options.addOption(Option.builder("r").longOpt("rule").hasArg().argName("file")
+                .desc("YAML rule configuration file (default: .linter-rule-config.yaml)").build());
+
         // Report format
-        options.addOption(Option.builder("f")
-            .longOpt("report-format")
-            .hasArg()
-            .argName("format")
-            .desc("Report format: console, json, json-compact (default: console)")
-            .build());
-        
+        options.addOption(Option.builder("f").longOpt("report-format").hasArg().argName("format")
+                .desc("Report format: console, json, json-compact (default: console)").build());
+
         // Report output
-        options.addOption(Option.builder("o")
-            .longOpt("report-output")
-            .hasArg()
-            .argName("file/directory")
-            .desc("Report output file or directory (default: stdout)")
-            .build());
-        
+        options.addOption(Option.builder("o").longOpt("report-output").hasArg().argName("file/directory")
+                .desc("Report output file or directory (default: stdout)").build());
+
         // Fail level
-        options.addOption(Option.builder("l")
-            .longOpt("fail-level")
-            .hasArg()
-            .argName("level")
-            .desc("Exit code 1 on: error, warn, info (default: error)")
-            .build());
-        
+        options.addOption(Option.builder("l").longOpt("fail-level").hasArg().argName("level")
+                .desc("Exit code 1 on: error, warn, info (default: error)").build());
+
         // Output configuration (predefined)
-        options.addOption(Option.builder()
-            .longOpt("output-config")
-            .hasArg()
-            .argName("name")
-            .desc("Predefined output configuration: enhanced, simple, compact (default: enhanced)")
-            .build());
-        
+        options.addOption(Option.builder().longOpt("output-config").hasArg().argName("name")
+                .desc("Predefined output configuration: enhanced, simple, compact (default: enhanced)").build());
+
         // Output configuration (custom file)
-        options.addOption(Option.builder()
-            .longOpt("output-config-file")
-            .hasArg()
-            .argName("file")
-            .desc("Custom YAML output configuration file for console formatting")
-            .build());
-        
+        options.addOption(Option.builder().longOpt("output-config-file").hasArg().argName("file")
+                .desc("Custom YAML output configuration file for console formatting").build());
+
         // Help
-        options.addOption(Option.builder("h")
-            .longOpt("help")
-            .desc("Show help for lint command")
-            .build());
-        
+        options.addOption(Option.builder("h").longOpt("help").desc("Show help for lint command").build());
+
         return options;
     }
-    
+
     @Override
     public int execute(CommandLine cmd) throws Exception {
         // Handle help
@@ -112,130 +81,123 @@ public class LintCommand implements Command {
             printHelp();
             return 0;
         }
-        
+
         // Check required input
         if (!cmd.hasOption("input")) {
             System.err.println("Error: --input is required for lint command");
             printHelp();
             return 2;
         }
-        
+
         try {
             // Parse configuration
             CLIConfig config = parseConfiguration(cmd);
-            
+
             // Display configuration (if not suppressed globally)
             boolean showConfig = !cmd.hasOption("quiet");
             if (showConfig) {
                 ConfigurationDisplay configDisplay = new ConfigurationDisplay();
                 configDisplay.display(config);
             }
-            
+
             // Run linter
             CLIRunner runner = new CLIRunner();
             return runner.run(config);
-            
+
         } catch (IllegalArgumentException e) {
             logger.error("Error: {}", e.getMessage());
             System.err.println("Error: " + e.getMessage());
             return 2;
         }
     }
-    
+
     @Override
     public void printHelp() {
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(100);
-        
+
         VersionInfo versionInfo = VersionInfo.getInstance();
         String programName = versionInfo.getArtifactId();
-        
+
         String header = "\nValidates AsciiDoc files against configurable rules.\n\n";
-        String footer = "\nExamples:\n" +
-            "  " + programName + " lint -i \"**/*.adoc\"\n" +
-            "  " + programName + " lint -i \"docs/**/*.adoc,examples/**/*.asciidoc\" -f json -o report.json\n" +
-            "  " + programName + " lint --input \"src/*/docs/**/*.adoc,README.adoc\" --rule strict.yaml --fail-level warn\n" +
-            "  " + programName + " lint -i \"**/*.adoc\" --output-config simple\n" +
-            "  " + programName + " lint -i \"**/*.adoc\" --output-config-file my-output.yaml\n" +
-            "\nAnt Pattern Syntax:\n" +
-            "  **  - matches any number of directories\n" +
-            "  *   - matches any number of characters (except /)\n" +
-            "  ?   - matches exactly one character\n" +
-            "\nExit codes:\n" +
-            "  0 - Success, no violations or only below fail level\n" +
-            "  1 - Violations at or above fail level found\n" +
-            "  2 - Invalid arguments or runtime error\n";
-        
-        formatter.printHelp(programName + " lint -i <patterns> [options]", 
-            header, getOptions(), footer, false);
+        String footer = "\nExamples:\n" + "  " + programName + " lint -i \"**/*.adoc\"\n" + "  " + programName
+                + " lint -i \"docs/**/*.adoc,examples/**/*.asciidoc\" -f json -o report.json\n" + "  " + programName
+                + " lint --input \"src/*/docs/**/*.adoc,README.adoc\" --rule strict.yaml --fail-level warn\n" + "  "
+                + programName + " lint -i \"**/*.adoc\" --output-config simple\n" + "  " + programName
+                + " lint -i \"**/*.adoc\" --output-config-file my-output.yaml\n" + "\nAnt Pattern Syntax:\n"
+                + "  **  - matches any number of directories\n"
+                + "  *   - matches any number of characters (except /)\n" + "  ?   - matches exactly one character\n"
+                + "\nExit codes:\n" + "  0 - Success, no violations or only below fail level\n"
+                + "  1 - Violations at or above fail level found\n" + "  2 - Invalid arguments or runtime error\n";
+
+        formatter.printHelp(programName + " lint -i <patterns> [options]", header, getOptions(), footer, false);
     }
-    
+
     private CLIConfig parseConfiguration(CommandLine cmd) {
         CLIConfig.Builder builder = CLIConfig.builder();
-        
+
         // Input patterns (required)
         String inputValue = cmd.getOptionValue("input");
-        List<String> patterns = Arrays.stream(inputValue.split(","))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .collect(Collectors.toList());
-        
+        List<String> patterns = Arrays.stream(inputValue.split(",")).map(String::trim).filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+
         if (patterns.isEmpty()) {
             throw new IllegalArgumentException("No input patterns provided");
         }
-        
+
         builder.inputPatterns(patterns);
-        
+
         // Config file
         if (cmd.hasOption("rule")) {
             builder.configFile(Paths.get(cmd.getOptionValue("rule")));
         }
-        
+
         // Output configuration
         if (cmd.hasOption("output-config") && cmd.hasOption("output-config-file")) {
             throw new IllegalArgumentException("Cannot use both --output-config and --output-config-file. Choose one.");
         }
-        
+
         if (cmd.hasOption("output-config")) {
             String configName = cmd.getOptionValue("output-config");
             try {
                 OutputFormat format = OutputFormat.fromValue(configName);
                 builder.outputConfigFormat(format);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Invalid output config name: " + configName + ". Valid options: enhanced, simple, compact");
+                throw new IllegalArgumentException(
+                        "Invalid output config name: " + configName + ". Valid options: enhanced, simple, compact");
             }
         }
-        
+
         if (cmd.hasOption("output-config-file")) {
             builder.outputConfigFile(Paths.get(cmd.getOptionValue("output-config-file")));
         }
-        
+
         // Report format
         if (cmd.hasOption("report-format")) {
             String format = cmd.getOptionValue("report-format");
             if (!format.equals("console") && !format.equals("json") && !format.equals("json-compact")) {
-                throw new IllegalArgumentException("Invalid report format: " + format + 
-                    ". Valid values are: console, json, json-compact");
+                throw new IllegalArgumentException(
+                        "Invalid report format: " + format + ". Valid values are: console, json, json-compact");
             }
             builder.reportFormat(format);
         }
-        
+
         // Report output
         if (cmd.hasOption("report-output")) {
             builder.reportOutput(Paths.get(cmd.getOptionValue("report-output")));
         }
-        
+
         // Fail level
         if (cmd.hasOption("fail-level")) {
             String level = cmd.getOptionValue("fail-level").toUpperCase();
             try {
                 builder.failLevel(Severity.valueOf(level));
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Invalid fail level: " + level + 
-                    ". Valid values are: error, warn, info");
+                throw new IllegalArgumentException(
+                        "Invalid fail level: " + level + ". Valid values are: error, warn, info");
             }
         }
-        
+
         return builder.build();
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/display/AsciiBoxDrawer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/display/AsciiBoxDrawer.java
@@ -5,28 +5,31 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Utility class for drawing ASCII box borders and content.
- * Provides methods to create well-formatted text boxes for console output.
+ * Utility class for drawing ASCII box borders and content. Provides methods to create well-formatted text boxes for
+ * console output.
  */
 public class AsciiBoxDrawer {
-    
+
     private final int width;
     private final PrintWriter printWriter;
-    
+
     /**
      * Creates a new AsciiBoxDrawer with the specified width.
-     * 
-     * @param width the total width of the box including borders
+     *
+     * @param width
+     *            the total width of the box including borders
      */
     public AsciiBoxDrawer(int width) {
         this(width, new PrintWriter(System.out, true));
     }
-    
+
     /**
      * Creates a new AsciiBoxDrawer with the specified width and print writer.
-     * 
-     * @param width the total width of the box including borders
-     * @param writer the print writer to write to
+     *
+     * @param width
+     *            the total width of the box including borders
+     * @param writer
+     *            the print writer to write to
      */
     public AsciiBoxDrawer(int width, PrintWriter writer) {
         if (width < 4) {
@@ -35,137 +38,147 @@ public class AsciiBoxDrawer {
         this.width = width;
         this.printWriter = Objects.requireNonNull(writer, "PrintWriter must not be null");
     }
-    
+
     /**
      * Outputs a line to the appropriate output.
      */
     private void println(String line) {
         printWriter.println(line);
     }
-    
+
     /**
      * Draws the top border of the box.
      */
     public void drawTop() {
         println("+" + "-".repeat(width - 2) + "+");
     }
-    
+
     /**
      * Draws the bottom border of the box.
      */
     public void drawBottom() {
         drawTop(); // Same as top border
     }
-    
+
     /**
      * Draws a separator line within the box.
      */
     public void drawSeparator() {
         drawTop(); // Same as borders
     }
-    
+
     /**
      * Draws a centered title within the box.
-     * 
-     * @param title the title text to center
+     *
+     * @param title
+     *            the title text to center
      */
     public void drawTitle(String title) {
         if (title == null) {
             title = "";
         }
-        
+
         int contentWidth = width - 2; // Subtract borders
         if (title.length() > contentWidth) {
             title = title.substring(0, contentWidth);
         }
-        
+
         int totalPadding = contentWidth - title.length();
         int leftPadding = totalPadding / 2;
         int rightPadding = totalPadding - leftPadding;
-        
+
         println("|" + " ".repeat(leftPadding) + title + " ".repeat(rightPadding) + "|");
     }
-    
+
     /**
      * Draws a simple content line with padding.
-     * 
-     * @param content the content to draw
+     *
+     * @param content
+     *            the content to draw
      */
     public void drawLine(String content) {
         if (content == null) {
             content = "";
         }
-        
+
         int contentWidth = width - 4; // Subtract borders and internal padding
         if (content.length() > contentWidth) {
             content = content.substring(0, contentWidth);
         }
-        
+
         println("| " + content + " ".repeat(contentWidth - content.length()) + " |");
     }
-    
+
     /**
      * Draws a labeled content line with proper alignment.
-     * 
-     * @param label the label text
-     * @param value the value text
-     * @param labelWidth the width allocated for the label
+     *
+     * @param label
+     *            the label text
+     * @param value
+     *            the value text
+     * @param labelWidth
+     *            the width allocated for the label
      */
     public void drawLabeledLine(String label, String value, int labelWidth) {
-        if (label == null) label = "";
-        if (value == null) value = "";
-        
+        if (label == null)
+            label = "";
+        if (value == null)
+            value = "";
+
         String paddedLabel = String.format("%-" + labelWidth + "s", label);
         int valueWidth = width - 4 - labelWidth; // Subtract borders, padding, and label
-        
+
         if (value.length() > valueWidth) {
             value = value.substring(0, valueWidth);
         }
-        
+
         println("| " + paddedLabel + value + " ".repeat(valueWidth - value.length()) + " |");
     }
-    
+
     /**
      * Draws multiple lines for labeled content, handling wrapped text.
-     * 
-     * @param label the label text (only shown on first line)
-     * @param lines the wrapped content lines
-     * @param labelWidth the width allocated for the label
+     *
+     * @param label
+     *            the label text (only shown on first line)
+     * @param lines
+     *            the wrapped content lines
+     * @param labelWidth
+     *            the width allocated for the label
      */
     public void drawLabeledLines(String label, List<String> lines, int labelWidth) {
         if (lines == null || lines.isEmpty()) {
             drawLabeledLine(label, "", labelWidth);
             return;
         }
-        
+
         // First line with label
         drawLabeledLine(label, lines.get(0), labelWidth);
-        
+
         // Additional lines with empty label space
         for (int i = 1; i < lines.size(); i++) {
             drawLabeledLine("", lines.get(i), labelWidth);
         }
     }
-    
+
     /**
      * Draws an empty line within the box.
      */
     public void drawEmptyLine() {
         drawLine("");
     }
-    
+
     /**
      * Gets the width of the box.
-     * 
+     *
      * @return the box width
      */
     public int getWidth() {
         return width;
     }
-    
+
     /**
      * Gets the available content width (excluding borders and padding).
-     * 
+     *
      * @return the content width
      */
     public int getContentWidth() {

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/display/DisplayConstants.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/display/DisplayConstants.java
@@ -1,23 +1,21 @@
 package com.dataliquid.asciidoc.linter.cli.display;
 
 /**
- * Constants for display formatting in the CLI.
- * Centralizes display-related configuration values.
+ * Constants for display formatting in the CLI. Centralizes display-related configuration values.
  */
 public final class DisplayConstants {
-    
+
     /**
-     * Default width for ASCII boxes used in console output.
-     * Set to 120 characters for better readability on modern terminals.
+     * Default width for ASCII boxes used in console output. Set to 120 characters for better readability on modern
+     * terminals.
      */
     public static final int DEFAULT_BOX_WIDTH = 120;
-    
+
     /**
-     * Default width for labels in configuration display.
-     * Proportionally adjusted for the wider box.
+     * Default width for labels in configuration display. Proportionally adjusted for the wider box.
      */
     public static final int DEFAULT_LABEL_WIDTH = 30;
-    
+
     private DisplayConstants() {
         // Private constructor to prevent instantiation
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/display/SplashScreen.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/display/SplashScreen.java
@@ -8,16 +8,12 @@ import com.dataliquid.asciidoc.linter.cli.VersionInfo;
  * Displays a splash screen for the AsciiDoc Linter CLI.
  */
 public class SplashScreen {
-    
-    private static final String[] ASCII_ART = {
-        "     _    ____   ____ ___ ___ ____             ",
-        "    / \\  / ___| / ___|_ _|_ _|  _ \\  ___   ___ ",
-        "   / _ \\ \\___ \\| |    | | | || | | |/ _ \\ / __|",
-        "  / ___ \\ ___) | |___ | | | || |_| | (_) | (__ ",
-        " /_/   \\_\\____/ \\____|___|___|____/ \\___/ \\___|",
-        "                                                "
-    };
-    
+
+    private static final String[] ASCII_ART = {"     _    ____   ____ ___ ___ ____             ",
+            "    / \\  / ___| / ___|_ _|_ _|  _ \\  ___   ___ ", "   / _ \\ \\___ \\| |    | | | || | | |/ _ \\ / __|",
+            "  / ___ \\ ___) | |___ | | | || |_| | (_) | (__ ", " /_/   \\_\\____/ \\____|___|___|____/ \\___/ \\___|",
+            "                                                "};
+
     /**
      * Displays the splash screen on the console.
      */
@@ -26,16 +22,16 @@ public class SplashScreen {
         for (String line : ASCII_ART) {
             System.out.println(line);
         }
-        
+
         // Version line
         VersionInfo versionInfo = VersionInfo.getInstance();
         String versionLine = String.format("        L I N T E R   v%s", versionInfo.getVersion());
         System.out.println(versionLine);
         System.out.println();
-        
+
         // Description
         System.out.println("  Powerful linter for AsciiDoc documents");
-        
+
         // Copyright
         String copyright = String.format("  © %d dataliquid - Apache License 2.0", Year.now().getValue());
         System.out.println(copyright);

--- a/src/main/java/com/dataliquid/asciidoc/linter/cli/display/TextWrapper.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/cli/display/TextWrapper.java
@@ -4,28 +4,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Utility class for wrapping text to fit within a specified width.
- * Provides different strategies for wrapping based on content type.
+ * Utility class for wrapping text to fit within a specified width. Provides different strategies for wrapping based on
+ * content type.
  */
 public class TextWrapper {
-    
+
     /**
-     * Wraps text to fit within the specified maximum width.
-     * Automatically detects the best wrapping strategy based on content.
-     * 
-     * @param text the text to wrap
-     * @param maxWidth the maximum width for each line
+     * Wraps text to fit within the specified maximum width. Automatically detects the best wrapping strategy based on
+     * content.
+     *
+     * @param text
+     *            the text to wrap
+     * @param maxWidth
+     *            the maximum width for each line
      * @return a list of wrapped lines
      */
     public List<String> wrap(String text, int maxWidth) {
         if (text == null || text.isEmpty()) {
             return List.of("");
         }
-        
+
         if (text.length() <= maxWidth) {
             return List.of(text);
         }
-        
+
         // Choose wrapping strategy based on content
         if (text.contains(",")) {
             return wrapByComma(text, maxWidth);
@@ -35,24 +37,25 @@ public class TextWrapper {
             return wrapByWords(text, maxWidth);
         }
     }
-    
+
     /**
-     * Wraps comma-separated text, breaking at commas when possible.
-     * Useful for lists of items.
-     * 
-     * @param text the comma-separated text to wrap
-     * @param maxWidth the maximum width for each line
+     * Wraps comma-separated text, breaking at commas when possible. Useful for lists of items.
+     *
+     * @param text
+     *            the comma-separated text to wrap
+     * @param maxWidth
+     *            the maximum width for each line
      * @return a list of wrapped lines
      */
     public List<String> wrapByComma(String text, int maxWidth) {
         List<String> lines = new ArrayList<>();
         String[] parts = text.split(",");
         StringBuilder currentLine = new StringBuilder();
-        
+
         for (int i = 0; i < parts.length; i++) {
             String part = parts[i].trim();
             String separator = i < parts.length - 1 ? ", " : "";
-            
+
             if (currentLine.length() == 0) {
                 currentLine.append(part).append(separator);
             } else if (currentLine.length() + part.length() + separator.length() <= maxWidth) {
@@ -62,30 +65,31 @@ public class TextWrapper {
                 currentLine = new StringBuilder(part).append(separator);
             }
         }
-        
+
         if (currentLine.length() > 0) {
             lines.add(currentLine.toString());
         }
-        
+
         return lines.isEmpty() ? List.of(text) : lines;
     }
-    
+
     /**
-     * Wraps file paths, breaking at path separators when possible.
-     * Preserves path structure for readability.
-     * 
-     * @param text the path text to wrap
-     * @param maxWidth the maximum width for each line
+     * Wraps file paths, breaking at path separators when possible. Preserves path structure for readability.
+     *
+     * @param text
+     *            the path text to wrap
+     * @param maxWidth
+     *            the maximum width for each line
      * @return a list of wrapped lines
      */
     public List<String> wrapByPath(String text, int maxWidth) {
         List<String> lines = new ArrayList<>();
         String remaining = text;
-        
+
         while (remaining.length() > maxWidth) {
             // Try to break at path separator
             int lastSeparator = findLastPathSeparator(remaining, maxWidth);
-            
+
             if (lastSeparator > 0 && lastSeparator < maxWidth) {
                 lines.add(remaining.substring(0, lastSeparator + 1));
                 remaining = remaining.substring(lastSeparator + 1);
@@ -95,27 +99,28 @@ public class TextWrapper {
                 remaining = remaining.substring(maxWidth);
             }
         }
-        
+
         if (!remaining.isEmpty()) {
             lines.add(remaining);
         }
-        
+
         return lines.isEmpty() ? List.of(text) : lines;
     }
-    
+
     /**
-     * Wraps text by words, breaking at spaces when possible.
-     * Standard word wrapping algorithm.
-     * 
-     * @param text the text to wrap
-     * @param maxWidth the maximum width for each line
+     * Wraps text by words, breaking at spaces when possible. Standard word wrapping algorithm.
+     *
+     * @param text
+     *            the text to wrap
+     * @param maxWidth
+     *            the maximum width for each line
      * @return a list of wrapped lines
      */
     public List<String> wrapByWords(String text, int maxWidth) {
         List<String> lines = new ArrayList<>();
         String[] words = text.split("\\s+");
         StringBuilder currentLine = new StringBuilder();
-        
+
         for (String word : words) {
             if (currentLine.length() == 0) {
                 currentLine.append(word);
@@ -126,19 +131,21 @@ public class TextWrapper {
                 currentLine = new StringBuilder(word);
             }
         }
-        
+
         if (currentLine.length() > 0) {
             lines.add(currentLine.toString());
         }
-        
+
         return lines.isEmpty() ? List.of(text) : lines;
     }
-    
+
     /**
      * Finds the last path separator (/ or \) within the specified limit.
-     * 
-     * @param text the text to search
-     * @param limit the maximum index to search up to
+     *
+     * @param text
+     *            the text to search
+     * @param limit
+     *            the maximum index to search up to
      * @return the index of the last path separator, or -1 if not found
      */
     private int findLastPathSeparator(String text, int limit) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/LinterConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/LinterConfiguration.java
@@ -19,7 +19,9 @@ public final class LinterConfiguration {
     }
 
     @JsonProperty(DOCUMENT)
-    public DocumentConfiguration document() { return document; }
+    public DocumentConfiguration document() {
+        return document;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -43,8 +45,10 @@ public final class LinterConfiguration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         LinterConfiguration that = (LinterConfiguration) o;
         return Objects.equals(document, that.document);
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AbstractBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AbstractBlock.java
@@ -17,69 +17,80 @@ public abstract class AbstractBlock implements Block {
     private final Severity severity;
     private final OccurrenceConfig occurrence;
     private final Integer order;
-    
+
     protected AbstractBlock(AbstractBuilder<?> builder) {
         this.name = builder.name;
         this.severity = builder.severity;
         this.occurrence = builder.occurrence;
         this.order = builder.order;
     }
-    
+
     public abstract BlockType getType();
-    
-    public String getName() { return name; }
-    public Severity getSeverity() { return severity; }
-    public OccurrenceConfig getOccurrence() { return occurrence; }
-    public Integer getOrder() { return order; }
-    
+
+    public String getName() {
+        return name;
+    }
+
+    public Severity getSeverity() {
+        return severity;
+    }
+
+    public OccurrenceConfig getOccurrence() {
+        return occurrence;
+    }
+
+    public Integer getOrder() {
+        return order;
+    }
+
     protected abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
         protected String name;
         protected Severity severity;
         protected OccurrenceConfig occurrence;
         protected Integer order;
-        
+
         @JsonProperty(NAME)
         @SuppressWarnings("unchecked")
         public T name(String name) {
             this.name = name;
             return (T) this;
         }
-        
+
         @JsonProperty(SEVERITY)
         @SuppressWarnings("unchecked")
         public T severity(Severity severity) {
             this.severity = severity;
             return (T) this;
         }
-        
+
         @JsonProperty(OCCURRENCE)
         @SuppressWarnings("unchecked")
         public T occurrence(OccurrenceConfig occurrence) {
             this.occurrence = occurrence;
             return (T) this;
         }
-        
+
         @JsonProperty(ORDER)
         @SuppressWarnings("unchecked")
         public T order(Integer order) {
             this.order = order;
             return (T) this;
         }
-        
+
         public abstract AbstractBlock build();
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         AbstractBlock that = (AbstractBlock) o;
-        return Objects.equals(name, that.name) &&
-               severity == that.severity &&
-               Objects.equals(occurrence, that.occurrence) &&
-               Objects.equals(order, that.order);
+        return Objects.equals(name, that.name) && severity == that.severity
+                && Objects.equals(occurrence, that.occurrence) && Objects.equals(order, that.order);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(name, severity, occurrence, order);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlock.java
@@ -36,7 +36,7 @@ public final class AdmonitionBlock extends AbstractBlock {
     private final ContentConfig content;
     @JsonProperty(ICON)
     private final IconConfig icon;
-    
+
     private AdmonitionBlock(Builder builder) {
         super(builder);
         this.type = builder.type;
@@ -44,32 +44,32 @@ public final class AdmonitionBlock extends AbstractBlock {
         this.content = builder.content;
         this.icon = builder.icon;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.ADMONITION;
     }
-    
+
     public TypeConfig getTypeConfig() {
         return type;
     }
-    
+
     public TitleConfig getTitle() {
         return title;
     }
-    
+
     public ContentConfig getContent() {
         return content;
     }
-    
+
     public IconConfig getIcon() {
         return icon;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = TypeConfig.TypeConfigBuilder.class)
     public static class TypeConfig {
         @JsonProperty(REQUIRED)
@@ -78,72 +78,72 @@ public final class AdmonitionBlock extends AbstractBlock {
         private final List<String> allowed;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TypeConfig(TypeConfigBuilder builder) {
             this.required = builder.required;
-            this.allowed = builder.allowed != null ? 
-                Collections.unmodifiableList(new ArrayList<>(builder.allowed)) : 
-                Collections.emptyList();
+            this.allowed = builder.allowed != null
+                    ? Collections.unmodifiableList(new ArrayList<>(builder.allowed))
+                    : Collections.emptyList();
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public List<String> getAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TypeConfigBuilder builder() {
             return new TypeConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TypeConfigBuilder {
             private boolean required;
             private List<String> allowed;
             private Severity severity;
-            
+
             public TypeConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TypeConfigBuilder allowed(List<String> allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public TypeConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TypeConfig build() {
                 return new TypeConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TypeConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(allowed, that.allowed) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TypeConfig that))
+                return false;
+            return required == that.required && Objects.equals(allowed, that.allowed) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, allowed, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
         @JsonProperty(REQUIRED)
@@ -156,7 +156,7 @@ public final class AdmonitionBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TitleConfig(TitleConfigBuilder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
@@ -164,31 +164,31 @@ public final class AdmonitionBlock extends AbstractBlock {
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TitleConfigBuilder builder() {
             return new TitleConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
@@ -196,61 +196,61 @@ public final class AdmonitionBlock extends AbstractBlock {
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             public TitleConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TitleConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public TitleConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public TitleConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TitleConfig build() {
                 return new TitleConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TitleConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TitleConfig that))
+                return false;
+            return required == that.required
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern())
+                    && Objects.equals(minLength, that.minLength) && Objects.equals(maxLength, that.maxLength)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, pattern == null ? null : pattern.pattern(), 
-                               minLength, maxLength, severity);
+            return Objects.hash(required, pattern == null ? null : pattern.pattern(), minLength, maxLength, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
         @JsonProperty(REQUIRED)
@@ -263,7 +263,7 @@ public final class AdmonitionBlock extends AbstractBlock {
         private final LineConfig lines;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private ContentConfig(ContentConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
@@ -271,31 +271,31 @@ public final class AdmonitionBlock extends AbstractBlock {
             this.lines = builder.lines;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public LineConfig getLines() {
             return lines;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static ContentConfigBuilder builder() {
             return new ContentConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private boolean required;
@@ -303,54 +303,54 @@ public final class AdmonitionBlock extends AbstractBlock {
             private Integer maxLength;
             private LineConfig lines;
             private Severity severity;
-            
+
             public ContentConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public ContentConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder lines(LineConfig lines) {
                 this.lines = lines;
                 return this;
             }
-            
+
             public ContentConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public ContentConfig build() {
                 return new ContentConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ContentConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(lines, that.lines) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof ContentConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && Objects.equals(lines, that.lines)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength, lines, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = IconConfig.IconConfigBuilder.class)
     public static class IconConfig {
         @JsonProperty(REQUIRED)
@@ -359,121 +359,122 @@ public final class AdmonitionBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private IconConfig(IconConfigBuilder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static IconConfigBuilder builder() {
             return new IconConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class IconConfigBuilder {
             private boolean required;
             private Pattern pattern;
             private Severity severity;
-            
+
             public IconConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public IconConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public IconConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public IconConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public IconConfig build() {
                 return new IconConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof IconConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof IconConfig that))
+                return false;
+            return required == that.required && Objects.equals(pattern == null ? null : pattern.pattern(),
+                    that.pattern == null ? null : that.pattern.pattern()) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, pattern == null ? null : pattern.pattern(), severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TypeConfig type;
         private TitleConfig title;
         private ContentConfig content;
         private IconConfig icon;
-        
+
         public Builder type(TypeConfig type) {
             this.type = type;
             return this;
         }
-        
+
         public Builder title(TitleConfig title) {
             this.title = title;
             return this;
         }
-        
+
         public Builder content(ContentConfig content) {
             this.content = content;
             return this;
         }
-        
+
         public Builder icon(IconConfig icon) {
             this.icon = icon;
             return this;
         }
-        
+
         @Override
         public AdmonitionBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new AdmonitionBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof AdmonitionBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(type, that.type) &&
-               Objects.equals(title, that.title) &&
-               Objects.equals(content, that.content) &&
-               Objects.equals(icon, that.icon);
+        if (this == o)
+            return true;
+        if (!(o instanceof AdmonitionBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(type, that.type) && Objects.equals(title, that.title)
+                && Objects.equals(content, that.content) && Objects.equals(icon, that.icon);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), type, title, content, icon);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlock.java
@@ -31,35 +31,35 @@ public final class AudioBlock extends AbstractBlock {
     private final OptionsConfig options;
     @JsonProperty(TITLE)
     private final TitleConfig title;
-    
+
     private AudioBlock(Builder builder) {
         super(builder);
         this.url = builder.url;
         this.options = builder.options;
         this.title = builder.title;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.AUDIO;
     }
-    
+
     public UrlConfig getUrl() {
         return url;
     }
-    
+
     public OptionsConfig getOptions() {
         return options;
     }
-    
+
     public TitleConfig getTitle() {
         return title;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = UrlConfig.UrlConfigBuilder.class)
     public static class UrlConfig {
         @JsonProperty(REQUIRED)
@@ -68,76 +68,78 @@ public final class AudioBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private UrlConfig(UrlConfigBuilder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static UrlConfigBuilder builder() {
             return new UrlConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class UrlConfigBuilder {
             private boolean required;
             private Pattern pattern;
             private Severity severity;
-            
+
             public UrlConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public UrlConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public UrlConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public UrlConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public UrlConfig build() {
                 return new UrlConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof UrlConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   Objects.equals(severity, that.severity);
+            if (this == o)
+                return true;
+            if (!(o instanceof UrlConfig that))
+                return false;
+            return required == that.required
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern())
+                    && Objects.equals(severity, that.severity);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, pattern == null ? null : pattern.pattern(), severity);
         }
     }
-    
+
     @JsonDeserialize(builder = OptionsConfig.OptionsConfigBuilder.class)
     public static class OptionsConfig {
         @JsonProperty(AUTOPLAY)
@@ -146,244 +148,248 @@ public final class AudioBlock extends AbstractBlock {
         private final ControlsConfig controls;
         @JsonProperty(LOOP)
         private final LoopConfig loop;
-        
+
         private OptionsConfig(OptionsConfigBuilder builder) {
             this.autoplay = builder.autoplay;
             this.controls = builder.controls;
             this.loop = builder.loop;
         }
-        
+
         public AutoplayConfig getAutoplay() {
             return autoplay;
         }
-        
+
         public ControlsConfig getControls() {
             return controls;
         }
-        
+
         public LoopConfig getLoop() {
             return loop;
         }
-        
+
         public static OptionsConfigBuilder builder() {
             return new OptionsConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class OptionsConfigBuilder {
             private AutoplayConfig autoplay;
             private ControlsConfig controls;
             private LoopConfig loop;
-            
+
             public OptionsConfigBuilder autoplay(AutoplayConfig autoplay) {
                 this.autoplay = autoplay;
                 return this;
             }
-            
+
             public OptionsConfigBuilder controls(ControlsConfig controls) {
                 this.controls = controls;
                 return this;
             }
-            
+
             public OptionsConfigBuilder loop(LoopConfig loop) {
                 this.loop = loop;
                 return this;
             }
-            
+
             public OptionsConfig build() {
                 return new OptionsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof OptionsConfig that)) return false;
-            return Objects.equals(autoplay, that.autoplay) &&
-                   Objects.equals(controls, that.controls) &&
-                   Objects.equals(loop, that.loop);
+            if (this == o)
+                return true;
+            if (!(o instanceof OptionsConfig that))
+                return false;
+            return Objects.equals(autoplay, that.autoplay) && Objects.equals(controls, that.controls)
+                    && Objects.equals(loop, that.loop);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(autoplay, controls, loop);
         }
     }
-    
+
     @JsonDeserialize(builder = AutoplayConfig.AutoplayConfigBuilder.class)
     public static class AutoplayConfig {
         @JsonProperty(ALLOWED)
         private final boolean allowed;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private AutoplayConfig(AutoplayConfigBuilder builder) {
             this.allowed = builder.allowed;
             this.severity = builder.severity;
         }
-        
+
         public boolean isAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static AutoplayConfigBuilder builder() {
             return new AutoplayConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AutoplayConfigBuilder {
             private boolean allowed;
             private Severity severity;
-            
+
             public AutoplayConfigBuilder allowed(boolean allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public AutoplayConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public AutoplayConfig build() {
                 return new AutoplayConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof AutoplayConfig that)) return false;
-            return allowed == that.allowed &&
-                   Objects.equals(severity, that.severity);
+            if (this == o)
+                return true;
+            if (!(o instanceof AutoplayConfig that))
+                return false;
+            return allowed == that.allowed && Objects.equals(severity, that.severity);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(allowed, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = ControlsConfig.ControlsConfigBuilder.class)
     public static class ControlsConfig {
         @JsonProperty(REQUIRED)
         private final boolean required;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private ControlsConfig(ControlsConfigBuilder builder) {
             this.required = builder.required;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static ControlsConfigBuilder builder() {
             return new ControlsConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ControlsConfigBuilder {
             private boolean required;
             private Severity severity;
-            
+
             public ControlsConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public ControlsConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public ControlsConfig build() {
                 return new ControlsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ControlsConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(severity, that.severity);
+            if (this == o)
+                return true;
+            if (!(o instanceof ControlsConfig that))
+                return false;
+            return required == that.required && Objects.equals(severity, that.severity);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = LoopConfig.LoopConfigBuilder.class)
     public static class LoopConfig {
         @JsonProperty(ALLOWED)
         private final boolean allowed;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private LoopConfig(LoopConfigBuilder builder) {
             this.allowed = builder.allowed;
             this.severity = builder.severity;
         }
-        
+
         public boolean isAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static LoopConfigBuilder builder() {
             return new LoopConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LoopConfigBuilder {
             private boolean allowed;
             private Severity severity;
-            
+
             public LoopConfigBuilder allowed(boolean allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public LoopConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public LoopConfig build() {
                 return new LoopConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof LoopConfig that)) return false;
-            return allowed == that.allowed &&
-                   Objects.equals(severity, that.severity);
+            if (this == o)
+                return true;
+            if (!(o instanceof LoopConfig that))
+                return false;
+            return allowed == that.allowed && Objects.equals(severity, that.severity);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(allowed, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
         @JsonProperty(REQUIRED)
@@ -394,120 +400,122 @@ public final class AudioBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TitleConfig(TitleConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TitleConfigBuilder builder() {
             return new TitleConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             public TitleConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TitleConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TitleConfig build() {
                 return new TitleConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TitleConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(severity, that.severity);
+            if (this == o)
+                return true;
+            if (!(o instanceof TitleConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && Objects.equals(severity, that.severity);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private UrlConfig url;
         private OptionsConfig options;
         private TitleConfig title;
-        
+
         public Builder url(UrlConfig url) {
             this.url = url;
             return this;
         }
-        
+
         public Builder options(OptionsConfig options) {
             this.options = options;
             return this;
         }
-        
+
         public Builder title(TitleConfig title) {
             this.title = title;
             return this;
         }
-        
+
         @Override
         public AudioBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new AudioBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof AudioBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(url, that.url) &&
-               Objects.equals(options, that.options) &&
-               Objects.equals(title, that.title);
+        if (this == o)
+            return true;
+        if (!(o instanceof AudioBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(url, that.url) && Objects.equals(options, that.options)
+                && Objects.equals(title, that.title);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), url, options, title);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/Block.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/Block.java
@@ -14,16 +14,16 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Com
 public interface Block {
     @JsonProperty(TYPE)
     BlockType getType();
-    
+
     @JsonProperty(NAME)
     String getName();
-    
+
     @JsonProperty(SEVERITY)
     Severity getSeverity();
-    
+
     @JsonProperty(OCCURRENCE)
     OccurrenceConfig getOccurrence();
-    
+
     @JsonProperty(ORDER)
     Integer getOrder();
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/BlockType.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/BlockType.java
@@ -4,30 +4,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum BlockType {
-    PARAGRAPH,
-    LISTING,
-    TABLE,
-    IMAGE,
-    VERSE,
-    ADMONITION,
-    PASS,
-    LITERAL,
-    AUDIO,
-    QUOTE,
-    SIDEBAR,
-    EXAMPLE,
-    VIDEO,
-    ULIST,
-    DLIST;
-    
+    PARAGRAPH, LISTING, TABLE, IMAGE, VERSE, ADMONITION, PASS, LITERAL, AUDIO, QUOTE, SIDEBAR, EXAMPLE, VIDEO, ULIST, DLIST;
+
     @JsonValue
     public String toValue() {
         return name().toLowerCase();
     }
-    
+
     @JsonCreator
     public static BlockType fromValue(String value) {
-        if (value == null) return null;
+        if (value == null)
+            return null;
         return switch (value.toLowerCase()) {
             case "paragraph" -> PARAGRAPH;
             case "listing" -> LISTING;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlock.java
@@ -24,8 +24,8 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMP
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Configuration for definition list (dlist) blocks in AsciiDoc.
- * Represents lists with term-description pairs using :: delimiters.
+ * Configuration for definition list (dlist) blocks in AsciiDoc. Represents lists with term-description pairs using ::
+ * delimiters.
  */
 @JsonDeserialize(builder = DlistBlock.Builder.class)
 public final class DlistBlock extends AbstractBlock {
@@ -37,7 +37,7 @@ public final class DlistBlock extends AbstractBlock {
     private final NestingLevelConfig nestingLevel;
     @JsonProperty(DELIMITER_STYLE)
     private final DelimiterStyleConfig delimiterStyle;
-    
+
     private DlistBlock(Builder builder) {
         super(builder);
         this.terms = builder.terms;
@@ -45,32 +45,32 @@ public final class DlistBlock extends AbstractBlock {
         this.nestingLevel = builder.nestingLevel;
         this.delimiterStyle = builder.delimiterStyle;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.DLIST;
     }
-    
+
     public TermsConfig getTerms() {
         return terms;
     }
-    
+
     public DescriptionsConfig getDescriptions() {
         return descriptions;
     }
-    
+
     public NestingLevelConfig getNestingLevel() {
         return nestingLevel;
     }
-    
+
     public DelimiterStyleConfig getDelimiterStyle() {
         return delimiterStyle;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     /**
      * Configuration for term validation.
      */
@@ -88,7 +88,7 @@ public final class DlistBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TermsConfig(TermsConfigBuilder builder) {
             this.min = builder.min;
             this.max = builder.max;
@@ -97,35 +97,35 @@ public final class DlistBlock extends AbstractBlock {
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMin() {
             return min;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public String getPattern() {
             return pattern;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TermsConfigBuilder builder() {
             return new TermsConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TermsConfigBuilder {
             private Integer min;
@@ -134,60 +134,59 @@ public final class DlistBlock extends AbstractBlock {
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             public TermsConfigBuilder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             public TermsConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public TermsConfigBuilder pattern(String pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public TermsConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public TermsConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public TermsConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TermsConfig build() {
                 return new TermsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TermsConfig that)) return false;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   Objects.equals(pattern, that.pattern) &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TermsConfig that))
+                return false;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max)
+                    && Objects.equals(pattern, that.pattern) && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, pattern, minLength, maxLength, severity);
         }
     }
-    
+
     /**
      * Configuration for description validation.
      */
@@ -203,7 +202,7 @@ public final class DlistBlock extends AbstractBlock {
         private final String pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private DescriptionsConfig(DescriptionsConfigBuilder builder) {
             this.required = builder.required;
             this.min = builder.min;
@@ -211,31 +210,31 @@ public final class DlistBlock extends AbstractBlock {
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public Boolean getRequired() {
             return required;
         }
-        
+
         public Integer getMin() {
             return min;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public String getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static DescriptionsConfigBuilder builder() {
             return new DescriptionsConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DescriptionsConfigBuilder {
             private Boolean required;
@@ -243,54 +242,54 @@ public final class DlistBlock extends AbstractBlock {
             private Integer max;
             private String pattern;
             private Severity severity;
-            
+
             public DescriptionsConfigBuilder required(Boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public DescriptionsConfigBuilder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             public DescriptionsConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public DescriptionsConfigBuilder pattern(String pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public DescriptionsConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public DescriptionsConfig build() {
                 return new DescriptionsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof DescriptionsConfig that)) return false;
-            return Objects.equals(required, that.required) &&
-                   Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   Objects.equals(pattern, that.pattern) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof DescriptionsConfig that))
+                return false;
+            return Objects.equals(required, that.required) && Objects.equals(min, that.min)
+                    && Objects.equals(max, that.max) && Objects.equals(pattern, that.pattern)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, min, max, pattern, severity);
         }
     }
-    
+
     /**
      * Configuration for nesting level validation.
      */
@@ -300,58 +299,59 @@ public final class DlistBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private NestingLevelConfig(NestingLevelConfigBuilder builder) {
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static NestingLevelConfigBuilder builder() {
             return new NestingLevelConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class NestingLevelConfigBuilder {
             private Integer max;
             private Severity severity;
-            
+
             public NestingLevelConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public NestingLevelConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public NestingLevelConfig build() {
                 return new NestingLevelConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof NestingLevelConfig that)) return false;
-            return Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof NestingLevelConfig that))
+                return false;
+            return Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(max, severity);
         }
     }
-    
+
     /**
      * Configuration for delimiter style validation.
      */
@@ -363,64 +363,65 @@ public final class DlistBlock extends AbstractBlock {
         private final Boolean consistent;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private DelimiterStyleConfig(DelimiterStyleConfigBuilder builder) {
             this.allowedDelimiters = builder.allowedDelimiters;
             this.consistent = builder.consistent;
             this.severity = builder.severity;
         }
-        
+
         public String[] getAllowedDelimiters() {
             return allowedDelimiters;
         }
-        
+
         public Boolean getConsistent() {
             return consistent;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static DelimiterStyleConfigBuilder builder() {
             return new DelimiterStyleConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DelimiterStyleConfigBuilder {
             private String[] allowedDelimiters;
             private Boolean consistent;
             private Severity severity;
-            
+
             public DelimiterStyleConfigBuilder allowedDelimiters(String[] allowedDelimiters) {
                 this.allowedDelimiters = allowedDelimiters;
                 return this;
             }
-            
+
             public DelimiterStyleConfigBuilder consistent(Boolean consistent) {
                 this.consistent = consistent;
                 return this;
             }
-            
+
             public DelimiterStyleConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public DelimiterStyleConfig build() {
                 return new DelimiterStyleConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof DelimiterStyleConfig that)) return false;
-            return java.util.Arrays.equals(allowedDelimiters, that.allowedDelimiters) &&
-                   Objects.equals(consistent, that.consistent) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof DelimiterStyleConfig that))
+                return false;
+            return java.util.Arrays.equals(allowedDelimiters, that.allowedDelimiters)
+                    && Objects.equals(consistent, that.consistent) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             int result = Objects.hash(consistent, severity);
@@ -428,52 +429,54 @@ public final class DlistBlock extends AbstractBlock {
             return result;
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TermsConfig terms;
         private DescriptionsConfig descriptions;
         private NestingLevelConfig nestingLevel;
         private DelimiterStyleConfig delimiterStyle;
-        
+
         public Builder terms(TermsConfig terms) {
             this.terms = terms;
             return this;
         }
-        
+
         public Builder descriptions(DescriptionsConfig descriptions) {
             this.descriptions = descriptions;
             return this;
         }
-        
+
         public Builder nestingLevel(NestingLevelConfig nestingLevel) {
             this.nestingLevel = nestingLevel;
             return this;
         }
-        
+
         public Builder delimiterStyle(DelimiterStyleConfig delimiterStyle) {
             this.delimiterStyle = delimiterStyle;
             return this;
         }
-        
+
         @Override
         public DlistBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new DlistBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DlistBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(terms, that.terms) &&
-               Objects.equals(descriptions, that.descriptions) &&
-               Objects.equals(nestingLevel, that.nestingLevel) &&
-               Objects.equals(delimiterStyle, that.delimiterStyle);
+        if (this == o)
+            return true;
+        if (!(o instanceof DlistBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(terms, that.terms) && Objects.equals(descriptions, that.descriptions)
+                && Objects.equals(nestingLevel, that.nestingLevel)
+                && Objects.equals(delimiterStyle, that.delimiterStyle);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), terms, descriptions, nestingLevel, delimiterStyle);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlock.java
@@ -22,91 +22,87 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * Configuration for EXAMPLE blocks.
- * 
- * Validates example blocks with optional numbering and caption format.
- * Based on the YAML schema definition for the linter.
+ *
+ * Validates example blocks with optional numbering and caption format. Based on the YAML schema definition for the
+ * linter.
  */
 @JsonDeserialize(builder = ExampleBlock.Builder.class)
 public class ExampleBlock extends AbstractBlock {
-    
+
     private final CaptionConfig caption;
     private final CollapsibleConfig collapsible;
-    
+
     private ExampleBlock(Builder builder) {
         super(builder);
         this.caption = builder.caption;
         this.collapsible = builder.collapsible;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.EXAMPLE;
     }
-    
+
     public CaptionConfig getCaption() {
         return caption;
     }
-    
+
     public CollapsibleConfig getCollapsible() {
         return collapsible;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
         ExampleBlock that = (ExampleBlock) o;
-        return Objects.equals(caption, that.caption) &&
-               Objects.equals(collapsible, that.collapsible);
+        return Objects.equals(caption, that.caption) && Objects.equals(collapsible, that.collapsible);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), caption, collapsible);
     }
-    
+
     @Override
     public String toString() {
-        return "ExampleBlock{" +
-                "name='" + getName() + '\'' +
-                ", severity=" + getSeverity() +
-                ", occurrence=" + getOccurrence() +
-                ", caption=" + caption +
-                ", collapsible=" + collapsible +
-                '}';
+        return "ExampleBlock{" + "name='" + getName() + '\'' + ", severity=" + getSeverity() + ", occurrence="
+                + getOccurrence() + ", caption=" + caption + ", collapsible=" + collapsible + '}';
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBlock.AbstractBuilder<Builder> {
         private CaptionConfig caption;
         private CollapsibleConfig collapsible;
-        
+
         @JsonProperty(CAPTION)
         public Builder caption(CaptionConfig caption) {
             this.caption = caption;
             return this;
         }
-        
+
         @JsonProperty(COLLAPSIBLE)
         public Builder collapsible(CollapsibleConfig collapsible) {
             this.collapsible = collapsible;
             return this;
         }
-        
+
         @Override
         public ExampleBlock build() {
             return new ExampleBlock(this);
         }
     }
-    
+
     /**
-     * Configuration for the caption of an example block.
-     * Based on the YAML schema requiring specific format.
+     * Configuration for the caption of an example block. Based on the YAML schema requiring specific format.
      */
     @JsonDeserialize(builder = CaptionConfig.Builder.class)
     public static class CaptionConfig {
@@ -115,7 +111,7 @@ public class ExampleBlock extends AbstractBlock {
         private final Integer minLength;
         private final Integer maxLength;
         private final Severity severity;
-        
+
         private CaptionConfig(Builder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
@@ -123,62 +119,57 @@ public class ExampleBlock extends AbstractBlock {
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             CaptionConfig that = (CaptionConfig) o;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(), 
-                                that.pattern == null ? null : that.pattern.pattern()) &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   severity == that.severity;
+            return required == that.required
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern())
+                    && Objects.equals(minLength, that.minLength) && Objects.equals(maxLength, that.maxLength)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, 
-                              pattern == null ? null : pattern.pattern(), 
-                              minLength, maxLength, severity);
+            return Objects.hash(required, pattern == null ? null : pattern.pattern(), minLength, maxLength, severity);
         }
-        
+
         @Override
         public String toString() {
-            return "CaptionConfig{" +
-                    "required=" + required +
-                    ", pattern=" + (pattern == null ? null : pattern.pattern()) +
-                    ", minLength=" + minLength +
-                    ", maxLength=" + maxLength +
-                    ", severity=" + severity +
-                    '}';
+            return "CaptionConfig{" + "required=" + required + ", pattern="
+                    + (pattern == null ? null : pattern.pattern()) + ", minLength=" + minLength + ", maxLength="
+                    + maxLength + ", severity=" + severity + '}';
         }
-        
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
@@ -186,123 +177,120 @@ public class ExampleBlock extends AbstractBlock {
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             @JsonProperty(PATTERN)
             public Builder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public CaptionConfig build() {
                 return new CaptionConfig(this);
             }
         }
     }
-    
+
     /**
-     * Configuration for the collapsible attribute of an example block.
-     * Based on the YAML schema allowing true/false values.
+     * Configuration for the collapsible attribute of an example block. Based on the YAML schema allowing true/false
+     * values.
      */
     @JsonDeserialize(builder = CollapsibleConfig.Builder.class)
     public static class CollapsibleConfig {
         private final boolean required;
         private final List<Boolean> allowed;
         private final Severity severity;
-        
+
         private CollapsibleConfig(Builder builder) {
             this.required = builder.required;
             this.allowed = builder.allowed;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public List<Boolean> getAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             CollapsibleConfig that = (CollapsibleConfig) o;
-            return required == that.required &&
-                   Objects.equals(allowed, that.allowed) &&
-                   severity == that.severity;
+            return required == that.required && Objects.equals(allowed, that.allowed) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, allowed, severity);
         }
-        
+
         @Override
         public String toString() {
-            return "CollapsibleConfig{" +
-                    "required=" + required +
-                    ", allowed=" + allowed +
-                    ", severity=" + severity +
-                    '}';
+            return "CollapsibleConfig{" + "required=" + required + ", allowed=" + allowed + ", severity=" + severity
+                    + '}';
         }
-        
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private List<Boolean> allowed;
             private Severity severity;
-            
+
             @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             @JsonProperty(ALLOWED)
             public Builder allowed(List<Boolean> allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public CollapsibleConfig build() {
                 return new CollapsibleConfig(this);
             }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlock.java
@@ -30,7 +30,7 @@ public final class ImageBlock extends AbstractBlock {
     private final DimensionConfig width;
     @JsonProperty(ALT)
     private final AltTextConfig alt;
-    
+
     private ImageBlock(Builder builder) {
         super(builder);
         this.url = builder.url;
@@ -38,96 +38,97 @@ public final class ImageBlock extends AbstractBlock {
         this.width = builder.width;
         this.alt = builder.alt;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.IMAGE;
     }
-    
+
     public UrlConfig getUrl() {
         return url;
     }
-    
+
     public DimensionConfig getHeight() {
         return height;
     }
-    
+
     public DimensionConfig getWidth() {
         return width;
     }
-    
+
     public AltTextConfig getAlt() {
         return alt;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = UrlConfig.UrlConfigBuilder.class)
     public static class UrlConfig {
         @JsonProperty(PATTERN)
         private final Pattern pattern;
         @JsonProperty(REQUIRED)
         private final boolean required;
-        
+
         private UrlConfig(UrlConfigBuilder builder) {
             this.pattern = builder.pattern;
             this.required = builder.required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public static UrlConfigBuilder builder() {
             return new UrlConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class UrlConfigBuilder {
             private Pattern pattern;
             private boolean required;
-            
+
             public UrlConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public UrlConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public UrlConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public UrlConfig build() {
                 return new UrlConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof UrlConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern());
+            if (this == o)
+                return true;
+            if (!(o instanceof UrlConfig that))
+                return false;
+            return required == that.required && Objects.equals(pattern == null ? null : pattern.pattern(),
+                    that.pattern == null ? null : that.pattern.pattern());
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(pattern == null ? null : pattern.pattern(), required);
         }
     }
-    
+
     @JsonDeserialize(builder = DimensionConfig.DimensionConfigBuilder.class)
     public static class DimensionConfig {
         @JsonProperty(MIN_VALUE)
@@ -136,70 +137,71 @@ public final class ImageBlock extends AbstractBlock {
         private final Integer maxValue;
         @JsonProperty(REQUIRED)
         private final boolean required;
-        
+
         private DimensionConfig(DimensionConfigBuilder builder) {
             this.minValue = builder.minValue;
             this.maxValue = builder.maxValue;
             this.required = builder.required;
         }
-        
+
         public Integer getMinValue() {
             return minValue;
         }
-        
+
         public Integer getMaxValue() {
             return maxValue;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public static DimensionConfigBuilder builder() {
             return new DimensionConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DimensionConfigBuilder {
             private Integer minValue;
             private Integer maxValue;
             private boolean required;
-            
+
             public DimensionConfigBuilder minValue(Integer minValue) {
                 this.minValue = minValue;
                 return this;
             }
-            
+
             public DimensionConfigBuilder maxValue(Integer maxValue) {
                 this.maxValue = maxValue;
                 return this;
             }
-            
+
             public DimensionConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public DimensionConfig build() {
                 return new DimensionConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof DimensionConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minValue, that.minValue) &&
-                   Objects.equals(maxValue, that.maxValue);
+            if (this == o)
+                return true;
+            if (!(o instanceof DimensionConfig that))
+                return false;
+            return required == that.required && Objects.equals(minValue, that.minValue)
+                    && Objects.equals(maxValue, that.maxValue);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(minValue, maxValue, required);
         }
     }
-    
+
     @JsonDeserialize(builder = AltTextConfig.AltTextConfigBuilder.class)
     public static class AltTextConfig {
         @JsonProperty(REQUIRED)
@@ -208,115 +210,117 @@ public final class ImageBlock extends AbstractBlock {
         private final Integer minLength;
         @JsonProperty(MAX_LENGTH)
         private final Integer maxLength;
-        
+
         private AltTextConfig(AltTextConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public static AltTextConfigBuilder builder() {
             return new AltTextConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AltTextConfigBuilder {
             private boolean required;
             private Integer minLength;
             private Integer maxLength;
-            
+
             public AltTextConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public AltTextConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public AltTextConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public AltTextConfig build() {
                 return new AltTextConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof AltTextConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength);
+            if (this == o)
+                return true;
+            if (!(o instanceof AltTextConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private UrlConfig url;
         private DimensionConfig height;
         private DimensionConfig width;
         private AltTextConfig alt;
-        
+
         public Builder url(UrlConfig url) {
             this.url = url;
             return this;
         }
-        
+
         public Builder height(DimensionConfig height) {
             this.height = height;
             return this;
         }
-        
+
         public Builder width(DimensionConfig width) {
             this.width = width;
             return this;
         }
-        
+
         public Builder alt(AltTextConfig alt) {
             this.alt = alt;
             return this;
         }
-        
+
         @Override
         public ImageBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new ImageBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ImageBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(url, that.url) &&
-               Objects.equals(height, that.height) &&
-               Objects.equals(width, that.width) &&
-               Objects.equals(alt, that.alt);
+        if (this == o)
+            return true;
+        if (!(o instanceof ImageBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(url, that.url) && Objects.equals(height, that.height) && Objects.equals(width, that.width)
+                && Objects.equals(alt, that.alt);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), url, height, width, alt);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlock.java
@@ -34,7 +34,7 @@ public final class ListingBlock extends AbstractBlock {
     private final TitleConfig title;
     @JsonProperty(CALLOUTS)
     private final CalloutsConfig callouts;
-    
+
     private ListingBlock(Builder builder) {
         super(builder);
         this.language = builder.language;
@@ -42,32 +42,32 @@ public final class ListingBlock extends AbstractBlock {
         this.title = builder.title;
         this.callouts = builder.callouts;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.LISTING;
     }
-    
+
     public LanguageConfig getLanguage() {
         return language;
     }
-    
+
     public LineConfig getLines() {
         return lines;
     }
-    
+
     public TitleConfig getTitle() {
         return title;
     }
-    
+
     public CalloutsConfig getCallouts() {
         return callouts;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = LanguageConfig.LanguageConfigBuilder.class)
     public static class LanguageConfig {
         @JsonProperty(REQUIRED)
@@ -76,72 +76,72 @@ public final class ListingBlock extends AbstractBlock {
         private final List<String> allowed;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private LanguageConfig(LanguageConfigBuilder builder) {
             this.required = builder.required;
-            this.allowed = builder.allowed != null ? 
-                Collections.unmodifiableList(new ArrayList<>(builder.allowed)) : 
-                Collections.emptyList();
+            this.allowed = builder.allowed != null
+                    ? Collections.unmodifiableList(new ArrayList<>(builder.allowed))
+                    : Collections.emptyList();
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public List<String> getAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static LanguageConfigBuilder builder() {
             return new LanguageConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LanguageConfigBuilder {
             private boolean required;
             private List<String> allowed;
             private Severity severity;
-            
+
             public LanguageConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public LanguageConfigBuilder allowed(List<String> allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public LanguageConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public LanguageConfig build() {
                 return new LanguageConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof LanguageConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(allowed, that.allowed) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof LanguageConfig that))
+                return false;
+            return required == that.required && Objects.equals(allowed, that.allowed) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, allowed, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
         @JsonProperty(REQUIRED)
@@ -150,76 +150,76 @@ public final class ListingBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TitleConfig(TitleConfigBuilder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TitleConfigBuilder builder() {
             return new TitleConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Pattern pattern;
             private Severity severity;
-            
+
             public TitleConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TitleConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public TitleConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public TitleConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TitleConfig build() {
                 return new TitleConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TitleConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TitleConfig that))
+                return false;
+            return required == that.required && Objects.equals(pattern == null ? null : pattern.pattern(),
+                    that.pattern == null ? null : that.pattern.pattern()) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, pattern == null ? null : pattern.pattern(), severity);
         }
     }
-    
+
     @JsonDeserialize(builder = CalloutsConfig.CalloutsConfigBuilder.class)
     public static class CalloutsConfig {
         @JsonProperty(ALLOWED)
@@ -228,115 +228,116 @@ public final class ListingBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private CalloutsConfig(CalloutsConfigBuilder builder) {
             this.allowed = builder.allowed;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public boolean isAllowed() {
             return allowed;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static CalloutsConfigBuilder builder() {
             return new CalloutsConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class CalloutsConfigBuilder {
             private boolean allowed;
             private Integer max;
             private Severity severity;
-            
+
             public CalloutsConfigBuilder allowed(boolean allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public CalloutsConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public CalloutsConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public CalloutsConfig build() {
                 return new CalloutsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof CalloutsConfig that)) return false;
-            return allowed == that.allowed &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof CalloutsConfig that))
+                return false;
+            return allowed == that.allowed && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(allowed, max, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private LanguageConfig language;
         private LineConfig lines;
         private TitleConfig title;
         private CalloutsConfig callouts;
-        
+
         public Builder language(LanguageConfig language) {
             this.language = language;
             return this;
         }
-        
+
         public Builder lines(LineConfig lines) {
             this.lines = lines;
             return this;
         }
-        
+
         public Builder title(TitleConfig title) {
             this.title = title;
             return this;
         }
-        
+
         public Builder callouts(CalloutsConfig callouts) {
             this.callouts = callouts;
             return this;
         }
-        
+
         @Override
         public ListingBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new ListingBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ListingBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(language, that.language) &&
-               Objects.equals(lines, that.lines) &&
-               Objects.equals(title, that.title) &&
-               Objects.equals(callouts, that.callouts);
+        if (this == o)
+            return true;
+        if (!(o instanceof ListingBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(language, that.language) && Objects.equals(lines, that.lines)
+                && Objects.equals(title, that.title) && Objects.equals(callouts, that.callouts);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), language, lines, title, callouts);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlock.java
@@ -23,10 +23,12 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMP
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Configuration for literal blocks in AsciiDoc.
- * Literal blocks are delimited by .... and display preformatted text without syntax highlighting.
- * 
- * <p>Example usage:
+ * Configuration for literal blocks in AsciiDoc. Literal blocks are delimited by .... and display preformatted text
+ * without syntax highlighting.
+ *
+ * <p>
+ * Example usage:
+ *
  * <pre>
  * ....
  * server:
@@ -35,8 +37,9 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  *   timeout: 30s
  * ....
  * </pre>
- * 
- * <p>Validation is based on the YAML schema configuration for literal blocks.
+ *
+ * <p>
+ * Validation is based on the YAML schema configuration for literal blocks.
  */
 @JsonDeserialize(builder = LiteralBlock.Builder.class)
 public final class LiteralBlock extends AbstractBlock {
@@ -46,35 +49,35 @@ public final class LiteralBlock extends AbstractBlock {
     private final LinesConfig lines;
     @JsonProperty(INDENTATION)
     private final IndentationConfig indentation;
-    
+
     private LiteralBlock(Builder builder) {
         super(builder);
         this.title = builder.title;
         this.lines = builder.lines;
         this.indentation = builder.indentation;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.LITERAL;
     }
-    
+
     public TitleConfig getTitle() {
         return title;
     }
-    
+
     public LinesConfig getLines() {
         return lines;
     }
-    
+
     public IndentationConfig getIndentation() {
         return indentation;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
         @JsonProperty(REQUIRED)
@@ -85,82 +88,82 @@ public final class LiteralBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TitleConfig(TitleConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TitleConfigBuilder builder() {
             return new TitleConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             public TitleConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TitleConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TitleConfig build() {
                 return new TitleConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TitleConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TitleConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = LinesConfig.LinesConfigBuilder.class)
     public static class LinesConfig {
         @JsonProperty(MIN)
@@ -169,70 +172,70 @@ public final class LiteralBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private LinesConfig(LinesConfigBuilder builder) {
             this.min = builder.min;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMin() {
             return min;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static LinesConfigBuilder builder() {
             return new LinesConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LinesConfigBuilder {
             private Integer min;
             private Integer max;
             private Severity severity;
-            
+
             public LinesConfigBuilder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             public LinesConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public LinesConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public LinesConfig build() {
                 return new LinesConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof LinesConfig that)) return false;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof LinesConfig that))
+                return false;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = IndentationConfig.IndentationConfigBuilder.class)
     public static class IndentationConfig {
         @JsonProperty(REQUIRED)
@@ -245,7 +248,7 @@ public final class LiteralBlock extends AbstractBlock {
         private final Integer maxSpaces;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private IndentationConfig(IndentationConfigBuilder builder) {
             this.required = builder.required;
             this.consistent = builder.consistent;
@@ -253,31 +256,31 @@ public final class LiteralBlock extends AbstractBlock {
             this.maxSpaces = builder.maxSpaces;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public boolean isConsistent() {
             return consistent;
         }
-        
+
         public Integer getMinSpaces() {
             return minSpaces;
         }
-        
+
         public Integer getMaxSpaces() {
             return maxSpaces;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static IndentationConfigBuilder builder() {
             return new IndentationConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class IndentationConfigBuilder {
             private boolean required;
@@ -285,92 +288,94 @@ public final class LiteralBlock extends AbstractBlock {
             private Integer minSpaces;
             private Integer maxSpaces;
             private Severity severity;
-            
+
             public IndentationConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public IndentationConfigBuilder consistent(boolean consistent) {
                 this.consistent = consistent;
                 return this;
             }
-            
+
             public IndentationConfigBuilder minSpaces(Integer minSpaces) {
                 this.minSpaces = minSpaces;
                 return this;
             }
-            
+
             public IndentationConfigBuilder maxSpaces(Integer maxSpaces) {
                 this.maxSpaces = maxSpaces;
                 return this;
             }
-            
+
             public IndentationConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public IndentationConfig build() {
                 return new IndentationConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof IndentationConfig that)) return false;
-            return required == that.required &&
-                   consistent == that.consistent &&
-                   Objects.equals(minSpaces, that.minSpaces) &&
-                   Objects.equals(maxSpaces, that.maxSpaces) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof IndentationConfig that))
+                return false;
+            return required == that.required && consistent == that.consistent
+                    && Objects.equals(minSpaces, that.minSpaces) && Objects.equals(maxSpaces, that.maxSpaces)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, consistent, minSpaces, maxSpaces, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TitleConfig title;
         private LinesConfig lines;
         private IndentationConfig indentation;
-        
+
         public Builder title(TitleConfig title) {
             this.title = title;
             return this;
         }
-        
+
         public Builder lines(LinesConfig lines) {
             this.lines = lines;
             return this;
         }
-        
+
         public Builder indentation(IndentationConfig indentation) {
             this.indentation = indentation;
             return this;
         }
-        
+
         @Override
         public LiteralBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new LiteralBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LiteralBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(title, that.title) &&
-               Objects.equals(lines, that.lines) &&
-               Objects.equals(indentation, that.indentation);
+        if (this == o)
+            return true;
+        if (!(o instanceof LiteralBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(title, that.title) && Objects.equals(lines, that.lines)
+                && Objects.equals(indentation, that.indentation);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), title, lines, indentation);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ParagraphBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ParagraphBlock.java
@@ -18,65 +18,72 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMP
 public final class ParagraphBlock extends AbstractBlock {
     @JsonProperty(LINES)
     private final LineConfig lines;
-    
+
     @JsonProperty(SENTENCE)
     private final SentenceConfig sentence;
-    
+
     private ParagraphBlock(Builder builder) {
         super(builder);
         this.lines = builder.lines;
         this.sentence = builder.sentence;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.PARAGRAPH;
     }
-    
-    public LineConfig getLines() { return lines; }
-    public SentenceConfig getSentence() { return sentence; }
-    
+
+    public LineConfig getLines() {
+        return lines;
+    }
+
+    public SentenceConfig getSentence() {
+        return sentence;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private LineConfig lines;
         private SentenceConfig sentence;
-        
+
         public Builder lines(LineConfig lines) {
             this.lines = lines;
             return this;
         }
-        
+
         public Builder sentence(SentenceConfig sentence) {
             this.sentence = sentence;
             return this;
         }
-        
+
         @Override
         public ParagraphBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new ParagraphBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
         ParagraphBlock that = (ParagraphBlock) o;
-        return Objects.equals(lines, that.lines) &&
-               Objects.equals(sentence, that.sentence);
+        return Objects.equals(lines, that.lines) && Objects.equals(sentence, that.sentence);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), lines, sentence);
     }
-    
+
     /**
      * Configuration for sentence-level validation in paragraph blocks.
      */
@@ -84,59 +91,65 @@ public final class ParagraphBlock extends AbstractBlock {
     public static final class SentenceConfig {
         @JsonProperty(OCCURRENCE)
         private final OccurrenceConfig occurrence;
-        
+
         @JsonProperty(WORDS)
         private final WordsConfig words;
-        
+
         private SentenceConfig(Builder builder) {
             this.occurrence = builder.occurrence;
             this.words = builder.words;
         }
-        
-        public OccurrenceConfig getOccurrence() { return occurrence; }
-        public WordsConfig getWords() { return words; }
-        
+
+        public OccurrenceConfig getOccurrence() {
+            return occurrence;
+        }
+
+        public WordsConfig getWords() {
+            return words;
+        }
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private OccurrenceConfig occurrence;
             private WordsConfig words;
-            
+
             @JsonProperty(OCCURRENCE)
             public Builder occurrence(OccurrenceConfig occurrence) {
                 this.occurrence = occurrence;
                 return this;
             }
-            
+
             @JsonProperty(WORDS)
             public Builder words(WordsConfig words) {
                 this.words = words;
                 return this;
             }
-            
+
             public SentenceConfig build() {
                 return new SentenceConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             SentenceConfig that = (SentenceConfig) o;
-            return Objects.equals(occurrence, that.occurrence) &&
-                   Objects.equals(words, that.words);
+            return Objects.equals(occurrence, that.occurrence) && Objects.equals(words, that.words);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(occurrence, words);
         }
     }
-    
+
     /**
      * Configuration for word count validation in sentences.
      */
@@ -144,66 +157,74 @@ public final class ParagraphBlock extends AbstractBlock {
     public static final class WordsConfig {
         @JsonProperty(MIN)
         private final Integer min;
-        
+
         @JsonProperty(MAX)
         private final Integer max;
-        
+
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private WordsConfig(Builder builder) {
             this.min = builder.min;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
-        public Integer getMin() { return min; }
-        public Integer getMax() { return max; }
-        public Severity getSeverity() { return severity; }
-        
+
+        public Integer getMin() {
+            return min;
+        }
+
+        public Integer getMax() {
+            return max;
+        }
+
+        public Severity getSeverity() {
+            return severity;
+        }
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Integer min;
             private Integer max;
             private Severity severity;
-            
+
             @JsonProperty(MIN)
             public Builder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             @JsonProperty(MAX)
             public Builder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public WordsConfig build() {
                 return new WordsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             WordsConfig that = (WordsConfig) o;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, severity);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlock.java
@@ -17,16 +17,19 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Pas
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMPTY;
 
 /**
- * Configuration for pass blocks (passthrough content) in AsciiDoc.
- * Pass blocks are delimited by ++++ and pass content through without processing.
- * 
- * <p>This validator supports custom attributes that are not native to AsciiDoc:
+ * Configuration for pass blocks (passthrough content) in AsciiDoc. Pass blocks are delimited by ++++ and pass content
+ * through without processing.
+ *
+ * <p>
+ * This validator supports custom attributes that are not native to AsciiDoc:
  * <ul>
- *   <li>{@code pass-type}: Specifies the content type (html, xml, svg)</li>
- *   <li>{@code pass-reason}: Provides reason for using raw passthrough</li>
+ * <li>{@code pass-type}: Specifies the content type (html, xml, svg)</li>
+ * <li>{@code pass-reason}: Provides reason for using raw passthrough</li>
  * </ul>
- * 
- * <p>Example usage:
+ *
+ * <p>
+ * Example usage:
+ *
  * <pre>
  * [pass,pass-type=html,pass-reason="Custom widget for product gallery"]
  * ++++
@@ -35,8 +38,9 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMP
  * &lt;/div&gt;
  * ++++
  * </pre>
- * 
- * <p>Validation is based on the YAML schema configuration for pass blocks.
+ *
+ * <p>
+ * Validation is based on the YAML schema configuration for pass blocks.
  */
 @JsonDeserialize(builder = PassBlock.Builder.class)
 public final class PassBlock extends AbstractBlock {
@@ -46,35 +50,35 @@ public final class PassBlock extends AbstractBlock {
     private final ContentConfig content;
     @JsonProperty(REASON)
     private final ReasonConfig reason;
-    
+
     private PassBlock(Builder builder) {
         super(builder);
         this.type = builder.type;
         this.content = builder.content;
         this.reason = builder.reason;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.PASS;
     }
-    
+
     public TypeConfig getTypeConfig() {
         return type;
     }
-    
+
     public ContentConfig getContent() {
         return content;
     }
-    
+
     public ReasonConfig getReason() {
         return reason;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = TypeConfig.TypeConfigBuilder.class)
     public static class TypeConfig {
         @JsonProperty(REQUIRED)
@@ -83,72 +87,72 @@ public final class PassBlock extends AbstractBlock {
         private final List<String> allowed;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TypeConfig(TypeConfigBuilder builder) {
             this.required = builder.required;
-            this.allowed = builder.allowed != null ? 
-                Collections.unmodifiableList(new ArrayList<>(builder.allowed)) : 
-                Collections.emptyList();
+            this.allowed = builder.allowed != null
+                    ? Collections.unmodifiableList(new ArrayList<>(builder.allowed))
+                    : Collections.emptyList();
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public List<String> getAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TypeConfigBuilder builder() {
             return new TypeConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TypeConfigBuilder {
             private boolean required;
             private List<String> allowed;
             private Severity severity;
-            
+
             public TypeConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TypeConfigBuilder allowed(List<String> allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public TypeConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TypeConfig build() {
                 return new TypeConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TypeConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(allowed, that.allowed) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TypeConfig that))
+                return false;
+            return required == that.required && Objects.equals(allowed, that.allowed) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, allowed, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
         @JsonProperty(REQUIRED)
@@ -159,89 +163,89 @@ public final class PassBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private ContentConfig(ContentConfigBuilder builder) {
             this.required = builder.required;
             this.maxLength = builder.maxLength;
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static ContentConfigBuilder builder() {
             return new ContentConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private boolean required;
             private Integer maxLength;
             private Pattern pattern;
             private Severity severity;
-            
+
             public ContentConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public ContentConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public ContentConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public ContentConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public ContentConfig build() {
                 return new ContentConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ContentConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof ContentConfig that))
+                return false;
+            return required == that.required && Objects.equals(maxLength, that.maxLength)
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern())
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, maxLength, 
-                pattern == null ? null : pattern.pattern(), severity);
+            return Objects.hash(required, maxLength, pattern == null ? null : pattern.pattern(), severity);
         }
     }
-    
+
     @JsonDeserialize(builder = ReasonConfig.ReasonConfigBuilder.class)
     public static class ReasonConfig {
         @JsonProperty(REQUIRED)
@@ -252,120 +256,122 @@ public final class PassBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private ReasonConfig(ReasonConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static ReasonConfigBuilder builder() {
             return new ReasonConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ReasonConfigBuilder {
             private boolean required;
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             public ReasonConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public ReasonConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public ReasonConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public ReasonConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public ReasonConfig build() {
                 return new ReasonConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ReasonConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof ReasonConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TypeConfig type;
         private ContentConfig content;
         private ReasonConfig reason;
-        
+
         public Builder type(TypeConfig type) {
             this.type = type;
             return this;
         }
-        
+
         public Builder content(ContentConfig content) {
             this.content = content;
             return this;
         }
-        
+
         public Builder reason(ReasonConfig reason) {
             this.reason = reason;
             return this;
         }
-        
+
         @Override
         public PassBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new PassBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof PassBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(type, that.type) &&
-               Objects.equals(content, that.content) &&
-               Objects.equals(reason, that.reason);
+        if (this == o)
+            return true;
+        if (!(o instanceof PassBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(type, that.type) && Objects.equals(content, that.content)
+                && Objects.equals(reason, that.reason);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), type, content, reason);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlock.java
@@ -23,48 +23,44 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Configuration for quote blocks.
- * Based on the YAML schema structure for validating AsciiDoc quote blocks.
- * 
- * Syntax: [quote, Autor, Quelle]
- * ____
- * Quote content here
- * ____
+ * Configuration for quote blocks. Based on the YAML schema structure for validating AsciiDoc quote blocks.
+ *
+ * Syntax: [quote, Autor, Quelle] ____ Quote content here ____
  */
 @JsonDeserialize(builder = QuoteBlock.Builder.class)
 public class QuoteBlock extends AbstractBlock {
-    
+
     private final AttributionConfig attribution;
     private final CitationConfig citation;
     private final ContentConfig content;
-    
+
     private QuoteBlock(Builder builder) {
         super(builder);
         this.attribution = builder.attribution;
         this.citation = builder.citation;
         this.content = builder.content;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.QUOTE;
     }
-    
+
     @JsonProperty(ATTRIBUTION)
     public AttributionConfig getAttribution() {
         return attribution;
     }
-    
+
     @JsonProperty(CITATION)
     public CitationConfig getCitation() {
         return citation;
     }
-    
+
     @JsonProperty(CONTENT)
     public ContentConfig getContent() {
         return content;
     }
-    
+
     /**
      * Configuration for quote attribution validation.
      */
@@ -75,7 +71,7 @@ public class QuoteBlock extends AbstractBlock {
         private final Integer maxLength;
         private final Pattern pattern;
         private final Severity severity;
-        
+
         private AttributionConfig(Builder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
@@ -83,60 +79,61 @@ public class QuoteBlock extends AbstractBlock {
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         @JsonProperty(REQUIRED)
         public boolean isRequired() {
             return required;
         }
-        
+
         @JsonProperty(MIN_LENGTH)
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         @JsonProperty(MAX_LENGTH)
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         @JsonProperty(PATTERN)
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         @JsonProperty(SEVERITY)
         public Severity getSeverity() {
             return severity;
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             AttributionConfig that = (AttributionConfig) o;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   patternEquals(pattern, that.pattern) &&
-                   severity == that.severity;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && patternEquals(pattern, that.pattern)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, minLength, maxLength, 
-                               pattern != null ? pattern.pattern() : null, severity);
+            return Objects.hash(required, minLength, maxLength, pattern != null ? pattern.pattern() : null, severity);
         }
-        
+
         private boolean patternEquals(Pattern p1, Pattern p2) {
-            if (p1 == p2) return true;
-            if (p1 == null || p2 == null) return false;
+            if (p1 == p2)
+                return true;
+            if (p1 == null || p2 == null)
+                return false;
             return p1.pattern().equals(p2.pattern());
         }
-        
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
@@ -144,43 +141,43 @@ public class QuoteBlock extends AbstractBlock {
             private Integer maxLength;
             private Pattern pattern;
             private Severity severity;
-            
+
             @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             @JsonProperty(PATTERN)
             public Builder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public AttributionConfig build() {
                 return new AttributionConfig(this);
             }
         }
     }
-    
+
     /**
      * Configuration for quote citation validation.
      */
@@ -191,7 +188,7 @@ public class QuoteBlock extends AbstractBlock {
         private final Integer maxLength;
         private final Pattern pattern;
         private final Severity severity;
-        
+
         private CitationConfig(Builder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
@@ -199,60 +196,61 @@ public class QuoteBlock extends AbstractBlock {
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         @JsonProperty(REQUIRED)
         public boolean isRequired() {
             return required;
         }
-        
+
         @JsonProperty(MIN_LENGTH)
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         @JsonProperty(MAX_LENGTH)
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         @JsonProperty(PATTERN)
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         @JsonProperty(SEVERITY)
         public Severity getSeverity() {
             return severity;
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             CitationConfig that = (CitationConfig) o;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   patternEquals(pattern, that.pattern) &&
-                   severity == that.severity;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && patternEquals(pattern, that.pattern)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, minLength, maxLength, 
-                               pattern != null ? pattern.pattern() : null, severity);
+            return Objects.hash(required, minLength, maxLength, pattern != null ? pattern.pattern() : null, severity);
         }
-        
+
         private boolean patternEquals(Pattern p1, Pattern p2) {
-            if (p1 == p2) return true;
-            if (p1 == null || p2 == null) return false;
+            if (p1 == p2)
+                return true;
+            if (p1 == null || p2 == null)
+                return false;
             return p1.pattern().equals(p2.pattern());
         }
-        
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
@@ -260,43 +258,43 @@ public class QuoteBlock extends AbstractBlock {
             private Integer maxLength;
             private Pattern pattern;
             private Severity severity;
-            
+
             @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             @JsonProperty(PATTERN)
             public Builder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public CitationConfig build() {
                 return new CitationConfig(this);
             }
         }
     }
-    
+
     /**
      * Configuration for quote content validation.
      */
@@ -306,91 +304,91 @@ public class QuoteBlock extends AbstractBlock {
         private final Integer minLength;
         private final Integer maxLength;
         private final LinesConfig lines;
-        
+
         private ContentConfig(Builder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
             this.lines = builder.lines;
         }
-        
+
         @JsonProperty(REQUIRED)
         public boolean isRequired() {
             return required;
         }
-        
+
         @JsonProperty(MIN_LENGTH)
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         @JsonProperty(MAX_LENGTH)
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         @JsonProperty(LINES)
         public LinesConfig getLines() {
             return lines;
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             ContentConfig that = (ContentConfig) o;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(lines, that.lines);
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && Objects.equals(lines, that.lines);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength, lines);
         }
-        
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private boolean required = false;
             private Integer minLength;
             private Integer maxLength;
             private LinesConfig lines;
-            
+
             @JsonProperty(REQUIRED)
             public Builder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             @JsonProperty(MIN_LENGTH)
             public Builder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             @JsonProperty(MAX_LENGTH)
             public Builder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             @JsonProperty(LINES)
             public Builder lines(LinesConfig lines) {
                 this.lines = lines;
                 return this;
             }
-            
+
             public ContentConfig build() {
                 return new ContentConfig(this);
             }
         }
     }
-    
+
     /**
      * Configuration for content line count validation.
      */
@@ -399,120 +397,121 @@ public class QuoteBlock extends AbstractBlock {
         private final Integer min;
         private final Integer max;
         private final Severity severity;
-        
+
         private LinesConfig(Builder builder) {
             this.min = builder.min;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         @JsonProperty(MIN)
         public Integer getMin() {
             return min;
         }
-        
+
         @JsonProperty(MAX)
         public Integer getMax() {
             return max;
         }
-        
+
         @JsonProperty(SEVERITY)
         public Severity getSeverity() {
             return severity;
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             LinesConfig that = (LinesConfig) o;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, severity);
         }
-        
+
         public static Builder builder() {
             return new Builder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class Builder {
             private Integer min;
             private Integer max;
             private Severity severity;
-            
+
             @JsonProperty(MIN)
             public Builder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             @JsonProperty(MAX)
             public Builder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             @JsonProperty(SEVERITY)
             public Builder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public LinesConfig build() {
                 return new LinesConfig(this);
             }
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!super.equals(o))
+            return false;
         QuoteBlock that = (QuoteBlock) o;
-        return Objects.equals(attribution, that.attribution) &&
-               Objects.equals(citation, that.citation) &&
-               Objects.equals(content, that.content);
+        return Objects.equals(attribution, that.attribution) && Objects.equals(citation, that.citation)
+                && Objects.equals(content, that.content);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), attribution, citation, content);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBlock.AbstractBuilder<Builder> {
         private AttributionConfig attribution;
         private CitationConfig citation;
         private ContentConfig content;
-        
+
         @JsonProperty(ATTRIBUTION)
         public Builder attribution(AttributionConfig attribution) {
             this.attribution = attribution;
             return this;
         }
-        
+
         @JsonProperty(CITATION)
         public Builder citation(CitationConfig citation) {
             this.citation = citation;
             return this;
         }
-        
+
         @JsonProperty(CONTENT)
         public Builder content(ContentConfig content) {
             this.content = content;
             return this;
         }
-        
+
         @Override
         public QuoteBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlock.java
@@ -25,17 +25,20 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Configuration for sidebar blocks in AsciiDoc.
- * Sidebar blocks are used for supplementary information displayed alongside the main content.
- * 
- * <p>Example usage:
+ * Configuration for sidebar blocks in AsciiDoc. Sidebar blocks are used for supplementary information displayed
+ * alongside the main content.
+ *
+ * <p>
+ * Example usage:
+ *
  * <pre>
  * ****
  * Sidebar content here
  * ****
  * </pre>
- * 
- * <p>Validation is based on the YAML schema configuration for sidebar blocks.
+ *
+ * <p>
+ * Validation is based on the YAML schema configuration for sidebar blocks.
  */
 @JsonDeserialize(builder = SidebarBlock.Builder.class)
 public final class SidebarBlock extends AbstractBlock {
@@ -45,35 +48,35 @@ public final class SidebarBlock extends AbstractBlock {
     private final ContentConfig content;
     @JsonProperty(POSITION)
     private final PositionConfig position;
-    
+
     private SidebarBlock(Builder builder) {
         super(builder);
         this.title = builder.title;
         this.content = builder.content;
         this.position = builder.position;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.SIDEBAR;
     }
-    
+
     public TitleConfig getTitle() {
         return title;
     }
-    
+
     public ContentConfig getContent() {
         return content;
     }
-    
+
     public PositionConfig getPosition() {
         return position;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
     public static class TitleConfig {
         @JsonProperty(REQUIRED)
@@ -86,7 +89,7 @@ public final class SidebarBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private TitleConfig(TitleConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
@@ -94,31 +97,31 @@ public final class SidebarBlock extends AbstractBlock {
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static TitleConfigBuilder builder() {
             return new TitleConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class TitleConfigBuilder {
             private boolean required;
@@ -126,61 +129,61 @@ public final class SidebarBlock extends AbstractBlock {
             private Integer maxLength;
             private Pattern pattern;
             private Severity severity;
-            
+
             public TitleConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public TitleConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public TitleConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public TitleConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public TitleConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public TitleConfig build() {
                 return new TitleConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TitleConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(pattern != null ? pattern.pattern() : null, 
-                                that.pattern != null ? that.pattern.pattern() : null) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof TitleConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength)
+                    && Objects.equals(pattern != null ? pattern.pattern() : null,
+                            that.pattern != null ? that.pattern.pattern() : null)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, minLength, maxLength, 
-                              pattern != null ? pattern.pattern() : null, severity);
+            return Objects.hash(required, minLength, maxLength, pattern != null ? pattern.pattern() : null, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
         @JsonProperty(REQUIRED)
@@ -191,82 +194,82 @@ public final class SidebarBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(LINES)
         private final LinesConfig lines;
-        
+
         private ContentConfig(ContentConfigBuilder builder) {
             this.required = builder.required;
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
             this.lines = builder.lines;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public LinesConfig getLines() {
             return lines;
         }
-        
+
         public static ContentConfigBuilder builder() {
             return new ContentConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private boolean required;
             private Integer minLength;
             private Integer maxLength;
             private LinesConfig lines;
-            
+
             public ContentConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public ContentConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder lines(LinesConfig lines) {
                 this.lines = lines;
                 return this;
             }
-            
+
             public ContentConfig build() {
                 return new ContentConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ContentConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(lines, that.lines);
+            if (this == o)
+                return true;
+            if (!(o instanceof ContentConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && Objects.equals(lines, that.lines);
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, minLength, maxLength, lines);
         }
     }
-    
+
     @JsonDeserialize(builder = LinesConfig.LinesConfigBuilder.class)
     public static class LinesConfig {
         @JsonProperty(MIN)
@@ -275,70 +278,70 @@ public final class SidebarBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private LinesConfig(LinesConfigBuilder builder) {
             this.min = builder.min;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMin() {
             return min;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static LinesConfigBuilder builder() {
             return new LinesConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class LinesConfigBuilder {
             private Integer min;
             private Integer max;
             private Severity severity;
-            
+
             public LinesConfigBuilder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             public LinesConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public LinesConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public LinesConfig build() {
                 return new LinesConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof LinesConfig that)) return false;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof LinesConfig that))
+                return false;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = PositionConfig.PositionConfigBuilder.class)
     public static class PositionConfig {
         @JsonProperty(REQUIRED)
@@ -347,108 +350,110 @@ public final class SidebarBlock extends AbstractBlock {
         private final List<String> allowed;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private PositionConfig(PositionConfigBuilder builder) {
             this.required = builder.required;
             this.allowed = builder.allowed;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public List<String> getAllowed() {
             return allowed;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static PositionConfigBuilder builder() {
             return new PositionConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class PositionConfigBuilder {
             private boolean required;
             private List<String> allowed;
             private Severity severity;
-            
+
             public PositionConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public PositionConfigBuilder allowed(List<String> allowed) {
                 this.allowed = allowed;
                 return this;
             }
-            
+
             public PositionConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public PositionConfig build() {
                 return new PositionConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof PositionConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(allowed, that.allowed) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof PositionConfig that))
+                return false;
+            return required == that.required && Objects.equals(allowed, that.allowed) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, allowed, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private TitleConfig title;
         private ContentConfig content;
         private PositionConfig position;
-        
+
         public Builder title(TitleConfig title) {
             this.title = title;
             return this;
         }
-        
+
         public Builder content(ContentConfig content) {
             this.content = content;
             return this;
         }
-        
+
         public Builder position(PositionConfig position) {
             this.position = position;
             return this;
         }
-        
+
         @Override
         public SidebarBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new SidebarBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SidebarBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(title, that.title) &&
-               Objects.equals(content, that.content) &&
-               Objects.equals(position, that.position);
+        if (this == o)
+            return true;
+        if (!(o instanceof SidebarBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(title, that.title) && Objects.equals(content, that.content)
+                && Objects.equals(position, that.position);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), title, content, position);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlock.java
@@ -37,7 +37,7 @@ public final class TableBlock extends AbstractBlock {
     private final CaptionConfig caption;
     @JsonProperty(FORMAT)
     private final FormatConfig format;
-    
+
     private TableBlock(Builder builder) {
         super(builder);
         this.columns = builder.columns;
@@ -46,36 +46,36 @@ public final class TableBlock extends AbstractBlock {
         this.caption = builder.caption;
         this.format = builder.format;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.TABLE;
     }
-    
+
     public DimensionConfig getColumns() {
         return columns;
     }
-    
+
     public DimensionConfig getRows() {
         return rows;
     }
-    
+
     public HeaderConfig getHeader() {
         return header;
     }
-    
+
     public CaptionConfig getCaption() {
         return caption;
     }
-    
+
     public FormatConfig getFormat() {
         return format;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = DimensionConfig.DimensionConfigBuilder.class)
     public static class DimensionConfig {
         @JsonProperty(MIN)
@@ -84,70 +84,70 @@ public final class TableBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private DimensionConfig(DimensionConfigBuilder builder) {
             this.min = builder.min;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMin() {
             return min;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static DimensionConfigBuilder builder() {
             return new DimensionConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class DimensionConfigBuilder {
             private Integer min;
             private Integer max;
             private Severity severity;
-            
+
             public DimensionConfigBuilder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             public DimensionConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public DimensionConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public DimensionConfig build() {
                 return new DimensionConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof DimensionConfig that)) return false;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof DimensionConfig that))
+                return false;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = HeaderConfig.HeaderConfigBuilder.class)
     public static class HeaderConfig {
         @JsonProperty(REQUIRED)
@@ -156,76 +156,76 @@ public final class TableBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private HeaderConfig(HeaderConfigBuilder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static HeaderConfigBuilder builder() {
             return new HeaderConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class HeaderConfigBuilder {
             private boolean required;
             private Pattern pattern;
             private Severity severity;
-            
+
             public HeaderConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public HeaderConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public HeaderConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public HeaderConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public HeaderConfig build() {
                 return new HeaderConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof HeaderConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof HeaderConfig that))
+                return false;
+            return required == that.required && Objects.equals(pattern == null ? null : pattern.pattern(),
+                    that.pattern == null ? null : that.pattern.pattern()) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(required, pattern == null ? null : pattern.pattern(), severity);
         }
     }
-    
+
     @JsonDeserialize(builder = CaptionConfig.CaptionConfigBuilder.class)
     public static class CaptionConfig {
         @JsonProperty(REQUIRED)
@@ -238,7 +238,7 @@ public final class TableBlock extends AbstractBlock {
         private final Integer maxLength;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private CaptionConfig(CaptionConfigBuilder builder) {
             this.required = builder.required;
             this.pattern = builder.pattern;
@@ -246,31 +246,31 @@ public final class TableBlock extends AbstractBlock {
             this.maxLength = builder.maxLength;
             this.severity = builder.severity;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static CaptionConfigBuilder builder() {
             return new CaptionConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class CaptionConfigBuilder {
             private boolean required;
@@ -278,61 +278,61 @@ public final class TableBlock extends AbstractBlock {
             private Integer minLength;
             private Integer maxLength;
             private Severity severity;
-            
+
             public CaptionConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public CaptionConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public CaptionConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public CaptionConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public CaptionConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public CaptionConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public CaptionConfig build() {
                 return new CaptionConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof CaptionConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern()) &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof CaptionConfig that))
+                return false;
+            return required == that.required
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern())
+                    && Objects.equals(minLength, that.minLength) && Objects.equals(maxLength, that.maxLength)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(required, pattern == null ? null : pattern.pattern(), 
-                               minLength, maxLength, severity);
+            return Objects.hash(required, pattern == null ? null : pattern.pattern(), minLength, maxLength, severity);
         }
     }
-    
+
     @JsonDeserialize(builder = FormatConfig.FormatConfigBuilder.class)
     public static class FormatConfig {
         @JsonProperty(STYLE)
@@ -341,70 +341,71 @@ public final class TableBlock extends AbstractBlock {
         private final Boolean borders;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private FormatConfig(FormatConfigBuilder builder) {
             this.style = builder.style;
             this.borders = builder.borders;
             this.severity = builder.severity;
         }
-        
+
         public String getStyle() {
             return style;
         }
-        
+
         public Boolean getBorders() {
             return borders;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static FormatConfigBuilder builder() {
             return new FormatConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class FormatConfigBuilder {
             private String style;
             private Boolean borders;
             private Severity severity;
-            
+
             public FormatConfigBuilder style(String style) {
                 this.style = style;
                 return this;
             }
-            
+
             public FormatConfigBuilder borders(Boolean borders) {
                 this.borders = borders;
                 return this;
             }
-            
+
             public FormatConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public FormatConfig build() {
                 return new FormatConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof FormatConfig that)) return false;
-            return Objects.equals(style, that.style) &&
-                   Objects.equals(borders, that.borders) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof FormatConfig that))
+                return false;
+            return Objects.equals(style, that.style) && Objects.equals(borders, that.borders)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(style, borders, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private DimensionConfig columns;
@@ -412,51 +413,52 @@ public final class TableBlock extends AbstractBlock {
         private HeaderConfig header;
         private CaptionConfig caption;
         private FormatConfig format;
-        
+
         public Builder columns(DimensionConfig columns) {
             this.columns = columns;
             return this;
         }
-        
+
         public Builder rows(DimensionConfig rows) {
             this.rows = rows;
             return this;
         }
-        
+
         public Builder header(HeaderConfig header) {
             this.header = header;
             return this;
         }
-        
+
         public Builder caption(CaptionConfig caption) {
             this.caption = caption;
             return this;
         }
-        
+
         public Builder format(FormatConfig format) {
             this.format = format;
             return this;
         }
-        
+
         @Override
         public TableBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new TableBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TableBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(columns, that.columns) &&
-               Objects.equals(rows, that.rows) &&
-               Objects.equals(header, that.header) &&
-               Objects.equals(caption, that.caption) &&
-               Objects.equals(format, that.format);
+        if (this == o)
+            return true;
+        if (!(o instanceof TableBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(columns, that.columns) && Objects.equals(rows, that.rows)
+                && Objects.equals(header, that.header) && Objects.equals(caption, that.caption)
+                && Objects.equals(format, that.format);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), columns, rows, header, caption, format);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlock.java
@@ -17,8 +17,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Configuration for unordered list (ulist) blocks in AsciiDoc.
- * Represents bullet point lists with * or - markers.
+ * Configuration for unordered list (ulist) blocks in AsciiDoc. Represents bullet point lists with * or - markers.
  */
 @JsonDeserialize(builder = UlistBlock.Builder.class)
 public final class UlistBlock extends AbstractBlock {
@@ -28,35 +27,35 @@ public final class UlistBlock extends AbstractBlock {
     private final NestingLevelConfig nestingLevel;
     @JsonProperty(MARKER_STYLE)
     private final String markerStyle;
-    
+
     private UlistBlock(Builder builder) {
         super(builder);
         this.items = builder.items;
         this.nestingLevel = builder.nestingLevel;
         this.markerStyle = builder.markerStyle;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.ULIST;
     }
-    
+
     public ItemsConfig getItems() {
         return items;
     }
-    
+
     public NestingLevelConfig getNestingLevel() {
         return nestingLevel;
     }
-    
+
     public String getMarkerStyle() {
         return markerStyle;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     /**
      * Configuration for list items count validation.
      */
@@ -68,70 +67,70 @@ public final class UlistBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private ItemsConfig(ItemsConfigBuilder builder) {
             this.min = builder.min;
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMin() {
             return min;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static ItemsConfigBuilder builder() {
             return new ItemsConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ItemsConfigBuilder {
             private Integer min;
             private Integer max;
             private Severity severity;
-            
+
             public ItemsConfigBuilder min(Integer min) {
                 this.min = min;
                 return this;
             }
-            
+
             public ItemsConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public ItemsConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public ItemsConfig build() {
                 return new ItemsConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ItemsConfig that)) return false;
-            return Objects.equals(min, that.min) &&
-                   Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof ItemsConfig that))
+                return false;
+            return Objects.equals(min, that.min) && Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(min, max, severity);
         }
     }
-    
+
     /**
      * Configuration for nesting level validation.
      */
@@ -141,96 +140,99 @@ public final class UlistBlock extends AbstractBlock {
         private final Integer max;
         @JsonProperty(SEVERITY)
         private final Severity severity;
-        
+
         private NestingLevelConfig(NestingLevelConfigBuilder builder) {
             this.max = builder.max;
             this.severity = builder.severity;
         }
-        
+
         public Integer getMax() {
             return max;
         }
-        
+
         public Severity getSeverity() {
             return severity;
         }
-        
+
         public static NestingLevelConfigBuilder builder() {
             return new NestingLevelConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class NestingLevelConfigBuilder {
             private Integer max;
             private Severity severity;
-            
+
             public NestingLevelConfigBuilder max(Integer max) {
                 this.max = max;
                 return this;
             }
-            
+
             public NestingLevelConfigBuilder severity(Severity severity) {
                 this.severity = severity;
                 return this;
             }
-            
+
             public NestingLevelConfig build() {
                 return new NestingLevelConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof NestingLevelConfig that)) return false;
-            return Objects.equals(max, that.max) &&
-                   severity == that.severity;
+            if (this == o)
+                return true;
+            if (!(o instanceof NestingLevelConfig that))
+                return false;
+            return Objects.equals(max, that.max) && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(max, severity);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private ItemsConfig items;
         private NestingLevelConfig nestingLevel;
         private String markerStyle;
-        
+
         public Builder items(ItemsConfig items) {
             this.items = items;
             return this;
         }
-        
+
         public Builder nestingLevel(NestingLevelConfig nestingLevel) {
             this.nestingLevel = nestingLevel;
             return this;
         }
-        
+
         public Builder markerStyle(String markerStyle) {
             this.markerStyle = markerStyle;
             return this;
         }
-        
+
         @Override
         public UlistBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new UlistBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof UlistBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(items, that.items) &&
-               Objects.equals(nestingLevel, that.nestingLevel) &&
-               Objects.equals(markerStyle, that.markerStyle);
+        if (this == o)
+            return true;
+        if (!(o instanceof UlistBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(items, that.items) && Objects.equals(nestingLevel, that.nestingLevel)
+                && Objects.equals(markerStyle, that.markerStyle);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), items, nestingLevel, markerStyle);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlock.java
@@ -26,35 +26,35 @@ public final class VerseBlock extends AbstractBlock {
     private final AttributionConfig attribution;
     @JsonProperty(CONTENT)
     private final ContentConfig content;
-    
+
     private VerseBlock(Builder builder) {
         super(builder);
         this.author = builder.author;
         this.attribution = builder.attribution;
         this.content = builder.content;
     }
-    
+
     @Override
     public BlockType getType() {
         return BlockType.VERSE;
     }
-    
+
     public AuthorConfig getAuthor() {
         return author;
     }
-    
+
     public AttributionConfig getAttribution() {
         return attribution;
     }
-    
+
     public ContentConfig getContent() {
         return content;
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonDeserialize(builder = AuthorConfig.AuthorConfigBuilder.class)
     public static class AuthorConfig {
         @JsonProperty(DEFAULT_VALUE)
@@ -67,7 +67,7 @@ public final class VerseBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(REQUIRED)
         private final boolean required;
-        
+
         private AuthorConfig(AuthorConfigBuilder builder) {
             this.defaultValue = builder.defaultValue;
             this.minLength = builder.minLength;
@@ -75,31 +75,31 @@ public final class VerseBlock extends AbstractBlock {
             this.pattern = builder.pattern;
             this.required = builder.required;
         }
-        
+
         public String getDefaultValue() {
             return defaultValue;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public static AuthorConfigBuilder builder() {
             return new AuthorConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AuthorConfigBuilder {
             private String defaultValue;
@@ -107,61 +107,61 @@ public final class VerseBlock extends AbstractBlock {
             private Integer maxLength;
             private Pattern pattern;
             private boolean required;
-            
+
             public AuthorConfigBuilder defaultValue(String defaultValue) {
                 this.defaultValue = defaultValue;
                 return this;
             }
-            
+
             public AuthorConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public AuthorConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public AuthorConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public AuthorConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public AuthorConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public AuthorConfig build() {
                 return new AuthorConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof AuthorConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(defaultValue, that.defaultValue) &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern());
+            if (this == o)
+                return true;
+            if (!(o instanceof AuthorConfig that))
+                return false;
+            return required == that.required && Objects.equals(defaultValue, that.defaultValue)
+                    && Objects.equals(minLength, that.minLength) && Objects.equals(maxLength, that.maxLength)
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern());
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(defaultValue, minLength, maxLength,
-                               pattern == null ? null : pattern.pattern(), required);
+            return Objects.hash(defaultValue, minLength, maxLength, pattern == null ? null : pattern.pattern(),
+                    required);
         }
     }
-    
+
     @JsonDeserialize(builder = AttributionConfig.AttributionConfigBuilder.class)
     public static class AttributionConfig {
         @JsonProperty(DEFAULT_VALUE)
@@ -174,7 +174,7 @@ public final class VerseBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(REQUIRED)
         private final boolean required;
-        
+
         private AttributionConfig(AttributionConfigBuilder builder) {
             this.defaultValue = builder.defaultValue;
             this.minLength = builder.minLength;
@@ -182,31 +182,31 @@ public final class VerseBlock extends AbstractBlock {
             this.pattern = builder.pattern;
             this.required = builder.required;
         }
-        
+
         public String getDefaultValue() {
             return defaultValue;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public static AttributionConfigBuilder builder() {
             return new AttributionConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class AttributionConfigBuilder {
             private String defaultValue;
@@ -214,61 +214,61 @@ public final class VerseBlock extends AbstractBlock {
             private Integer maxLength;
             private Pattern pattern;
             private boolean required;
-            
+
             public AttributionConfigBuilder defaultValue(String defaultValue) {
                 this.defaultValue = defaultValue;
                 return this;
             }
-            
+
             public AttributionConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public AttributionConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public AttributionConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public AttributionConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public AttributionConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public AttributionConfig build() {
                 return new AttributionConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof AttributionConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(defaultValue, that.defaultValue) &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern());
+            if (this == o)
+                return true;
+            if (!(o instanceof AttributionConfig that))
+                return false;
+            return required == that.required && Objects.equals(defaultValue, that.defaultValue)
+                    && Objects.equals(minLength, that.minLength) && Objects.equals(maxLength, that.maxLength)
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern());
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(defaultValue, minLength, maxLength,
-                               pattern == null ? null : pattern.pattern(), required);
+            return Objects.hash(defaultValue, minLength, maxLength, pattern == null ? null : pattern.pattern(),
+                    required);
         }
     }
-    
+
     @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
     public static class ContentConfig {
         @JsonProperty(MIN_LENGTH)
@@ -279,127 +279,129 @@ public final class VerseBlock extends AbstractBlock {
         private final Pattern pattern;
         @JsonProperty(REQUIRED)
         private final boolean required;
-        
+
         private ContentConfig(ContentConfigBuilder builder) {
             this.minLength = builder.minLength;
             this.maxLength = builder.maxLength;
             this.pattern = builder.pattern;
             this.required = builder.required;
         }
-        
+
         public Integer getMinLength() {
             return minLength;
         }
-        
+
         public Integer getMaxLength() {
             return maxLength;
         }
-        
+
         public Pattern getPattern() {
             return pattern;
         }
-        
+
         public boolean isRequired() {
             return required;
         }
-        
+
         public static ContentConfigBuilder builder() {
             return new ContentConfigBuilder();
         }
-        
+
         @JsonPOJOBuilder(withPrefix = EMPTY)
         public static class ContentConfigBuilder {
             private Integer minLength;
             private Integer maxLength;
             private Pattern pattern;
             private boolean required;
-            
+
             public ContentConfigBuilder minLength(Integer minLength) {
                 this.minLength = minLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder maxLength(Integer maxLength) {
                 this.maxLength = maxLength;
                 return this;
             }
-            
+
             public ContentConfigBuilder pattern(Pattern pattern) {
                 this.pattern = pattern;
                 return this;
             }
-            
+
             public ContentConfigBuilder pattern(String pattern) {
                 this.pattern = pattern != null ? Pattern.compile(pattern) : null;
                 return this;
             }
-            
+
             public ContentConfigBuilder required(boolean required) {
                 this.required = required;
                 return this;
             }
-            
+
             public ContentConfig build() {
                 return new ContentConfig(this);
             }
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ContentConfig that)) return false;
-            return required == that.required &&
-                   Objects.equals(minLength, that.minLength) &&
-                   Objects.equals(maxLength, that.maxLength) &&
-                   Objects.equals(pattern == null ? null : pattern.pattern(),
-                                 that.pattern == null ? null : that.pattern.pattern());
+            if (this == o)
+                return true;
+            if (!(o instanceof ContentConfig that))
+                return false;
+            return required == that.required && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength)
+                    && Objects.equals(pattern == null ? null : pattern.pattern(),
+                            that.pattern == null ? null : that.pattern.pattern());
         }
-        
+
         @Override
         public int hashCode() {
-            return Objects.hash(minLength, maxLength,
-                               pattern == null ? null : pattern.pattern(), required);
+            return Objects.hash(minLength, maxLength, pattern == null ? null : pattern.pattern(), required);
         }
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static class Builder extends AbstractBuilder<Builder> {
         private AuthorConfig author;
         private AttributionConfig attribution;
         private ContentConfig content;
-        
+
         public Builder author(AuthorConfig author) {
             this.author = author;
             return this;
         }
-        
+
         public Builder attribution(AttributionConfig attribution) {
             this.attribution = attribution;
             return this;
         }
-        
+
         public Builder content(ContentConfig content) {
             this.content = content;
             return this;
         }
-        
+
         @Override
         public VerseBlock build() {
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity is required");
             return new VerseBlock(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof VerseBlock that)) return false;
-        if (!super.equals(o)) return false;
-        return Objects.equals(author, that.author) &&
-               Objects.equals(attribution, that.attribution) &&
-               Objects.equals(content, that.content);
+        if (this == o)
+            return true;
+        if (!(o instanceof VerseBlock that))
+            return false;
+        if (!super.equals(o))
+            return false;
+        return Objects.equals(author, that.author) && Objects.equals(attribution, that.attribution)
+                && Objects.equals(content, that.content);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), author, attribution, content);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlock.java
@@ -34,7 +34,7 @@ public class VideoBlock extends AbstractBlock {
     private final PosterConfig poster;
     private final OptionsConfig options;
     private final CaptionConfig caption;
-    
+
     @Override
     public BlockType getType() {
         return BlockType.VIDEO;
@@ -80,16 +80,16 @@ public class VideoBlock extends AbstractBlock {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof VideoBlock)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof VideoBlock))
+            return false;
+        if (!super.equals(o))
+            return false;
         VideoBlock that = (VideoBlock) o;
-        return Objects.equals(url, that.url) &&
-                Objects.equals(width, that.width) &&
-                Objects.equals(height, that.height) &&
-                Objects.equals(poster, that.poster) &&
-                Objects.equals(options, that.options) &&
-                Objects.equals(caption, that.caption);
+        return Objects.equals(url, that.url) && Objects.equals(width, that.width) && Objects.equals(height, that.height)
+                && Objects.equals(poster, that.poster) && Objects.equals(options, that.options)
+                && Objects.equals(caption, that.caption);
     }
 
     @Override
@@ -179,12 +179,13 @@ public class VideoBlock extends AbstractBlock {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof UrlConfig)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof UrlConfig))
+                return false;
             UrlConfig urlConfig = (UrlConfig) o;
-            return Objects.equals(required, urlConfig.required) &&
-                    patternEquals(pattern, urlConfig.pattern) &&
-                    severity == urlConfig.severity;
+            return Objects.equals(required, urlConfig.required) && patternEquals(pattern, urlConfig.pattern)
+                    && severity == urlConfig.severity;
         }
 
         @Override
@@ -193,8 +194,10 @@ public class VideoBlock extends AbstractBlock {
         }
 
         private boolean patternEquals(Pattern p1, Pattern p2) {
-            if (p1 == p2) return true;
-            if (p1 == null || p2 == null) return false;
+            if (p1 == p2)
+                return true;
+            if (p1 == null || p2 == null)
+                return false;
             return p1.pattern().equals(p2.pattern());
         }
 
@@ -274,13 +277,13 @@ public class VideoBlock extends AbstractBlock {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof DimensionConfig)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof DimensionConfig))
+                return false;
             DimensionConfig that = (DimensionConfig) o;
-            return Objects.equals(required, that.required) &&
-                    Objects.equals(minValue, that.minValue) &&
-                    Objects.equals(maxValue, that.maxValue) &&
-                    severity == that.severity;
+            return Objects.equals(required, that.required) && Objects.equals(minValue, that.minValue)
+                    && Objects.equals(maxValue, that.maxValue) && severity == that.severity;
         }
 
         @Override
@@ -355,12 +358,13 @@ public class VideoBlock extends AbstractBlock {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof PosterConfig)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof PosterConfig))
+                return false;
             PosterConfig that = (PosterConfig) o;
-            return Objects.equals(required, that.required) &&
-                    patternEquals(pattern, that.pattern) &&
-                    severity == that.severity;
+            return Objects.equals(required, that.required) && patternEquals(pattern, that.pattern)
+                    && severity == that.severity;
         }
 
         @Override
@@ -369,8 +373,10 @@ public class VideoBlock extends AbstractBlock {
         }
 
         private boolean patternEquals(Pattern p1, Pattern p2) {
-            if (p1 == p2) return true;
-            if (p1 == null || p2 == null) return false;
+            if (p1 == p2)
+                return true;
+            if (p1 == null || p2 == null)
+                return false;
             return p1.pattern().equals(p2.pattern());
         }
 
@@ -432,8 +438,10 @@ public class VideoBlock extends AbstractBlock {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof OptionsConfig)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof OptionsConfig))
+                return false;
             OptionsConfig that = (OptionsConfig) o;
             return Objects.equals(controls, that.controls);
         }
@@ -483,11 +491,12 @@ public class VideoBlock extends AbstractBlock {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ControlsConfig)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof ControlsConfig))
+                return false;
             ControlsConfig that = (ControlsConfig) o;
-            return Objects.equals(required, that.required) &&
-                    severity == that.severity;
+            return Objects.equals(required, that.required) && severity == that.severity;
         }
 
         @Override
@@ -554,13 +563,13 @@ public class VideoBlock extends AbstractBlock {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof CaptionConfig)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof CaptionConfig))
+                return false;
             CaptionConfig that = (CaptionConfig) o;
-            return Objects.equals(required, that.required) &&
-                    Objects.equals(minLength, that.minLength) &&
-                    Objects.equals(maxLength, that.maxLength) &&
-                    severity == that.severity;
+            return Objects.equals(required, that.required) && Objects.equals(minLength, that.minLength)
+                    && Objects.equals(maxLength, that.maxLength) && severity == that.severity;
         }
 
         @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/common/JsonPropertyNames.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/common/JsonPropertyNames.java
@@ -1,20 +1,20 @@
 package com.dataliquid.asciidoc.linter.config.common;
 
 /**
- * Central repository for all JSON property names used in configuration classes.
- * This class provides constants for JSON property names to ensure consistency
- * and maintainability across all configuration POJOs.
+ * Central repository for all JSON property names used in configuration classes. This class provides constants for JSON
+ * property names to ensure consistency and maintainability across all configuration POJOs.
  */
 public final class JsonPropertyNames {
-    
+
     // Prevent instantiation
-    private JsonPropertyNames() {}
-    
+    private JsonPropertyNames() {
+    }
+
     /**
      * Empty string constant for use in annotations like @JsonPOJOBuilder
      */
     public static final String EMPTY = "";
-    
+
     /**
      * Common property names used across multiple configuration classes
      */
@@ -46,7 +46,7 @@ public final class JsonPropertyNames {
         public static final String THRESHOLD = "threshold";
         public static final String DEFAULT_VALUE = "defaultValue";
     }
-    
+
     /**
      * Property names for document configuration
      */
@@ -58,7 +58,7 @@ public final class JsonPropertyNames {
         public static final String SUBSECTIONS = "subsections";
         public static final String ALLOWED_BLOCKS = "allowedBlocks";
     }
-    
+
     /**
      * Property names for admonition block configuration
      */
@@ -66,7 +66,7 @@ public final class JsonPropertyNames {
         public static final String TYPE = "type";
         public static final String ICON = "icon";
     }
-    
+
     /**
      * Property names for audio/video block configuration
      */
@@ -77,7 +77,7 @@ public final class JsonPropertyNames {
         public static final String POSTER = "poster";
         public static final String NO_CONTROLS = "nocontrols";
     }
-    
+
     /**
      * Property names for quote/verse block configuration
      */
@@ -86,7 +86,7 @@ public final class JsonPropertyNames {
         public static final String CITATION = "citation";
         public static final String AUTHOR = "author";
     }
-    
+
     /**
      * Property names for listing block configuration
      */
@@ -94,7 +94,7 @@ public final class JsonPropertyNames {
         public static final String LANGUAGE = "language";
         public static final String CALLOUTS = "callouts";
     }
-    
+
     /**
      * Property names for literal block configuration
      */
@@ -104,21 +104,21 @@ public final class JsonPropertyNames {
         public static final String MAX_SPACES = "maxSpaces";
         public static final String CONSISTENT = "consistent";
     }
-    
+
     /**
      * Property names for example block configuration
      */
     public static final class Example {
         public static final String COLLAPSIBLE = "collapsible";
     }
-    
+
     /**
      * Property names for sidebar block configuration
      */
     public static final class Sidebar {
         public static final String POSITION = "position";
     }
-    
+
     /**
      * Property names for table block configuration
      */
@@ -130,7 +130,7 @@ public final class JsonPropertyNames {
         public static final String STYLE = "style";
         public static final String BORDERS = "borders";
     }
-    
+
     /**
      * Property names for list block configuration
      */
@@ -143,7 +143,7 @@ public final class JsonPropertyNames {
         public static final String DELIMITER_STYLE = "delimiterStyle";
         public static final String ALLOWED_DELIMITERS = "allowedDelimiters";
     }
-    
+
     /**
      * Property names for paragraph block configuration
      */
@@ -151,21 +151,21 @@ public final class JsonPropertyNames {
         public static final String SENTENCE = "sentence";
         public static final String WORDS = "words";
     }
-    
+
     /**
      * Property names for pass block configuration
      */
     public static final class Pass {
         public static final String REASON = "reason";
     }
-    
+
     /**
      * Property names for image block configuration
      */
     public static final class Image {
         public static final String ALT = "alt";
     }
-    
+
     /**
      * Property names for output configuration
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/common/Severity.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/common/Severity.java
@@ -4,18 +4,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Severity {
-    ERROR,
-    WARN,
-    INFO;
-    
+    ERROR, WARN, INFO;
+
     @JsonValue
     public String toValue() {
         return name().toLowerCase();
     }
-    
+
     @JsonCreator
     public static Severity fromValue(String value) {
-        if (value == null) return null;
+        if (value == null)
+            return null;
         return switch (value.toLowerCase()) {
             case "error" -> ERROR;
             case "warn" -> WARN;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/document/DocumentConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/document/DocumentConfiguration.java
@@ -25,10 +25,14 @@ public final class DocumentConfiguration {
     }
 
     @JsonProperty(METADATA)
-    public MetadataConfiguration metadata() { return metadata; }
-    
+    public MetadataConfiguration metadata() {
+        return metadata;
+    }
+
     @JsonProperty(SECTIONS)
-    public List<SectionConfig> sections() { return sections; }
+    public List<SectionConfig> sections() {
+        return sections;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -63,11 +67,12 @@ public final class DocumentConfiguration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         DocumentConfiguration that = (DocumentConfiguration) o;
-        return Objects.equals(metadata, that.metadata) &&
-               Objects.equals(sections, that.sections);
+        return Objects.equals(metadata, that.metadata) && Objects.equals(sections, that.sections);
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/document/MetadataConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/document/MetadataConfiguration.java
@@ -22,8 +22,8 @@ public final class MetadataConfiguration {
     }
 
     @JsonProperty(ATTRIBUTES)
-    public List<AttributeConfig> attributes() { 
-        return attributes; 
+    public List<AttributeConfig> attributes() {
+        return attributes;
     }
 
     public static Builder builder() {
@@ -52,8 +52,10 @@ public final class MetadataConfiguration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         MetadataConfiguration that = (MetadataConfiguration) o;
         return Objects.equals(attributes, that.attributes);
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/loader/BlockListDeserializer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/loader/BlockListDeserializer.java
@@ -28,8 +28,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Custom deserializer for Block lists in YAML.
- * Handles the special YAML structure where block type is the key:
+ * Custom deserializer for Block lists in YAML. Handles the special YAML structure where block type is the key:
+ *
  * <pre>
  * allowedBlocks:
  *   - paragraph:
@@ -42,35 +42,34 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *       name: code-example
  *       severity: error
  * </pre>
- * 
- * This deserializer expects valid YAML that conforms to the schema.
- * No transformations or default values are applied.
+ *
+ * This deserializer expects valid YAML that conforms to the schema. No transformations or default values are applied.
  */
 public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
-    
+
     @Override
     public List<Block> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         List<Block> blocks = new ArrayList<>();
         JsonNode node = p.getCodec().readTree(p);
-        
+
         if (!node.isArray()) {
             throw new IOException("Expected array for block list");
         }
-        
+
         ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        
+
         for (JsonNode blockNode : node) {
             if (!blockNode.isObject()) {
                 continue;
             }
-            
+
             // Each block is an object with a single key (the block type)
             String blockType = blockNode.fieldNames().next();
             JsonNode blockData = blockNode.get(blockType);
-            
+
             // Convert blockType string to BlockType enum
             BlockType type = BlockType.fromValue(blockType);
-            
+
             // Deserialize based on block type - Jackson will handle all validation
             Block block = switch (type) {
                 case PARAGRAPH -> mapper.treeToValue(blockData, ParagraphBlock.class);
@@ -89,10 +88,10 @@ public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
                 case ULIST -> mapper.treeToValue(blockData, UlistBlock.class);
                 case DLIST -> mapper.treeToValue(blockData, DlistBlock.class);
             };
-            
+
             blocks.add(block);
         }
-        
+
         return blocks;
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationException.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationException.java
@@ -2,13 +2,13 @@ package com.dataliquid.asciidoc.linter.config.loader;
 
 public class ConfigurationException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	public ConfigurationException(String message) {
-		super(message);
-	}
+    public ConfigurationException(String message) {
+        super(message);
+    }
 
-	public ConfigurationException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoader.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoader.java
@@ -15,21 +15,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class ConfigurationLoader {
-    
+
     private static final Logger logger = LogManager.getLogger(ConfigurationLoader.class);
-    
+
     private final ObjectMapper mapper;
     private final RuleSchemaValidator schemaValidator;
     private final boolean skipRuleSchemaValidation;
-    
+
     public ConfigurationLoader() {
         this(false);
     }
-    
+
     public ConfigurationLoader(boolean skipRuleSchemaValidation) {
         this.mapper = new ObjectMapper(new YAMLFactory());
         this.skipRuleSchemaValidation = skipRuleSchemaValidation;
-        
+
         if (!skipRuleSchemaValidation) {
             this.schemaValidator = new RuleSchemaValidator();
         } else {
@@ -37,35 +37,33 @@ public class ConfigurationLoader {
             logger.warn("Rule configuration schema validation is DISABLED");
         }
     }
-    
+
     public LinterConfiguration loadConfiguration(Path configPath) throws IOException {
         // First: Validate user config against schema
         if (!skipRuleSchemaValidation && schemaValidator != null) {
             try {
                 schemaValidator.validateUserConfig(configPath);
             } catch (RuleValidationException e) {
-                throw new ConfigurationException(
-                    "User configuration does not match schema: " + e.getMessage(), e);
+                throw new ConfigurationException("User configuration does not match schema: " + e.getMessage(), e);
             }
         }
-        
+
         // Then: Parse the validated config
         try (InputStream inputStream = Files.newInputStream(configPath)) {
             return loadConfiguration(inputStream);
         }
     }
-    
+
     public LinterConfiguration loadConfiguration(String yamlContent) {
         // First: Validate string config against schema
         if (!skipRuleSchemaValidation && schemaValidator != null) {
             try {
                 schemaValidator.validateYamlString(yamlContent);
             } catch (RuleValidationException e) {
-                throw new ConfigurationException(
-                    "User configuration does not match schema: " + e.getMessage(), e);
+                throw new ConfigurationException("User configuration does not match schema: " + e.getMessage(), e);
             }
         }
-        
+
         // Then: Parse the validated config
         try {
             LinterConfiguration config = mapper.readValue(yamlContent, LinterConfiguration.class);
@@ -77,7 +75,7 @@ public class ConfigurationLoader {
             throw new ConfigurationException("Failed to parse YAML configuration: " + e.getMessage(), e);
         }
     }
-    
+
     public LinterConfiguration loadConfiguration(InputStream inputStream) {
         try {
             LinterConfiguration config = mapper.readValue(inputStream, LinterConfiguration.class);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/DisplayConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/DisplayConfig.java
@@ -25,14 +25,14 @@ public final class DisplayConfig {
     private static final boolean DEFAULT_SHOW_LINE_NUMBERS = true;
     private static final int DEFAULT_MAX_LINE_WIDTH = 120;
     private static final boolean DEFAULT_SHOW_HEADER = true;
-    
+
     private final int contextLines;
     private final HighlightStyle highlightStyle;
     private final boolean useColors;
     private final boolean showLineNumbers;
     private final int maxLineWidth;
     private final boolean showHeader;
-    
+
     private DisplayConfig(Builder builder) {
         this.contextLines = builder.contextLines;
         this.highlightStyle = builder.highlightStyle;
@@ -41,54 +41,52 @@ public final class DisplayConfig {
         this.maxLineWidth = builder.maxLineWidth;
         this.showHeader = builder.showHeader;
     }
-    
+
     public int getContextLines() {
         return contextLines;
     }
-    
+
     public HighlightStyle getHighlightStyle() {
         return highlightStyle;
     }
-    
+
     public boolean isUseColors() {
         return useColors;
     }
-    
+
     public boolean isShowLineNumbers() {
         return showLineNumbers;
     }
-    
+
     public int getMaxLineWidth() {
         return maxLineWidth;
     }
-    
+
     public boolean isShowHeader() {
         return showHeader;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         DisplayConfig that = (DisplayConfig) o;
-        return contextLines == that.contextLines &&
-                useColors == that.useColors &&
-                showLineNumbers == that.showLineNumbers &&
-                maxLineWidth == that.maxLineWidth &&
-                showHeader == that.showHeader &&
-                highlightStyle == that.highlightStyle;
+        return contextLines == that.contextLines && useColors == that.useColors
+                && showLineNumbers == that.showLineNumbers && maxLineWidth == that.maxLineWidth
+                && showHeader == that.showHeader && highlightStyle == that.highlightStyle;
     }
-    
+
     @Override
     public int hashCode() {
-        return Objects.hash(contextLines, highlightStyle, useColors, 
-                          showLineNumbers, maxLineWidth, showHeader);
+        return Objects.hash(contextLines, highlightStyle, useColors, showLineNumbers, maxLineWidth, showHeader);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private int contextLines = DEFAULT_CONTEXT_LINES;
@@ -97,46 +95,46 @@ public final class DisplayConfig {
         private boolean showLineNumbers = DEFAULT_SHOW_LINE_NUMBERS;
         private int maxLineWidth = DEFAULT_MAX_LINE_WIDTH;
         private boolean showHeader = DEFAULT_SHOW_HEADER;
-        
+
         private Builder() {
         }
-        
+
         @JsonProperty(CONTEXT_LINES)
         public Builder contextLines(int contextLines) {
             this.contextLines = contextLines;
             return this;
         }
-        
+
         @JsonProperty(HIGHLIGHT_STYLE)
         public Builder highlightStyle(HighlightStyle highlightStyle) {
             this.highlightStyle = highlightStyle != null ? highlightStyle : DEFAULT_HIGHLIGHT_STYLE;
             return this;
         }
-        
+
         @JsonProperty(USE_COLORS)
         public Builder useColors(boolean useColors) {
             this.useColors = useColors;
             return this;
         }
-        
+
         @JsonProperty(SHOW_LINE_NUMBERS)
         public Builder showLineNumbers(boolean showLineNumbers) {
             this.showLineNumbers = showLineNumbers;
             return this;
         }
-        
+
         @JsonProperty(MAX_LINE_WIDTH)
         public Builder maxLineWidth(int maxLineWidth) {
             this.maxLineWidth = maxLineWidth;
             return this;
         }
-        
+
         @JsonProperty(SHOW_HEADER)
         public Builder showHeader(boolean showHeader) {
             this.showHeader = showHeader;
             return this;
         }
-        
+
         public DisplayConfig build() {
             return new DisplayConfig(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/ErrorGroupingConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/ErrorGroupingConfig.java
@@ -17,60 +17,62 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 public final class ErrorGroupingConfig {
     private static final boolean DEFAULT_ENABLED = true;
     private static final int DEFAULT_THRESHOLD = 3;
-    
+
     private final boolean enabled;
     private final int threshold;
-    
+
     private ErrorGroupingConfig(Builder builder) {
         this.enabled = builder.enabled;
         this.threshold = builder.threshold;
     }
-    
+
     public boolean isEnabled() {
         return enabled;
     }
-    
+
     public int getThreshold() {
         return threshold;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         ErrorGroupingConfig that = (ErrorGroupingConfig) o;
         return enabled == that.enabled && threshold == that.threshold;
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(enabled, threshold);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private boolean enabled = DEFAULT_ENABLED;
         private int threshold = DEFAULT_THRESHOLD;
-        
+
         private Builder() {
         }
-        
+
         @JsonProperty(ENABLED)
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }
-        
+
         @JsonProperty(THRESHOLD)
         public Builder threshold(int threshold) {
             this.threshold = threshold;
             return this;
         }
-        
+
         public ErrorGroupingConfig build() {
             return new ErrorGroupingConfig(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/HighlightStyle.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/HighlightStyle.java
@@ -11,23 +11,23 @@ public enum HighlightStyle {
      * Underline style using tilde characters.
      */
     UNDERLINE("underline"),
-    
+
     /**
      * No highlighting.
      */
     NONE("none");
-    
+
     private final String value;
-    
+
     HighlightStyle(String value) {
         this.value = value;
     }
-    
+
     @JsonValue
     public String getValue() {
         return value;
     }
-    
+
     @JsonCreator
     public static HighlightStyle fromValue(String value) {
         for (HighlightStyle style : HighlightStyle.values()) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigWrapper.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigWrapper.java
@@ -10,51 +10,52 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMP
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Wrapper class for the output configuration to match the YAML structure.
- * The YAML file has "output" as the root key.
+ * Wrapper class for the output configuration to match the YAML structure. The YAML file has "output" as the root key.
  */
 @JsonDeserialize(builder = OutputConfigWrapper.Builder.class)
 public final class OutputConfigWrapper {
     private final OutputConfiguration output;
-    
+
     private OutputConfigWrapper(Builder builder) {
         this.output = Objects.requireNonNull(builder.output, "[" + getClass().getName() + "] output must not be null");
     }
-    
+
     public OutputConfiguration getOutput() {
         return output;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         OutputConfigWrapper that = (OutputConfigWrapper) o;
         return Objects.equals(output, that.output);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(output);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private OutputConfiguration output;
-        
+
         private Builder() {
         }
-        
+
         @JsonProperty(OUTPUT)
         public Builder output(OutputConfiguration output) {
             this.output = output;
             return this;
         }
-        
+
         public OutputConfigWrapper build() {
             return new OutputConfigWrapper(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfiguration.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfiguration.java
@@ -14,99 +14,90 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.EMP
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
- * Root configuration for console output formatting.
- * This configuration is loaded from a separate YAML file and controls
+ * Root configuration for console output formatting. This configuration is loaded from a separate YAML file and controls
  * how validation results are displayed to the user.
  */
 @JsonDeserialize(builder = OutputConfiguration.Builder.class)
 public final class OutputConfiguration {
     private static final OutputFormat DEFAULT_FORMAT = OutputFormat.ENHANCED;
-    
+
     private final OutputFormat format;
     private final DisplayConfig display;
     private final SuggestionsConfig suggestions;
     private final ErrorGroupingConfig errorGrouping;
     private final SummaryConfig summary;
-    
+
     private OutputConfiguration(Builder builder) {
         this.format = Objects.requireNonNull(builder.format, "[" + getClass().getName() + "] format must not be null");
-        this.display = Objects.requireNonNull(builder.display, "[" + getClass().getName() + "] display must not be null");
-        this.suggestions = Objects.requireNonNull(builder.suggestions, "[" + getClass().getName() + "] suggestions must not be null");
-        this.errorGrouping = Objects.requireNonNull(builder.errorGrouping, "[" + getClass().getName() + "] errorGrouping must not be null");
-        this.summary = Objects.requireNonNull(builder.summary, "[" + getClass().getName() + "] summary must not be null");
+        this.display = Objects.requireNonNull(builder.display,
+                "[" + getClass().getName() + "] display must not be null");
+        this.suggestions = Objects.requireNonNull(builder.suggestions,
+                "[" + getClass().getName() + "] suggestions must not be null");
+        this.errorGrouping = Objects.requireNonNull(builder.errorGrouping,
+                "[" + getClass().getName() + "] errorGrouping must not be null");
+        this.summary = Objects.requireNonNull(builder.summary,
+                "[" + getClass().getName() + "] summary must not be null");
     }
-    
+
     public OutputFormat getFormat() {
         return format;
     }
-    
+
     public DisplayConfig getDisplay() {
         return display;
     }
-    
+
     public SuggestionsConfig getSuggestions() {
         return suggestions;
     }
-    
+
     public ErrorGroupingConfig getErrorGrouping() {
         return errorGrouping;
     }
-    
+
     public SummaryConfig getSummary() {
         return summary;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         OutputConfiguration that = (OutputConfiguration) o;
-        return format == that.format &&
-                Objects.equals(display, that.display) &&
-                Objects.equals(suggestions, that.suggestions) &&
-                Objects.equals(errorGrouping, that.errorGrouping) &&
-                Objects.equals(summary, that.summary);
+        return format == that.format && Objects.equals(display, that.display)
+                && Objects.equals(suggestions, that.suggestions) && Objects.equals(errorGrouping, that.errorGrouping)
+                && Objects.equals(summary, that.summary);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(format, display, suggestions, errorGrouping, summary);
     }
-    
+
     /**
      * Creates a default output configuration with enhanced format.
      */
     public static OutputConfiguration defaultConfig() {
         return builder().build();
     }
-    
+
     /**
      * Creates a compact output configuration for CI/CD environments.
      */
     public static OutputConfiguration compactConfig() {
-        return builder()
-            .format(OutputFormat.COMPACT)
-            .display(DisplayConfig.builder()
-                .contextLines(0)
-                .useColors(false)
-                .showHeader(false)
-                .build())
-            .suggestions(SuggestionsConfig.builder()
-                .enabled(false)
-                .build())
-            .errorGrouping(ErrorGroupingConfig.builder()
-                .enabled(false)
-                .build())
-            .summary(SummaryConfig.builder()
-                .enabled(false)
-                .build())
-            .build();
+        return builder().format(OutputFormat.COMPACT)
+                .display(DisplayConfig.builder().contextLines(0).useColors(false).showHeader(false).build())
+                .suggestions(SuggestionsConfig.builder().enabled(false).build())
+                .errorGrouping(ErrorGroupingConfig.builder().enabled(false).build())
+                .summary(SummaryConfig.builder().enabled(false).build()).build();
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private OutputFormat format = DEFAULT_FORMAT;
@@ -114,40 +105,40 @@ public final class OutputConfiguration {
         private SuggestionsConfig suggestions = SuggestionsConfig.builder().build();
         private ErrorGroupingConfig errorGrouping = ErrorGroupingConfig.builder().build();
         private SummaryConfig summary = SummaryConfig.builder().build();
-        
+
         private Builder() {
         }
-        
+
         @JsonProperty(FORMAT)
         public Builder format(OutputFormat format) {
             this.format = format != null ? format : DEFAULT_FORMAT;
             return this;
         }
-        
+
         @JsonProperty(DISPLAY)
         public Builder display(DisplayConfig display) {
             this.display = display != null ? display : DisplayConfig.builder().build();
             return this;
         }
-        
+
         @JsonProperty(SUGGESTIONS)
         public Builder suggestions(SuggestionsConfig suggestions) {
             this.suggestions = suggestions != null ? suggestions : SuggestionsConfig.builder().build();
             return this;
         }
-        
+
         @JsonProperty(ERROR_GROUPING)
         public Builder errorGrouping(ErrorGroupingConfig errorGrouping) {
             this.errorGrouping = errorGrouping != null ? errorGrouping : ErrorGroupingConfig.builder().build();
             return this;
         }
-        
+
         @JsonProperty(SUMMARY)
         public Builder summary(SummaryConfig summary) {
             this.summary = summary != null ? summary : SummaryConfig.builder().build();
             return this;
         }
-        
+
         public OutputConfiguration build() {
             return new OutputConfiguration(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationException.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationException.java
@@ -5,11 +5,11 @@ package com.dataliquid.asciidoc.linter.config.output;
  */
 public class OutputConfigurationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
-    
+
     public OutputConfigurationException(String message) {
         super(message);
     }
-    
+
     public OutputConfigurationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationLoader.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationLoader.java
@@ -14,17 +14,17 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
  */
 public class OutputConfigurationLoader {
     private static final String SCHEMA_PATH = "/schemas/output/output-config-schema.yaml";
-    
+
     private final ObjectMapper mapper;
     private final OutputSchemaValidator validator;
-    
+
     /**
      * Creates a loader with schema validation enabled.
      */
     public OutputConfigurationLoader() {
         this(false);
     }
-    
+
     /**
      * Creates a loader with optional schema validation.
      */
@@ -32,7 +32,7 @@ public class OutputConfigurationLoader {
         this.mapper = new ObjectMapper(new YAMLFactory());
         this.validator = skipValidation ? null : new OutputSchemaValidator(SCHEMA_PATH);
     }
-    
+
     /**
      * Loads output configuration from a file path.
      */
@@ -41,34 +41,36 @@ public class OutputConfigurationLoader {
         if (!Files.exists(path)) {
             throw new IOException("Configuration file not found: " + filePath);
         }
-        
+
         try (InputStream input = Files.newInputStream(path)) {
             return loadConfiguration(input);
         }
     }
-    
+
     /**
      * Loads output configuration from an input stream.
      */
     public OutputConfiguration loadConfiguration(InputStream input) throws IOException {
         // Parse YAML
         OutputConfigWrapper wrapper = mapper.readValue(input, OutputConfigWrapper.class);
-        
+
         // Validate against schema if enabled
         if (validator != null) {
             String yaml = mapper.writeValueAsString(wrapper);
             validator.validate(yaml);
         }
-        
+
         return wrapper.getOutput();
     }
-    
+
     /**
      * Loads a predefined output configuration from resources.
-     * 
-     * @param format The output format to load configuration for
+     *
+     * @param format
+     *            The output format to load configuration for
      * @return The loaded output configuration
-     * @throws IOException if the configuration cannot be loaded
+     * @throws IOException
+     *             if the configuration cannot be loaded
      */
     public OutputConfiguration loadPredefinedConfiguration(OutputFormat format) throws IOException {
         String resourcePath = "/output-configs/" + format.getValue() + ".yaml";

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputFormat.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputFormat.java
@@ -11,28 +11,28 @@ public enum OutputFormat {
      * Enhanced format with full context, highlighting, and suggestions.
      */
     ENHANCED("enhanced"),
-    
+
     /**
      * Simple format with basic error information.
      */
     SIMPLE("simple"),
-    
+
     /**
      * Compact single-line format for CI/CD environments.
      */
     COMPACT("compact");
-    
+
     private final String value;
-    
+
     OutputFormat(String value) {
         this.value = value;
     }
-    
+
     @JsonValue
     public String getValue() {
         return value;
     }
-    
+
     @JsonCreator
     public static OutputFormat fromValue(String value) {
         for (OutputFormat format : OutputFormat.values()) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/SuggestionsConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/SuggestionsConfig.java
@@ -19,75 +19,75 @@ public final class SuggestionsConfig {
     private static final boolean DEFAULT_ENABLED = true;
     private static final int DEFAULT_MAX_PER_ERROR = 3;
     private static final boolean DEFAULT_SHOW_EXAMPLES = true;
-    
+
     private final boolean enabled;
     private final int maxPerError;
     private final boolean showExamples;
-    
+
     private SuggestionsConfig(Builder builder) {
         this.enabled = builder.enabled;
         this.maxPerError = builder.maxPerError;
         this.showExamples = builder.showExamples;
     }
-    
+
     public boolean isEnabled() {
         return enabled;
     }
-    
+
     public int getMaxPerError() {
         return maxPerError;
     }
-    
+
     public boolean isShowExamples() {
         return showExamples;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         SuggestionsConfig that = (SuggestionsConfig) o;
-        return enabled == that.enabled &&
-                maxPerError == that.maxPerError &&
-                showExamples == that.showExamples;
+        return enabled == that.enabled && maxPerError == that.maxPerError && showExamples == that.showExamples;
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(enabled, maxPerError, showExamples);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private boolean enabled = DEFAULT_ENABLED;
         private int maxPerError = DEFAULT_MAX_PER_ERROR;
         private boolean showExamples = DEFAULT_SHOW_EXAMPLES;
-        
+
         private Builder() {
         }
-        
+
         @JsonProperty(ENABLED)
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }
-        
+
         @JsonProperty(MAX_PER_ERROR)
         public Builder maxPerError(int maxPerError) {
             this.maxPerError = maxPerError;
             return this;
         }
-        
+
         @JsonProperty(SHOW_EXAMPLES)
         public Builder showExamples(boolean showExamples) {
             this.showExamples = showExamples;
             return this;
         }
-        
+
         public SuggestionsConfig build() {
             return new SuggestionsConfig(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/SummaryConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/SummaryConfig.java
@@ -21,89 +21,89 @@ public final class SummaryConfig {
     private static final boolean DEFAULT_SHOW_STATISTICS = true;
     private static final boolean DEFAULT_SHOW_MOST_COMMON = true;
     private static final boolean DEFAULT_SHOW_FILE_LIST = false;
-    
+
     private final boolean enabled;
     private final boolean showStatistics;
     private final boolean showMostCommon;
     private final boolean showFileList;
-    
+
     private SummaryConfig(Builder builder) {
         this.enabled = builder.enabled;
         this.showStatistics = builder.showStatistics;
         this.showMostCommon = builder.showMostCommon;
         this.showFileList = builder.showFileList;
     }
-    
+
     public boolean isEnabled() {
         return enabled;
     }
-    
+
     public boolean isShowStatistics() {
         return showStatistics;
     }
-    
+
     public boolean isShowMostCommon() {
         return showMostCommon;
     }
-    
+
     public boolean isShowFileList() {
         return showFileList;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         SummaryConfig that = (SummaryConfig) o;
-        return enabled == that.enabled &&
-                showStatistics == that.showStatistics &&
-                showMostCommon == that.showMostCommon &&
-                showFileList == that.showFileList;
+        return enabled == that.enabled && showStatistics == that.showStatistics && showMostCommon == that.showMostCommon
+                && showFileList == that.showFileList;
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(enabled, showStatistics, showMostCommon, showFileList);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     @JsonPOJOBuilder(withPrefix = EMPTY)
     public static final class Builder {
         private boolean enabled = DEFAULT_ENABLED;
         private boolean showStatistics = DEFAULT_SHOW_STATISTICS;
         private boolean showMostCommon = DEFAULT_SHOW_MOST_COMMON;
         private boolean showFileList = DEFAULT_SHOW_FILE_LIST;
-        
+
         private Builder() {
         }
-        
+
         @JsonProperty(ENABLED)
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
         }
-        
+
         @JsonProperty(SHOW_STATISTICS)
         public Builder showStatistics(boolean showStatistics) {
             this.showStatistics = showStatistics;
             return this;
         }
-        
+
         @JsonProperty(SHOW_MOST_COMMON)
         public Builder showMostCommon(boolean showMostCommon) {
             this.showMostCommon = showMostCommon;
             return this;
         }
-        
+
         @JsonProperty(SHOW_FILE_LIST)
         public Builder showFileList(boolean showFileList) {
             this.showFileList = showFileList;
             return this;
         }
-        
+
         public SummaryConfig build() {
             return new SummaryConfig(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/AttributeConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/AttributeConfig.java
@@ -31,25 +31,39 @@ public final class AttributeConfig {
     }
 
     @JsonProperty(NAME)
-    public String name() { return name; }
-    
+    public String name() {
+        return name;
+    }
+
     @JsonProperty(ORDER)
-    public Integer order() { return order; }
-    
+    public Integer order() {
+        return order;
+    }
+
     @JsonProperty(REQUIRED)
-    public boolean required() { return required; }
-    
+    public boolean required() {
+        return required;
+    }
+
     @JsonProperty(MIN_LENGTH)
-    public Integer minLength() { return minLength; }
-    
+    public Integer minLength() {
+        return minLength;
+    }
+
     @JsonProperty(MAX_LENGTH)
-    public Integer maxLength() { return maxLength; }
-    
+    public Integer maxLength() {
+        return maxLength;
+    }
+
     @JsonProperty(PATTERN)
-    public String pattern() { return pattern; }
-    
+    public String pattern() {
+        return pattern;
+    }
+
     @JsonProperty(SEVERITY)
-    public Severity severity() { return severity; }
+    public Severity severity() {
+        return severity;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -116,16 +130,14 @@ public final class AttributeConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         AttributeConfig that = (AttributeConfig) o;
-        return required == that.required &&
-               Objects.equals(name, that.name) &&
-               Objects.equals(order, that.order) &&
-               Objects.equals(minLength, that.minLength) &&
-               Objects.equals(maxLength, that.maxLength) &&
-               Objects.equals(pattern, that.pattern) &&
-               severity == that.severity;
+        return required == that.required && Objects.equals(name, that.name) && Objects.equals(order, that.order)
+                && Objects.equals(minLength, that.minLength) && Objects.equals(maxLength, that.maxLength)
+                && Objects.equals(pattern, that.pattern) && severity == that.severity;
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/LineConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/LineConfig.java
@@ -25,13 +25,19 @@ public final class LineConfig {
     }
 
     @JsonProperty(MIN)
-    public Integer min() { return min; }
-    
+    public Integer min() {
+        return min;
+    }
+
     @JsonProperty(MAX)
-    public Integer max() { return max; }
-    
+    public Integer max() {
+        return max;
+    }
+
     @JsonProperty(SEVERITY)
-    public Severity severity() { return severity; }
+    public Severity severity() {
+        return severity;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -68,12 +74,12 @@ public final class LineConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         LineConfig lineRule = (LineConfig) o;
-        return Objects.equals(min, lineRule.min) &&
-               Objects.equals(max, lineRule.max) &&
-               severity == lineRule.severity;
+        return Objects.equals(min, lineRule.min) && Objects.equals(max, lineRule.max) && severity == lineRule.severity;
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/OccurrenceConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/OccurrenceConfig.java
@@ -28,16 +28,24 @@ public final class OccurrenceConfig {
     }
 
     @JsonProperty(ORDER)
-    public Integer order() { return order; }
-    
+    public Integer order() {
+        return order;
+    }
+
     @JsonProperty(MIN)
-    public int min() { return min; }
-    
+    public int min() {
+        return min;
+    }
+
     @JsonProperty(MAX)
-    public int max() { return max; }
-    
+    public int max() {
+        return max;
+    }
+
     @JsonProperty(SEVERITY)
-    public Severity severity() { return severity; }
+    public Severity severity() {
+        return severity;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -81,13 +89,12 @@ public final class OccurrenceConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         OccurrenceConfig that = (OccurrenceConfig) o;
-        return min == that.min &&
-               max == that.max &&
-               Objects.equals(order, that.order) &&
-               severity == that.severity;
+        return min == that.min && max == that.max && Objects.equals(order, that.order) && severity == that.severity;
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/OrderConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/OrderConfig.java
@@ -15,23 +15,34 @@ public final class OrderConfig {
     private final List<OrderConstraint> before;
     private final List<OrderConstraint> after;
     private final Severity severity;
-    
+
     private OrderConfig(Builder builder) {
         this.fixedOrder = Collections.unmodifiableList(new ArrayList<>(builder.fixedOrder));
         this.before = Collections.unmodifiableList(new ArrayList<>(builder.before));
         this.after = Collections.unmodifiableList(new ArrayList<>(builder.after));
         this.severity = builder.severity;
     }
-    
-    public List<String> fixedOrder() { return fixedOrder; }
-    public List<OrderConstraint> before() { return before; }
-    public List<OrderConstraint> after() { return after; }
-    public Severity severity() { return severity; }
-    
+
+    public List<String> fixedOrder() {
+        return fixedOrder;
+    }
+
+    public List<OrderConstraint> before() {
+        return before;
+    }
+
+    public List<OrderConstraint> after() {
+        return after;
+    }
+
+    public Severity severity() {
+        return severity;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     /**
      * Represents an order constraint between two blocks.
      */
@@ -39,94 +50,105 @@ public final class OrderConfig {
         private final String first;
         private final String second;
         private final Severity severity;
-        
+
         private OrderConstraint(String first, String second, Severity severity) {
             this.first = Objects.requireNonNull(first, "[" + getClass().getName() + "] first must not be null");
             this.second = Objects.requireNonNull(second, "[" + getClass().getName() + "] second must not be null");
-            this.severity = Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
+            this.severity = Objects.requireNonNull(severity,
+                    "[" + getClass().getName() + "] severity must not be null");
         }
-        
-        public String first() { return first; }
-        public String second() { return second; }
-        public Severity severity() { return severity; }
-        
+
+        public String first() {
+            return first;
+        }
+
+        public String second() {
+            return second;
+        }
+
+        public Severity severity() {
+            return severity;
+        }
+
         public static OrderConstraint of(String first, String second, Severity severity) {
             return new OrderConstraint(first, second, severity);
         }
-        
+
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             OrderConstraint that = (OrderConstraint) o;
-            return Objects.equals(first, that.first) &&
-                   Objects.equals(second, that.second) &&
-                   severity == that.severity;
+            return Objects.equals(first, that.first) && Objects.equals(second, that.second)
+                    && severity == that.severity;
         }
-        
+
         @Override
         public int hashCode() {
             return Objects.hash(first, second, severity);
         }
     }
-    
+
     public static class Builder {
         private List<String> fixedOrder = new ArrayList<>();
         private List<OrderConstraint> before = new ArrayList<>();
         private List<OrderConstraint> after = new ArrayList<>();
         private Severity severity = Severity.ERROR;
-        
+
         public Builder fixedOrder(List<String> fixedOrder) {
             this.fixedOrder = fixedOrder != null ? new ArrayList<>(fixedOrder) : new ArrayList<>();
             return this;
         }
-        
+
         public Builder addFixedOrder(String blockName) {
             this.fixedOrder.add(blockName);
             return this;
         }
-        
+
         public Builder before(List<OrderConstraint> before) {
             this.before = before != null ? new ArrayList<>(before) : new ArrayList<>();
             return this;
         }
-        
+
         public Builder addBefore(String first, String second, Severity severity) {
             this.before.add(OrderConstraint.of(first, second, severity));
             return this;
         }
-        
+
         public Builder after(List<OrderConstraint> after) {
             this.after = after != null ? new ArrayList<>(after) : new ArrayList<>();
             return this;
         }
-        
+
         public Builder addAfter(String first, String second, Severity severity) {
             this.after.add(OrderConstraint.of(first, second, severity));
             return this;
         }
-        
+
         public Builder severity(Severity severity) {
-            this.severity = Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
+            this.severity = Objects.requireNonNull(severity,
+                    "[" + getClass().getName() + "] severity must not be null");
             return this;
         }
-        
+
         public OrderConfig build() {
             return new OrderConfig(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         OrderConfig that = (OrderConfig) o;
-        return Objects.equals(fixedOrder, that.fixedOrder) &&
-               Objects.equals(before, that.before) &&
-               Objects.equals(after, that.after) &&
-               severity == that.severity;
+        return Objects.equals(fixedOrder, that.fixedOrder) && Objects.equals(before, that.before)
+                && Objects.equals(after, that.after) && severity == that.severity;
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(fixedOrder, before, after, severity);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/SectionConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/SectionConfig.java
@@ -37,25 +37,39 @@ public final class SectionConfig {
     }
 
     @JsonProperty(NAME)
-    public String name() { return name; }
-    
+    public String name() {
+        return name;
+    }
+
     @JsonProperty(ORDER)
-    public Integer order() { return order; }
-    
+    public Integer order() {
+        return order;
+    }
+
     @JsonProperty(LEVEL)
-    public int level() { return level; }
-    
+    public int level() {
+        return level;
+    }
+
     @JsonProperty(OCCURRENCE)
-    public OccurrenceConfig occurrence() { return occurrence; }
-    
+    public OccurrenceConfig occurrence() {
+        return occurrence;
+    }
+
     @JsonProperty(TITLE)
-    public TitleConfig title() { return title; }
-    
+    public TitleConfig title() {
+        return title;
+    }
+
     @JsonProperty(ALLOWED_BLOCKS)
-    public List<Block> allowedBlocks() { return allowedBlocks; }
-    
+    public List<Block> allowedBlocks() {
+        return allowedBlocks;
+    }
+
     @JsonProperty(SUBSECTIONS)
-    public List<SectionConfig> subsections() { return subsections; }
+    public List<SectionConfig> subsections() {
+        return subsections;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -131,16 +145,14 @@ public final class SectionConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         SectionConfig that = (SectionConfig) o;
-        return level == that.level &&
-               Objects.equals(occurrence, that.occurrence) &&
-               Objects.equals(name, that.name) &&
-               Objects.equals(order, that.order) &&
-               Objects.equals(title, that.title) &&
-               Objects.equals(allowedBlocks, that.allowedBlocks) &&
-               Objects.equals(subsections, that.subsections);
+        return level == that.level && Objects.equals(occurrence, that.occurrence) && Objects.equals(name, that.name)
+                && Objects.equals(order, that.order) && Objects.equals(title, that.title)
+                && Objects.equals(allowedBlocks, that.allowedBlocks) && Objects.equals(subsections, that.subsections);
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/TitleConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/TitleConfig.java
@@ -22,10 +22,14 @@ public final class TitleConfig {
     }
 
     @JsonProperty(PATTERN)
-    public String pattern() { return pattern; }
-    
+    public String pattern() {
+        return pattern;
+    }
+
     @JsonProperty(SEVERITY)
-    public Severity severity() { return severity; }
+    public Severity severity() {
+        return severity;
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -44,7 +48,8 @@ public final class TitleConfig {
 
         @JsonProperty(SEVERITY)
         public Builder severity(Severity severity) {
-            this.severity = Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
+            this.severity = Objects.requireNonNull(severity,
+                    "[" + getClass().getName() + "] severity must not be null");
             return this;
         }
 
@@ -58,11 +63,12 @@ public final class TitleConfig {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         TitleConfig that = (TitleConfig) o;
-        return Objects.equals(pattern, that.pattern) &&
-               severity == that.severity;
+        return Objects.equals(pattern, that.pattern) && severity == that.severity;
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleSchemaValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleSchemaValidator.java
@@ -23,15 +23,15 @@ import com.networknt.schema.ValidationMessage;
  */
 public class RuleSchemaValidator {
     private static final String SCHEMA_PATH = "/schemas/rules/linter-config-schema.yaml";
-    
+
     private final JsonSchema schema;
     private final ObjectMapper yamlMapper;
-    
+
     public RuleSchemaValidator() {
         this.yamlMapper = new ObjectMapper(new YAMLFactory());
         this.schema = loadSchema();
     }
-    
+
     private JsonSchema loadSchema() {
         try {
             // Load the main schema from classpath
@@ -39,76 +39,76 @@ public class RuleSchemaValidator {
             if (schemaStream == null) {
                 throw new RuleValidationException("Schema not found: " + SCHEMA_PATH);
             }
-            
+
             // Convert YAML schema to JSON
             JsonNode schemaNode = yamlMapper.readTree(schemaStream);
-            
+
             // Get the current classloader base URL for mapping
             String baseClasspathUrl = getClass().getResource("/schemas/").toString();
-            
+
             // Configure JsonSchemaFactory for JSON Schema 2020-12 with schema mappings
             JsonSchemaFactory factory = JsonSchemaFactory.builder()
-                .defaultMetaSchemaIri(JsonMetaSchema.getV202012().getIri())
-                .schemaMappers(schemaMappers -> {
-                    // Map HTTPS references to actual classpath URLs
-                    schemaMappers.mapPrefix("https://dataliquid.com/asciidoc/linter/schemas/", baseClasspathUrl);
-                })
-                .metaSchema(JsonMetaSchema.getV202012())
-                .build();
-            
+                    .defaultMetaSchemaIri(JsonMetaSchema.getV202012().getIri()).schemaMappers(schemaMappers -> {
+                        // Map HTTPS references to actual classpath URLs
+                        schemaMappers.mapPrefix("https://dataliquid.com/asciidoc/linter/schemas/", baseClasspathUrl);
+                    }).metaSchema(JsonMetaSchema.getV202012()).build();
+
             // Configure validators
-            SchemaValidatorsConfig config = SchemaValidatorsConfig.builder()
-                .pathType(PathType.JSON_POINTER)
-                .build();
-            
+            SchemaValidatorsConfig config = SchemaValidatorsConfig.builder().pathType(PathType.JSON_POINTER).build();
+
             // Load schema with the resource URL as base URI
             URI schemaUri = getClass().getResource(SCHEMA_PATH).toURI();
             return factory.getSchema(schemaUri, schemaNode, config);
-            
+
         } catch (IOException | URISyntaxException e) {
             throw new RuleValidationException("Failed to load schema", e);
         }
     }
-    
+
     /**
      * Validates a user configuration file against the schema.
-     * 
-     * @param userConfigFile the user's configuration file
-     * @throws RuleValidationException if validation fails
+     *
+     * @param userConfigFile
+     *            the user's configuration file
+     * @throws RuleValidationException
+     *             if validation fails
      */
     public void validateUserConfig(Path userConfigFile) throws RuleValidationException {
         if (!Files.exists(userConfigFile)) {
             throw new RuleValidationException("Configuration file not found: " + userConfigFile);
         }
-        
+
         try {
             JsonNode configNode = yamlMapper.readTree(userConfigFile.toFile());
             validateUserConfig(configNode);
         } catch (IOException e) {
-            throw new RuleValidationException(
-                "Failed to read configuration file: " + userConfigFile, e);
+            throw new RuleValidationException("Failed to read configuration file: " + userConfigFile, e);
         }
     }
-    
+
     /**
      * Validates a user configuration JsonNode against the schema.
-     * 
-     * @param userConfigNode the configuration as JsonNode
-     * @throws RuleValidationException if validation fails
+     *
+     * @param userConfigNode
+     *            the configuration as JsonNode
+     * @throws RuleValidationException
+     *             if validation fails
      */
     public void validateUserConfig(JsonNode userConfigNode) throws RuleValidationException {
         Set<ValidationMessage> messages = schema.validate(userConfigNode);
-        
+
         if (!messages.isEmpty()) {
             throw new RuleValidationException(formatErrors(messages));
         }
     }
-    
+
     /**
      * Validates a user configuration from an InputStream.
-     * 
-     * @param yamlStream the YAML configuration stream
-     * @throws RuleValidationException if validation fails
+     *
+     * @param yamlStream
+     *            the YAML configuration stream
+     * @throws RuleValidationException
+     *             if validation fails
      */
     public void validateUserConfig(InputStream yamlStream) throws RuleValidationException {
         try {
@@ -118,12 +118,14 @@ public class RuleSchemaValidator {
             throw new RuleValidationException("Failed to parse YAML configuration", e);
         }
     }
-    
+
     /**
      * Validates a user configuration from a YAML string.
-     * 
-     * @param yamlContent the YAML configuration as string
-     * @throws RuleValidationException if validation fails
+     *
+     * @param yamlContent
+     *            the YAML configuration as string
+     * @throws RuleValidationException
+     *             if validation fails
      */
     public void validateYamlString(String yamlContent) throws RuleValidationException {
         try {
@@ -133,14 +135,14 @@ public class RuleSchemaValidator {
             throw new RuleValidationException("Failed to parse YAML configuration string", e);
         }
     }
-    
+
     private String formatErrors(Set<ValidationMessage> messages) {
         StringBuilder sb = new StringBuilder("User configuration does not match schema:");
-        
+
         for (ValidationMessage msg : messages) {
             sb.append("\n\n  Error at ").append(msg.getInstanceLocation()).append(":");
             sb.append("\n    ").append(msg.getMessage());
-            
+
             // Add helpful context for common errors
             if ("enum".equals(msg.getType())) {
                 sb.append("\n    Valid values: error, warn, info");
@@ -150,7 +152,7 @@ public class RuleSchemaValidator {
                 sb.append("\n    Check the allowed range");
             }
         }
-        
+
         return sb.toString();
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleValidationException.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleValidationException.java
@@ -5,13 +5,13 @@ package com.dataliquid.asciidoc.linter.config.validation;
  */
 public class RuleValidationException extends RuntimeException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	public RuleValidationException(String message) {
-		super(message);
-	}
+    public RuleValidationException(String message) {
+        super(message);
+    }
 
-	public RuleValidationException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public RuleValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleValidationResult.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleValidationResult.java
@@ -12,38 +12,33 @@ import com.networknt.schema.ValidationMessage;
  */
 public class RuleValidationResult {
     private final List<ValidationError> errors;
-    
+
     private RuleValidationResult(List<ValidationError> errors) {
         this.errors = Collections.unmodifiableList(errors);
     }
-    
+
     public boolean isValid() {
         return errors.isEmpty();
     }
-    
+
     public List<ValidationError> getErrors() {
         return errors;
     }
-    
+
     /**
      * Creates a result from networknt validation messages.
      */
     public static RuleValidationResult from(Set<ValidationMessage> messages) {
-        List<ValidationError> errors = messages.stream()
-            .map(RuleValidationResult::convertMessage)
-            .collect(Collectors.toList());
-            
+        List<ValidationError> errors = messages.stream().map(RuleValidationResult::convertMessage)
+                .collect(Collectors.toList());
+
         return new RuleValidationResult(errors);
     }
-    
+
     private static ValidationError convertMessage(ValidationMessage msg) {
-        return new ValidationError(
-            msg.getInstanceLocation().toString(),
-            msg.getMessage(),
-            msg.getType()
-        );
+        return new ValidationError(msg.getInstanceLocation().toString(), msg.getMessage(), msg.getType());
     }
-    
+
     /**
      * Represents a single validation error.
      */
@@ -51,25 +46,25 @@ public class RuleValidationResult {
         private final String path;
         private final String message;
         private final String keyword;
-        
+
         public ValidationError(String path, String message, String keyword) {
             this.path = path;
             this.message = message;
             this.keyword = keyword;
         }
-        
+
         public String getPath() {
             return path;
         }
-        
+
         public String getMessage() {
             return message;
         }
-        
+
         public String getKeyword() {
             return keyword;
         }
-        
+
         public String format() {
             return String.format("  - %s: %s", path, message);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/DocumentationFormat.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/DocumentationFormat.java
@@ -4,28 +4,27 @@ package com.dataliquid.asciidoc.linter.documentation;
  * Supported documentation output formats.
  */
 public enum DocumentationFormat {
-    ASCIIDOC(".adoc", "AsciiDoc", "text/asciidoc"),
-    MARKDOWN(".md", "Markdown", "text/markdown"),
-    HTML(".html", "HTML", "text/html");
-    
+    ASCIIDOC(".adoc", "AsciiDoc", "text/asciidoc"), MARKDOWN(".md", "Markdown", "text/markdown"), HTML(".html", "HTML",
+            "text/html");
+
     private final String extension;
     private final String displayName;
     private final String mimeType;
-    
+
     DocumentationFormat(String extension, String displayName, String mimeType) {
         this.extension = extension;
         this.displayName = displayName;
         this.mimeType = mimeType;
     }
-    
+
     public String getExtension() {
         return extension;
     }
-    
+
     public String getDisplayName() {
         return displayName;
     }
-    
+
     public String getMimeType() {
         return mimeType;
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/HierarchyVisualizer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/HierarchyVisualizer.java
@@ -8,18 +8,20 @@ import com.dataliquid.asciidoc.linter.config.LinterConfiguration;
  * Interface for visualizing rule hierarchies in documentation.
  */
 public interface HierarchyVisualizer {
-    
+
     /**
      * Visualizes the rule hierarchy from the given configuration.
-     * 
-     * @param config the linter configuration
-     * @param writer the output writer
+     *
+     * @param config
+     *            the linter configuration
+     * @param writer
+     *            the output writer
      */
     void visualize(LinterConfiguration config, PrintWriter writer);
-    
+
     /**
      * Returns the visualization style this visualizer implements.
-     * 
+     *
      * @return the visualization style
      */
     VisualizationStyle getStyle();

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/HierarchyVisualizerFactory.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/HierarchyVisualizerFactory.java
@@ -12,27 +12,29 @@ import com.dataliquid.asciidoc.linter.documentation.visualizers.TreeVisualizer;
  * Factory for creating hierarchy visualizers.
  */
 public class HierarchyVisualizerFactory {
-    
+
     private final Map<VisualizationStyle, HierarchyVisualizer> visualizers;
-    
+
     public HierarchyVisualizerFactory() {
         this.visualizers = new HashMap<>();
         registerVisualizers();
     }
-    
+
     private void registerVisualizers() {
         visualizers.put(VisualizationStyle.TREE, new TreeVisualizer());
         visualizers.put(VisualizationStyle.NESTED, new NestedListVisualizer());
         visualizers.put(VisualizationStyle.BREADCRUMB, new BreadcrumbVisualizer());
         visualizers.put(VisualizationStyle.TABLE, new TableVisualizer());
     }
-    
+
     /**
      * Creates a visualizer for the specified style.
-     * 
-     * @param style the visualization style
+     *
+     * @param style
+     *            the visualization style
      * @return the visualizer
-     * @throws IllegalArgumentException if no visualizer exists for the style
+     * @throws IllegalArgumentException
+     *             if no visualizer exists for the style
      */
     public HierarchyVisualizer create(VisualizationStyle style) {
         HierarchyVisualizer visualizer = visualizers.get(style);
@@ -41,11 +43,12 @@ public class HierarchyVisualizerFactory {
         }
         return visualizer;
     }
-    
+
     /**
      * Checks if a visualizer is available for the specified style.
-     * 
-     * @param style the visualization style
+     *
+     * @param style
+     *            the visualization style
      * @return true if a visualizer exists, false otherwise
      */
     public boolean hasVisualizer(VisualizationStyle style) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/PatternHumanizer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/PatternHumanizer.java
@@ -8,40 +8,42 @@ import java.util.regex.Pattern;
  * Converts regular expression patterns into human-readable descriptions.
  */
 public class PatternHumanizer {
-    
+
     private final Map<String, String> knownPatterns;
-    
+
     public PatternHumanizer() {
         this.knownPatterns = new HashMap<>();
         initializeKnownPatterns();
     }
-    
+
     private void initializeKnownPatterns() {
         // Common patterns
         knownPatterns.put("^[A-Z].*", "Must start with an uppercase letter");
         knownPatterns.put("^[a-z].*", "Must start with a lowercase letter");
         knownPatterns.put("^\\d+\\.\\d+\\.\\d+$", "Semantic Versioning Format (e.g. 1.0.0)");
         knownPatterns.put("^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$", "Valid email address");
-        
+
         // URL patterns
         knownPatterns.put("^https?://.*", "Must start with http:// or https://");
         knownPatterns.put(".*\\.(png|jpg|jpeg|gif|svg)$", "Image file (PNG, JPG, JPEG, GIF or SVG)");
         knownPatterns.put(".*\\.(mp3|ogg|wav|m4a)$", "Audio file (MP3, OGG, WAV or M4A)");
-        
+
         // Title patterns
         knownPatterns.put("^(Introduction|Einführung)$", "Must be 'Introduction' or 'Einführung'");
         knownPatterns.put("^Listing \\d+:.*", "Must start with 'Listing' followed by a number and colon");
         knownPatterns.put("^Table \\d+:.*", "Must start with 'Table' followed by a number and colon");
         knownPatterns.put("^Figure \\d+:.*", "Must start with 'Figure' followed by a number and colon");
-        
+
         // Language patterns
-        knownPatterns.put("^(java|python|javascript|yaml|json|xml)$", "Allowed languages: java, python, javascript, yaml, json, xml");
+        knownPatterns.put("^(java|python|javascript|yaml|json|xml)$",
+                "Allowed languages: java, python, javascript, yaml, json, xml");
     }
-    
+
     /**
      * Converts a regex pattern to a human-readable description.
-     * 
-     * @param pattern the pattern to humanize
+     *
+     * @param pattern
+     *            the pattern to humanize
      * @return a human-readable description
      */
     public String humanize(Pattern pattern) {
@@ -50,43 +52,43 @@ public class PatternHumanizer {
         }
         return humanize(pattern.pattern());
     }
-    
+
     /**
      * Converts a regex pattern string to a human-readable description.
-     * 
-     * @param patternString the pattern string to humanize
+     *
+     * @param patternString
+     *            the pattern string to humanize
      * @return a human-readable description
      */
     public String humanize(String patternString) {
         if (patternString == null || patternString.isEmpty()) {
             return "";
         }
-        
+
         // Check known patterns first
         String known = knownPatterns.get(patternString);
         if (known != null) {
             return known;
         }
-        
+
         // Try to generate description for common patterns
         String description = generateDescription(patternString);
         if (description != null) {
             return description;
         }
-        
+
         // Fallback: show the pattern itself
         return "Must match pattern: " + patternString;
     }
-    
+
     private String generateDescription(String pattern) {
         // Handle file extensions
         if (pattern.matches(".*\\\\\\.(\\w+\\|)*\\w+\\)\\$")) {
-            String extensions = pattern.replaceAll(".*\\\\\\.(\\()?", "")
-                                     .replaceAll("\\)\\$", "")
-                                     .replaceAll("\\|", ", ");
+            String extensions = pattern.replaceAll(".*\\\\\\.(\\()?", "").replaceAll("\\)\\$", "").replaceAll("\\|",
+                    ", ");
             return "File extension must be: " + extensions.toUpperCase();
         }
-        
+
         // Handle simple starts-with patterns
         if (pattern.startsWith("^") && !pattern.contains("$")) {
             String prefix = pattern.substring(1).replaceAll("\\\\_", "_");
@@ -94,7 +96,7 @@ public class PatternHumanizer {
                 return "Must start with '" + prefix + "'";
             }
         }
-        
+
         // Handle simple ends-with patterns
         if (pattern.endsWith("$") && !pattern.startsWith("^")) {
             String suffix = pattern.substring(0, pattern.length() - 1);
@@ -102,7 +104,7 @@ public class PatternHumanizer {
                 return "Must end with '" + suffix + "'";
             }
         }
-        
+
         // Handle exact match patterns
         if (pattern.startsWith("^") && pattern.endsWith("$")) {
             String exact = pattern.substring(1, pattern.length() - 1);
@@ -110,7 +112,7 @@ public class PatternHumanizer {
                 return "Must be exactly '" + exact + "'";
             }
         }
-        
+
         // Handle character class patterns
         if (pattern.equals("^[A-Za-z]+$")) {
             return "Only letters allowed";
@@ -121,15 +123,17 @@ public class PatternHumanizer {
         if (pattern.equals("^[A-Za-z0-9]+$")) {
             return "Only letters and numbers allowed";
         }
-        
+
         return null;
     }
-    
+
     /**
      * Registers a custom pattern description.
-     * 
-     * @param pattern the regex pattern
-     * @param description the human-readable description
+     *
+     * @param pattern
+     *            the regex pattern
+     * @param description
+     *            the human-readable description
      */
     public void registerPattern(String pattern, String description) {
         knownPatterns.put(pattern, description);

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/RuleDocumentationGenerator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/RuleDocumentationGenerator.java
@@ -6,30 +6,34 @@ import com.dataliquid.asciidoc.linter.config.LinterConfiguration;
 
 /**
  * Interface for generating human-readable documentation from linter configuration rules.
- * 
- * <p>Implementations of this interface convert YAML-based linter rules into
- * documentation formats suitable for content authors.</p>
+ *
+ * <p>
+ * Implementations of this interface convert YAML-based linter rules into documentation formats suitable for content
+ * authors.
+ * </p>
  */
 public interface RuleDocumentationGenerator {
-    
+
     /**
      * Generates documentation from the given linter configuration.
-     * 
-     * @param config the linter configuration containing all rules
-     * @param writer the writer to output the documentation to
+     *
+     * @param config
+     *            the linter configuration containing all rules
+     * @param writer
+     *            the writer to output the documentation to
      */
     void generate(LinterConfiguration config, PrintWriter writer);
-    
+
     /**
      * Returns the documentation format this generator produces.
-     * 
+     *
      * @return the documentation format
      */
     DocumentationFormat getFormat();
-    
+
     /**
      * Returns the name of this generator for display purposes.
-     * 
+     *
      * @return the generator name
      */
     String getName();

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/VisualizationStyle.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/VisualizationStyle.java
@@ -4,29 +4,27 @@ package com.dataliquid.asciidoc.linter.documentation;
  * Available visualization styles for rule hierarchy documentation.
  */
 public enum VisualizationStyle {
-    TREE("tree", "ASCII-art tree structure"),
-    NESTED("nested", "Nested lists with severity indicators"),
-    BREADCRUMB("breadcrumb", "Path-style representation"),
-    TABLE("table", "Hierarchical table with indentation"),
-    PLANTUML("plantuml", "PlantUML diagram"),
-    SEVERITY_FLOW("severity-flow", "Severity inheritance visualization");
-    
+    TREE("tree", "ASCII-art tree structure"), NESTED("nested", "Nested lists with severity indicators"), BREADCRUMB(
+            "breadcrumb",
+            "Path-style representation"), TABLE("table", "Hierarchical table with indentation"), PLANTUML("plantuml",
+                    "PlantUML diagram"), SEVERITY_FLOW("severity-flow", "Severity inheritance visualization");
+
     private final String name;
     private final String description;
-    
+
     VisualizationStyle(String name, String description) {
         this.name = name;
         this.description = description;
     }
-    
+
     public String getName() {
         return name;
     }
-    
+
     public String getDescription() {
         return description;
     }
-    
+
     public static VisualizationStyle fromName(String name) {
         for (VisualizationStyle style : values()) {
             if (style.name.equalsIgnoreCase(name)) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/BreadcrumbVisualizer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/BreadcrumbVisualizer.java
@@ -18,123 +18,120 @@ import com.dataliquid.asciidoc.linter.documentation.VisualizationStyle;
  * Visualizes rule hierarchy as breadcrumb paths.
  */
 public class BreadcrumbVisualizer implements HierarchyVisualizer {
-    
+
     private static class RulePath {
         final String path;
         final Severity severity;
         final String description;
-        
+
         RulePath(String path, Severity severity, String description) {
             this.path = path;
             this.severity = severity;
             this.description = description;
         }
     }
-    
+
     @Override
     public void visualize(LinterConfiguration config, PrintWriter writer) {
         List<RulePath> paths = collectAllPaths(config.document());
-        
+
         writer.println("[%header,cols=\"3,1,2\"]");
         writer.println("|===");
         writer.println("|Rule Path |Severity |Description");
         writer.println();
-        
+
         for (RulePath path : paths) {
             writer.println("|`" + path.path + "`");
             writer.println("|" + path.severity);
             writer.println("|" + path.description);
             writer.println();
         }
-        
+
         writer.println("|===");
     }
-    
+
     @Override
     public VisualizationStyle getStyle() {
         return VisualizationStyle.BREADCRUMB;
     }
-    
+
     private List<RulePath> collectAllPaths(DocumentConfiguration doc) {
         List<RulePath> paths = new ArrayList<>();
-        
+
         // Add document root
         paths.add(new RulePath("document", null, "Document root"));
-        
+
         // Collect metadata paths
         if (doc.metadata() != null) {
             collectMetadataPaths(doc.metadata(), "document", paths);
         }
-        
+
         // Collect section paths
         if (doc.sections() != null) {
-            paths.add(new RulePath("document > sections", Severity.ERROR, 
-                                  "Sections (at least one required)"));
-            
+            paths.add(new RulePath("document > sections", Severity.ERROR, "Sections (at least one required)"));
+
             for (SectionConfig section : doc.sections()) {
                 collectSectionPaths(section, "document > sections", paths);
             }
         }
-        
+
         return paths;
     }
-    
-    private void collectMetadataPaths(MetadataConfiguration metadata, String parentPath, 
-                                     List<RulePath> paths) {
+
+    private void collectMetadataPaths(MetadataConfiguration metadata, String parentPath, List<RulePath> paths) {
         String metadataPath = parentPath + " > metadata";
         paths.add(new RulePath(metadataPath, Severity.ERROR, "Metadata container (required)"));
-        
+
         if (metadata.attributes() != null) {
             for (AttributeConfig attr : metadata.attributes()) {
                 String attrPath = metadataPath + " > " + attr.name();
-                String description = getAttributeDescription(attr) + 
-                                   " (" + (attr.required() ? "Required" : "Optional") + ")";
+                String description = getAttributeDescription(attr) + " (" + (attr.required() ? "Required" : "Optional")
+                        + ")";
                 paths.add(new RulePath(attrPath, attr.severity(), description));
             }
         }
     }
-    
-    private void collectSectionPaths(SectionConfig section, String parentPath, 
-                                    List<RulePath> paths) {
+
+    private void collectSectionPaths(SectionConfig section, String parentPath, List<RulePath> paths) {
         String sectionPath = parentPath + " > " + section.name();
-        String description = getSectionDescription(section) + 
-                           " (Level " + section.level() + ")";
-        Severity severity = (section.occurrence() != null && section.occurrence().min() > 0) ? 
-                          Severity.ERROR : Severity.INFO;
-        
+        String description = getSectionDescription(section) + " (Level " + section.level() + ")";
+        Severity severity = (section.occurrence() != null && section.occurrence().min() > 0)
+                ? Severity.ERROR
+                : Severity.INFO;
+
         paths.add(new RulePath(sectionPath, severity, description));
-        
+
         // Collect allowed blocks
         if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
             String blocksPath = sectionPath + " > allowedBlocks";
             paths.add(new RulePath(blocksPath, null, "Allowed block types"));
-            
+
             for (Block block : section.allowedBlocks()) {
                 collectBlockPaths(block, blocksPath, paths);
             }
         }
-        
+
         // Collect subsections
         if (section.subsections() != null && !section.subsections().isEmpty()) {
             String subsectionsPath = sectionPath + " > subsections";
             paths.add(new RulePath(subsectionsPath, null, "Subsections"));
-            
+
             for (SectionConfig subsection : section.subsections()) {
                 collectSectionPaths(subsection, subsectionsPath, paths);
             }
         }
     }
-    
+
     private void collectBlockPaths(Block block, String parentPath, List<RulePath> paths) {
         String blockPath = parentPath + " > " + block.getType().toValue();
         String description = getBlockDescription(block);
-        
+
         paths.add(new RulePath(blockPath, block.getSeverity(), description));
-        
+
         // Add block-specific rule paths
         collectBlockRulePaths(block, blockPath, paths);
     }
-    
+
     private void collectBlockRulePaths(Block block, String blockPath, List<RulePath> paths) {
         // TODO: Add specific rule paths based on block type
         // For example, for AudioBlock:
@@ -142,16 +139,17 @@ public class BreadcrumbVisualizer implements HierarchyVisualizer {
         // - blockPath > options > autoplay
         // - blockPath > options > controls
         // - blockPath > title
-        
+
         if (block.getOccurrence() != null) {
             String occurrencePath = blockPath + " > occurrence";
             String description = "Occurrence constraints";
-            Severity severity = block.getOccurrence().severity() != null ? 
-                              block.getOccurrence().severity() : block.getSeverity();
+            Severity severity = block.getOccurrence().severity() != null
+                    ? block.getOccurrence().severity()
+                    : block.getSeverity();
             paths.add(new RulePath(occurrencePath, severity, description));
         }
     }
-    
+
     private String getAttributeDescription(AttributeConfig attr) {
         return switch (attr.name()) {
             case "title" -> "Document title";
@@ -161,7 +159,7 @@ public class BreadcrumbVisualizer implements HierarchyVisualizer {
             default -> attr.name();
         };
     }
-    
+
     private String getSectionDescription(SectionConfig section) {
         return switch (section.name()) {
             case "introduction" -> "Introduction section";
@@ -170,7 +168,7 @@ public class BreadcrumbVisualizer implements HierarchyVisualizer {
             default -> section.name();
         };
     }
-    
+
     private String getBlockDescription(Block block) {
         String desc = switch (block.getType()) {
             case PARAGRAPH -> "Text paragraphs";
@@ -183,11 +181,11 @@ public class BreadcrumbVisualizer implements HierarchyVisualizer {
             case LITERAL -> "Literal blocks";
             default -> "Block type " + block.getType().toValue();
         };
-        
+
         if (block.getName() != null) {
             desc += " (" + block.getName() + ")";
         }
-        
+
         return desc;
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/NestedListVisualizer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/NestedListVisualizer.java
@@ -17,38 +17,38 @@ import com.dataliquid.asciidoc.linter.documentation.VisualizationStyle;
  * Visualizes rule hierarchy as nested lists with severity indicators.
  */
 public class NestedListVisualizer implements HierarchyVisualizer {
-    
+
     @Override
     public void visualize(LinterConfiguration config, PrintWriter writer) {
         writer.println("=== icon:file-alt[] Document Level");
         writer.println();
-        
+
         DocumentConfiguration doc = config.document();
         if (doc.metadata() != null) {
             visualizeMetadata(doc.metadata(), writer);
         }
-        
+
         if (doc.sections() != null && !doc.sections().isEmpty()) {
             visualizeSections(doc.sections(), "", writer);
         }
     }
-    
+
     @Override
     public VisualizationStyle getStyle() {
         return VisualizationStyle.NESTED;
     }
-    
+
     private void visualizeMetadata(MetadataConfiguration metadata, PrintWriter writer) {
         writer.println("* " + getSeverityIcon(Severity.ERROR) + " **metadata** _(Required)_");
-        
+
         if (metadata.attributes() != null) {
             for (AttributeConfig attr : metadata.attributes()) {
                 String icon = getSeverityIcon(attr.severity());
                 String required = attr.required() ? "Required" : "Optional";
-                
+
                 writer.println("** " + icon + " **" + attr.name() + "** - " + getAttributeDescription(attr));
                 writer.println("*** " + required);
-                
+
                 if (attr.minLength() != null || attr.maxLength() != null) {
                     writer.print("*** ");
                     if (attr.minLength() != null) {
@@ -62,7 +62,7 @@ public class NestedListVisualizer implements HierarchyVisualizer {
                     }
                     writer.println(" characters");
                 }
-                
+
                 if (attr.pattern() != null) {
                     writer.println("*** Pattern: " + attr.pattern());
                 }
@@ -70,35 +70,34 @@ public class NestedListVisualizer implements HierarchyVisualizer {
         }
         writer.println();
     }
-    
-    private void visualizeSections(List<SectionConfig> sections, String indent, 
-                                  PrintWriter writer) {
+
+    private void visualizeSections(List<SectionConfig> sections, String indent, PrintWriter writer) {
         writer.println(indent + "* icon:folder[] **sections** _(Required)_");
-        
+
         for (SectionConfig section : sections) {
             visualizeSection(section, indent + "*", writer);
         }
     }
-    
+
     private void visualizeSection(SectionConfig section, String indent, PrintWriter writer) {
-        String required = (section.occurrence() != null && section.occurrence().min() > 0) ? 
-            getSeverityIcon(Severity.ERROR) : getSeverityIcon(Severity.INFO);
-        
-        writer.println(indent + " " + required + " **" + section.name() + "** - " + 
-                      getSectionDescription(section));
+        String required = (section.occurrence() != null && section.occurrence().min() > 0)
+                ? getSeverityIcon(Severity.ERROR)
+                : getSeverityIcon(Severity.INFO);
+
+        writer.println(indent + " " + required + " **" + section.name() + "** - " + getSectionDescription(section));
         writer.println(indent + "* Level: " + section.level());
-        
+
         if (section.order() != null) {
             writer.println(indent + "* Position: " + section.order());
         }
-        
+
         if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
             writer.println(indent + "* icon:cubes[] **allowedBlocks**");
             for (Block block : section.allowedBlocks()) {
                 visualizeBlock(block, indent + "**", writer);
             }
         }
-        
+
         if (section.subsections() != null && !section.subsections().isEmpty()) {
             writer.println(indent + "* **subsections**");
             for (SectionConfig subsection : section.subsections()) {
@@ -106,15 +105,15 @@ public class NestedListVisualizer implements HierarchyVisualizer {
             }
         }
     }
-    
+
     private void visualizeBlock(Block block, String indent, PrintWriter writer) {
         String blockIcon = getBlockIcon(block);
-        
+
         writer.print(indent + " " + blockIcon + " **" + block.getType().toValue() + "**");
         if (block.getName() != null) {
             writer.print(" (" + block.getName() + ")");
         }
-        
+
         if (block.getOccurrence() != null) {
             writer.print(" (");
             int min = block.getOccurrence().min();
@@ -129,18 +128,17 @@ public class NestedListVisualizer implements HierarchyVisualizer {
             writer.print(")");
         }
         writer.println();
-        
+
         // Add block-specific rules
         visualizeBlockRules(block, indent + "*", writer);
     }
-    
+
     private void visualizeBlockRules(Block block, String indent, PrintWriter writer) {
         // TODO: Add specific rules based on block type
         // For now, just show severity if it differs from default
-        writer.println(indent + " " + getSeverityIcon(block.getSeverity()) + 
-                      " Severity: " + block.getSeverity());
+        writer.println(indent + " " + getSeverityIcon(block.getSeverity()) + " Severity: " + block.getSeverity());
     }
-    
+
     private String getSeverityIcon(Severity severity) {
         return switch (severity) {
             case ERROR -> "icon:times-circle[role=\"red\"]";
@@ -148,7 +146,7 @@ public class NestedListVisualizer implements HierarchyVisualizer {
             case INFO -> "icon:info-circle[role=\"blue\"]";
         };
     }
-    
+
     private String getBlockIcon(Block block) {
         return switch (block.getType()) {
             case PARAGRAPH -> "icon:paragraph[]";
@@ -162,7 +160,7 @@ public class NestedListVisualizer implements HierarchyVisualizer {
             default -> "icon:file[]";
         };
     }
-    
+
     private String getAttributeDescription(AttributeConfig attr) {
         return switch (attr.name()) {
             case "title" -> "Document title";
@@ -172,7 +170,7 @@ public class NestedListVisualizer implements HierarchyVisualizer {
             default -> attr.name();
         };
     }
-    
+
     private String getSectionDescription(SectionConfig section) {
         return switch (section.name()) {
             case "introduction" -> "Introduction section";

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/TableVisualizer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/TableVisualizer.java
@@ -18,16 +18,16 @@ import com.dataliquid.asciidoc.linter.documentation.VisualizationStyle;
  * Visualizes rule hierarchy as a table with indentation.
  */
 public class TableVisualizer implements HierarchyVisualizer {
-    
+
     private static final String INDENT = "{nbsp}{nbsp}";
-    
+
     private static class TableRow {
         final String rule;
         final int level;
         final Severity severity;
         final String type;
         final String requirements;
-        
+
         TableRow(String rule, int level, Severity severity, String type, String requirements) {
             this.rule = rule;
             this.level = level;
@@ -36,16 +36,16 @@ public class TableVisualizer implements HierarchyVisualizer {
             this.requirements = requirements;
         }
     }
-    
+
     @Override
     public void visualize(LinterConfiguration config, PrintWriter writer) {
         List<TableRow> rows = collectTableRows(config.document());
-        
+
         writer.println("[%header,cols=\"<4,^1,^1,2,3\"]");
         writer.println("|===");
         writer.println("|Rule |Level |Severity |Type |Requirements");
         writer.println();
-        
+
         for (TableRow row : rows) {
             writer.println("|" + getIndentedRule(row.rule, row.level));
             writer.println("|" + row.level);
@@ -54,103 +54,97 @@ public class TableVisualizer implements HierarchyVisualizer {
             writer.println("|" + row.requirements);
             writer.println();
         }
-        
+
         writer.println("|===");
         writer.println();
         writer.println("_* = Overrides parent severity_");
     }
-    
+
     @Override
     public VisualizationStyle getStyle() {
         return VisualizationStyle.TABLE;
     }
-    
+
     private List<TableRow> collectTableRows(DocumentConfiguration doc) {
         List<TableRow> rows = new ArrayList<>();
-        
+
         // Add document root
         rows.add(new TableRow("**DOCUMENT**", 0, null, "Root", "Base configuration"));
-        
+
         // Add metadata
         if (doc.metadata() != null) {
             collectMetadataRows(doc.metadata(), 1, rows);
         }
-        
+
         // Add sections
         if (doc.sections() != null && !doc.sections().isEmpty()) {
             rows.add(new TableRow("└ sections", 1, Severity.ERROR, "Container", "At least 1 section"));
-            
+
             for (SectionConfig section : doc.sections()) {
                 collectSectionRows(section, 2, rows);
             }
         }
-        
+
         return rows;
     }
-    
-    private void collectMetadataRows(MetadataConfiguration metadata, int level, 
-                                    List<TableRow> rows) {
+
+    private void collectMetadataRows(MetadataConfiguration metadata, int level, List<TableRow> rows) {
         rows.add(new TableRow("└ metadata", level, Severity.ERROR, "Container", "Required"));
-        
+
         if (metadata.attributes() != null) {
             for (int i = 0; i < metadata.attributes().size(); i++) {
                 AttributeConfig attr = metadata.attributes().get(i);
                 boolean isLast = i == metadata.attributes().size() - 1;
                 String prefix = isLast ? "└ " : "├ ";
-                
+
                 String requirements = buildAttributeRequirements(attr);
-                rows.add(new TableRow(prefix + attr.name(), level + 1, attr.severity(), 
-                                     "Attribute", requirements));
+                rows.add(new TableRow(prefix + attr.name(), level + 1, attr.severity(), "Attribute", requirements));
             }
         }
     }
-    
-    private void collectSectionRows(SectionConfig section, int level, 
-                                   List<TableRow> rows) {
+
+    private void collectSectionRows(SectionConfig section, int level, List<TableRow> rows) {
         String requirements = "Level " + section.level();
         if (section.order() != null) {
             requirements += ", Position " + section.order();
         }
-        
-        Severity severity = (section.occurrence() != null && section.occurrence().min() > 0) ? 
-                          Severity.ERROR : Severity.INFO;
-        
+
+        Severity severity = (section.occurrence() != null && section.occurrence().min() > 0)
+                ? Severity.ERROR
+                : Severity.INFO;
+
         rows.add(new TableRow("└ " + section.name(), level, severity, "Section", requirements));
-        
+
         if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
-            rows.add(new TableRow("├ allowedBlocks", level + 1, null, "Container", 
-                                 "Block definitions"));
-            
+            rows.add(new TableRow("├ allowedBlocks", level + 1, null, "Container", "Block definitions"));
+
             for (int i = 0; i < section.allowedBlocks().size(); i++) {
                 Block block = section.allowedBlocks().get(i);
                 boolean isLast = i == section.allowedBlocks().size() - 1;
-                
+
                 collectBlockRows(block, level + 2, isLast, rows);
             }
         }
-        
+
         if (section.subsections() != null && !section.subsections().isEmpty()) {
-            rows.add(new TableRow("└ subsections", level + 1, null, "Container", 
-                                 "Subsections"));
-            
+            rows.add(new TableRow("└ subsections", level + 1, null, "Container", "Subsections"));
+
             for (SectionConfig subsection : section.subsections()) {
                 collectSectionRows(subsection, level + 2, rows);
             }
         }
     }
-    
-    private void collectBlockRows(Block block, int level, boolean isLast, 
-                                 List<TableRow> rows) {
+
+    private void collectBlockRows(Block block, int level, boolean isLast, List<TableRow> rows) {
         String prefix = isLast ? "└ " : "├ ";
         String requirements = getBlockDescription(block);
-        
-        rows.add(new TableRow(prefix + block.getType().toValue(), level, 
-                             block.getSeverity(), "Block", requirements));
-        
+
+        rows.add(new TableRow(prefix + block.getType().toValue(), level, block.getSeverity(), "Block", requirements));
+
         // Add block-specific rules
         // TODO: Add specific rules based on block type with severity override indicators
     }
-    
+
     private String getIndentedRule(String rule, int level) {
         StringBuilder indented = new StringBuilder();
         for (int i = 0; i < level; i++) {
@@ -159,16 +153,16 @@ public class TableVisualizer implements HierarchyVisualizer {
         indented.append(rule);
         return indented.toString();
     }
-    
+
     private String buildAttributeRequirements(AttributeConfig attr) {
         List<String> reqs = new ArrayList<>();
-        
+
         if (attr.required()) {
             reqs.add("Required");
         } else {
             reqs.add("Optional");
         }
-        
+
         if (attr.minLength() != null || attr.maxLength() != null) {
             if (attr.minLength() != null && attr.maxLength() != null) {
                 reqs.add(attr.minLength() + "-" + attr.maxLength() + " characters");
@@ -178,21 +172,21 @@ public class TableVisualizer implements HierarchyVisualizer {
                 reqs.add("Max. " + attr.maxLength() + " characters");
             }
         }
-        
+
         if (attr.pattern() != null) {
             reqs.add("Pattern defined");
         }
-        
+
         return String.join(", ", reqs);
     }
-    
+
     private String getBlockDescription(Block block) {
         List<String> desc = new ArrayList<>();
-        
+
         if (block.getName() != null) {
             desc.add(block.getName());
         }
-        
+
         if (block.getOccurrence() != null) {
             int min = block.getOccurrence().min();
             int max = block.getOccurrence().max();
@@ -204,7 +198,7 @@ public class TableVisualizer implements HierarchyVisualizer {
                 desc.add("Max. " + max + " times");
             }
         }
-        
+
         return desc.isEmpty() ? "No special requirements" : String.join(", ", desc);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/TreeVisualizer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/documentation/visualizers/TreeVisualizer.java
@@ -16,12 +16,12 @@ import com.dataliquid.asciidoc.linter.documentation.VisualizationStyle;
  * Visualizes rule hierarchy as an ASCII-art tree structure.
  */
 public class TreeVisualizer implements HierarchyVisualizer {
-    
+
     private static final String VERTICAL = "│   ";
     private static final String BRANCH = "├── ";
     private static final String LAST_BRANCH = "└── ";
     private static final String EMPTY = "    ";
-    
+
     @Override
     public void visualize(LinterConfiguration config, PrintWriter writer) {
         writer.println("[literal]");
@@ -29,39 +29,39 @@ public class TreeVisualizer implements HierarchyVisualizer {
         visualizeDocument(config.document(), "", writer);
         writer.println("....");
     }
-    
+
     @Override
     public VisualizationStyle getStyle() {
         return VisualizationStyle.TREE;
     }
-    
+
     private void visualizeDocument(DocumentConfiguration doc, String prefix, PrintWriter writer) {
         writer.println(prefix + "document/");
-        
+
         boolean hasMetadata = doc.metadata() != null;
         boolean hasSections = doc.sections() != null && !doc.sections().isEmpty();
-        
+
         if (hasMetadata) {
             String childPrefix = prefix + (hasSections ? VERTICAL : EMPTY);
             visualizeMetadata(doc.metadata(), prefix + BRANCH, childPrefix, writer);
         }
-        
+
         if (hasSections) {
             visualizeSections(doc.sections(), prefix + LAST_BRANCH, prefix + EMPTY, writer);
         }
     }
-    
-    private void visualizeMetadata(MetadataConfiguration metadata, String nodePrefix, 
-                                  String childPrefix, PrintWriter writer) {
+
+    private void visualizeMetadata(MetadataConfiguration metadata, String nodePrefix, String childPrefix,
+            PrintWriter writer) {
         writer.println(nodePrefix + "metadata/");
-        
+
         if (metadata.attributes() != null && !metadata.attributes().isEmpty()) {
             List<AttributeConfig> attrs = metadata.attributes();
             for (int i = 0; i < attrs.size(); i++) {
                 AttributeConfig attr = attrs.get(i);
                 boolean isLast = i == attrs.size() - 1;
                 String branch = isLast ? LAST_BRANCH : BRANCH;
-                
+
                 String attrLine = childPrefix + branch + attr.name();
                 if (attr.required()) {
                     attrLine += " (required)";
@@ -69,28 +69,27 @@ public class TreeVisualizer implements HierarchyVisualizer {
                     attrLine += " (optional)";
                 }
                 attrLine += " [" + attr.severity() + "]";
-                
+
                 writer.println(attrLine);
             }
         }
     }
-    
-    private void visualizeSections(List<SectionConfig> sections, String nodePrefix, 
-                                  String childPrefix, PrintWriter writer) {
+
+    private void visualizeSections(List<SectionConfig> sections, String nodePrefix, String childPrefix,
+            PrintWriter writer) {
         writer.println(nodePrefix + "sections/");
-        
+
         for (int i = 0; i < sections.size(); i++) {
             SectionConfig section = sections.get(i);
             boolean isLast = i == sections.size() - 1;
             String branch = isLast ? LAST_BRANCH : BRANCH;
             String nextChildPrefix = childPrefix + (isLast ? EMPTY : VERTICAL);
-            
+
             visualizeSection(section, childPrefix + branch, nextChildPrefix, writer);
         }
     }
-    
-    private void visualizeSection(SectionConfig section, String nodePrefix, 
-                                 String childPrefix, PrintWriter writer) {
+
+    private void visualizeSection(SectionConfig section, String nodePrefix, String childPrefix, PrintWriter writer) {
         String sectionLine = nodePrefix + section.name() + "/";
         sectionLine += " [Level " + section.level();
         if (section.order() != null) {
@@ -98,50 +97,46 @@ public class TreeVisualizer implements HierarchyVisualizer {
         }
         sectionLine += "]";
         writer.println(sectionLine);
-        
+
         boolean hasBlocks = section.allowedBlocks() != null && !section.allowedBlocks().isEmpty();
         boolean hasSubsections = section.subsections() != null && !section.subsections().isEmpty();
-        
+
         if (hasBlocks) {
             String blocksPrefix = hasSubsections ? BRANCH : LAST_BRANCH;
             String nextChildPrefix = childPrefix + (hasSubsections ? VERTICAL : EMPTY);
-            visualizeBlocks(section.allowedBlocks(), childPrefix + blocksPrefix, 
-                          nextChildPrefix, writer);
+            visualizeBlocks(section.allowedBlocks(), childPrefix + blocksPrefix, nextChildPrefix, writer);
         }
-        
+
         if (hasSubsections) {
-            visualizeSections(section.subsections(), childPrefix + LAST_BRANCH, 
-                            childPrefix + EMPTY, writer);
+            visualizeSections(section.subsections(), childPrefix + LAST_BRANCH, childPrefix + EMPTY, writer);
         }
     }
-    
-    private void visualizeBlocks(List<Block> blocks, String nodePrefix, 
-                               String childPrefix, PrintWriter writer) {
+
+    private void visualizeBlocks(List<Block> blocks, String nodePrefix, String childPrefix, PrintWriter writer) {
         writer.println(nodePrefix + "allowedBlocks/");
-        
+
         for (int i = 0; i < blocks.size(); i++) {
             Block block = blocks.get(i);
             boolean isLast = i == blocks.size() - 1;
             String branch = isLast ? LAST_BRANCH : BRANCH;
             String nextChildPrefix = childPrefix + (isLast ? EMPTY : VERTICAL);
-            
+
             visualizeBlock(block, childPrefix + branch, nextChildPrefix, writer);
         }
     }
-    
-    private void visualizeBlock(Block block, String nodePrefix, String childPrefix, 
-                               PrintWriter writer) {
+
+    private void visualizeBlock(Block block, String nodePrefix, String childPrefix, PrintWriter writer) {
         String blockLine = nodePrefix + block.getType().toValue() + "/";
         if (block.getName() != null) {
             blockLine += " (" + block.getName() + ")";
         }
         blockLine += " [" + block.getSeverity() + "]";
         writer.println(blockLine);
-        
+
         // Add block-specific details
         visualizeBlockDetails(block, childPrefix, writer);
     }
-    
+
     private void visualizeBlockDetails(Block block, String prefix, PrintWriter writer) {
         // TODO: Add specific details based on block type
         // For example, for AudioBlock show url, options, title requirements

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/JsonFormatter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/JsonFormatter.java
@@ -16,62 +16,63 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
- * Formats validation results as JSON using Jackson.
- * Supports both pretty-printed and compact (single-line) output formats.
+ * Formats validation results as JSON using Jackson. Supports both pretty-printed and compact (single-line) output
+ * formats.
  */
 public class JsonFormatter implements ReportFormatter {
-    
-    private static final DateTimeFormatter ISO_FORMATTER = 
-        DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC);
-    
+
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC);
+
     private final String name;
     private final ObjectMapper objectMapper;
-    
+
     /**
      * Creates a JSON formatter with the specified name and pretty-print setting.
-     * 
-     * @param name the formatter name (e.g., "json" or "json-compact")
-     * @param prettyPrint whether to enable pretty printing
+     *
+     * @param name
+     *            the formatter name (e.g., "json" or "json-compact")
+     * @param prettyPrint
+     *            whether to enable pretty printing
      */
     public JsonFormatter(String name, boolean prettyPrint) {
         this.name = name;
         this.objectMapper = new ObjectMapper();
-        
+
         if (prettyPrint) {
             this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         } else {
             this.objectMapper.disable(SerializationFeature.INDENT_OUTPUT);
         }
     }
-    
+
     /**
      * Creates a pretty-printing JSON formatter.
-     * 
+     *
      * @return a formatter that produces human-readable JSON
      */
     public static JsonFormatter pretty() {
         return new JsonFormatter("json", true);
     }
-    
+
     /**
      * Creates a compact JSON formatter.
-     * 
+     *
      * @return a formatter that produces single-line JSON
      */
     public static JsonFormatter compact() {
         return new JsonFormatter("json-compact", false);
     }
-    
+
     @Override
     public void format(ValidationResult result, PrintWriter writer) {
         Map<String, Object> root = new LinkedHashMap<>();
-        
+
         // Timestamp
         root.put("timestamp", ISO_FORMATTER.format(Instant.now()));
-        
+
         // Duration
         root.put("duration", formatDuration(result.getValidationTimeMillis()));
-        
+
         // Summary
         Map<String, Object> summary = new LinkedHashMap<>();
         summary.put("totalMessages", result.getMessages().size());
@@ -79,13 +80,12 @@ public class JsonFormatter implements ReportFormatter {
         summary.put("warnings", result.getWarningCount());
         summary.put("infos", result.getInfoCount());
         root.put("summary", summary);
-        
+
         // Messages
-        List<Map<String, Object>> messages = result.getMessages().stream()
-            .map(this::formatMessage)
-            .collect(Collectors.toList());
+        List<Map<String, Object>> messages = result.getMessages().stream().map(this::formatMessage)
+                .collect(Collectors.toList());
         root.put("messages", messages);
-        
+
         // Write JSON to PrintWriter
         try {
             objectMapper.writeValue(writer, root);
@@ -94,34 +94,32 @@ public class JsonFormatter implements ReportFormatter {
             throw new RuntimeException("Failed to write JSON output", e);
         }
     }
-    
+
     private Map<String, Object> formatMessage(ValidationMessage msg) {
         Map<String, Object> msgMap = new LinkedHashMap<>();
-        
+
         msgMap.put("file", msg.getLocation().getFilename());
         msgMap.put("line", msg.getLocation().getStartLine());
-        
+
         if (msg.getLocation().getStartColumn() > 1) {
             msgMap.put("column", msg.getLocation().getStartColumn());
         }
-        
+
         msgMap.put("severity", msg.getSeverity().toString());
         msgMap.put("message", msg.getMessage());
-        
+
         // Optional fields
         if (msg.getRuleId() != null) {
             msgMap.put("ruleId", msg.getRuleId());
         }
-        
-        msg.getActualValue().ifPresent(value -> 
-            msgMap.put("actualValue", value));
-        
-        msg.getExpectedValue().ifPresent(value -> 
-            msgMap.put("expectedValue", value));
-        
+
+        msg.getActualValue().ifPresent(value -> msgMap.put("actualValue", value));
+
+        msg.getExpectedValue().ifPresent(value -> msgMap.put("expectedValue", value));
+
         return msgMap;
     }
-    
+
     private String formatDuration(long millis) {
         if (millis < 1000) {
             return millis + "ms";
@@ -129,7 +127,7 @@ public class JsonFormatter implements ReportFormatter {
             return String.format("%.3fs", millis / 1000.0);
         }
     }
-    
+
     @Override
     public String getName() {
         return name;

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/ReportFormatter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/ReportFormatter.java
@@ -8,18 +8,20 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
  * Interface for formatting validation results in different output formats.
  */
 public interface ReportFormatter {
-    
+
     /**
      * Formats the validation result and writes it to the provided writer.
-     * 
-     * @param result the validation result to format
-     * @param writer the writer to output the formatted result
+     *
+     * @param result
+     *            the validation result to format
+     * @param writer
+     *            the writer to output the formatted result
      */
     void format(ValidationResult result, PrintWriter writer);
-    
+
     /**
      * Returns the name of this formatter (e.g., "console", "json").
-     * 
+     *
      * @return the formatter name
      */
     String getName();

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/ReportWriter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/ReportWriter.java
@@ -14,152 +14,178 @@ import com.dataliquid.asciidoc.linter.config.output.OutputConfiguration;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 /**
- * Facade for writing validation reports in different formats.
- * Manages available formatters and handles output to files or console.
+ * Facade for writing validation reports in different formats. Manages available formatters and handles output to files
+ * or console.
  */
 public class ReportWriter {
-    
+
     private final Map<String, ReportFormatter> formatters;
-    
+
     public ReportWriter() {
         this.formatters = new HashMap<>();
         registerDefaultFormatters();
     }
-    
+
     private void registerDefaultFormatters() {
         // Console formatter will be created dynamically with output config
         registerFormatter(JsonFormatter.pretty());
         registerFormatter(JsonFormatter.compact());
     }
-    
+
     /**
      * Registers a formatter for use by this writer.
-     * 
-     * @param formatter the formatter to register
+     *
+     * @param formatter
+     *            the formatter to register
      */
     public void registerFormatter(ReportFormatter formatter) {
         Objects.requireNonNull(formatter, "[" + getClass().getName() + "] formatter must not be null");
         formatters.put(formatter.getName(), formatter);
     }
-    
+
     /**
-     * Writes the validation result using the specified format.
-     * If outputPath is null, writes to standard output.
-     * 
-     * @param result the validation result to write
-     * @param format the output format (e.g., "console", "json")
-     * @param outputPath the output file path, or null for standard output
-     * @throws IOException if an I/O error occurs
-     * @throws IllegalArgumentException if the format is not supported
+     * Writes the validation result using the specified format. If outputPath is null, writes to standard output.
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format (e.g., "console", "json")
+     * @param outputPath
+     *            the output file path, or null for standard output
+     * @throws IOException
+     *             if an I/O error occurs
+     * @throws IllegalArgumentException
+     *             if the format is not supported
      */
     public void write(ValidationResult result, String format, String outputPath) throws IOException {
         write(result, format, outputPath, null);
     }
-    
+
     /**
      * Writes the validation result using the specified format with optional output configuration.
-     * 
-     * @param result the validation result to write
-     * @param format the output format (e.g., "console", "json")
-     * @param outputPath the output file path, or null for standard output
-     * @param outputConfig the output configuration for console format, or null for default
-     * @throws IOException if an I/O error occurs
-     * @throws IllegalArgumentException if the format is not supported
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format (e.g., "console", "json")
+     * @param outputPath
+     *            the output file path, or null for standard output
+     * @param outputConfig
+     *            the output configuration for console format, or null for default
+     * @throws IOException
+     *             if an I/O error occurs
+     * @throws IllegalArgumentException
+     *             if the format is not supported
      */
-    public void write(ValidationResult result, String format, String outputPath, OutputConfiguration outputConfig) throws IOException {
+    public void write(ValidationResult result, String format, String outputPath, OutputConfiguration outputConfig)
+            throws IOException {
         Objects.requireNonNull(result, "[" + getClass().getName() + "] result must not be null");
-        
+
         ReportFormatter formatter = getFormatter(format, outputConfig);
-        
+
         if (outputPath == null) {
             writeToConsole(result, formatter);
         } else {
             writeToFile(result, formatter, outputPath);
         }
     }
-    
+
     /**
      * Writes the validation result using the specified format to a Path.
-     * 
-     * @param result the validation result to write
-     * @param format the output format
-     * @param outputPath the output file path
-     * @throws IOException if an I/O error occurs
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format
+     * @param outputPath
+     *            the output file path
+     * @throws IOException
+     *             if an I/O error occurs
      */
     public void write(ValidationResult result, String format, Path outputPath) throws IOException {
         write(result, format, outputPath != null ? outputPath.toString() : null);
     }
-    
+
     /**
      * Writes the validation result to a PrintWriter using the specified format.
-     * 
-     * @param result the validation result to write
-     * @param format the output format
-     * @param writer the writer to write to
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format
+     * @param writer
+     *            the writer to write to
      */
     public void write(ValidationResult result, String format, PrintWriter writer) {
         write(result, format, writer, null);
     }
-    
+
     /**
      * Writes the validation result to a PrintWriter using the specified format with optional output configuration.
-     * 
-     * @param result the validation result to write
-     * @param format the output format
-     * @param writer the writer to write to
-     * @param outputConfig the output configuration for console format, or null for default
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format
+     * @param writer
+     *            the writer to write to
+     * @param outputConfig
+     *            the output configuration for console format, or null for default
      */
     public void write(ValidationResult result, String format, PrintWriter writer, OutputConfiguration outputConfig) {
         Objects.requireNonNull(result, "[" + getClass().getName() + "] result must not be null");
         Objects.requireNonNull(writer, "[" + getClass().getName() + "] writer must not be null");
-        
+
         ReportFormatter formatter = getFormatter(format, outputConfig);
         formatter.format(result, writer);
         writer.flush();
     }
-    
+
     /**
      * Writes the validation result to the console using the specified format.
-     * 
-     * @param result the validation result to write
-     * @param format the output format
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format
      */
     public void writeToConsole(ValidationResult result, String format) {
         writeToConsole(result, format, null);
     }
-    
+
     /**
      * Writes the validation result to the console using the specified format with optional output configuration.
-     * 
-     * @param result the validation result to write
-     * @param format the output format
-     * @param outputConfig the output configuration for console format, or null for default
+     *
+     * @param result
+     *            the validation result to write
+     * @param format
+     *            the output format
+     * @param outputConfig
+     *            the output configuration for console format, or null for default
      */
     public void writeToConsole(ValidationResult result, String format, OutputConfiguration outputConfig) {
         Objects.requireNonNull(result, "[" + getClass().getName() + "] result must not be null");
-        
+
         ReportFormatter formatter = getFormatter(format, outputConfig);
         writeToConsole(result, formatter);
     }
-    
+
     private void writeToConsole(ValidationResult result, ReportFormatter formatter) {
         try (PrintWriter writer = new PrintWriter(System.out)) {
             formatter.format(result, writer);
             writer.flush();
         }
     }
-    
-    private void writeToFile(ValidationResult result, ReportFormatter formatter, String outputPath) 
-            throws IOException {
-        try (PrintWriter writer = new PrintWriter(
-                new FileWriter(outputPath, StandardCharsets.UTF_8))) {
+
+    private void writeToFile(ValidationResult result, ReportFormatter formatter, String outputPath) throws IOException {
+        try (PrintWriter writer = new PrintWriter(new FileWriter(outputPath, StandardCharsets.UTF_8))) {
             formatter.format(result, writer);
         }
     }
-    
+
     private ReportFormatter getFormatter(String format, OutputConfiguration outputConfig) {
         String formatName = format != null ? format.toLowerCase() : "console";
-        
+
         // Special handling for console format with output configuration
         if ("console".equals(formatName)) {
             if (outputConfig != null) {
@@ -168,30 +194,31 @@ public class ReportWriter {
                 return new ConsoleFormatter();
             }
         }
-        
+
         ReportFormatter formatter = formatters.get(formatName);
-        
+
         if (formatter == null) {
             throw new IllegalArgumentException(
-                "Unsupported format: " + format + ". Available formats: console, " + getAvailableFormats());
+                    "Unsupported format: " + format + ". Available formats: console, " + getAvailableFormats());
         }
-        
+
         return formatter;
     }
-    
+
     /**
      * Returns the set of available format names.
-     * 
+     *
      * @return the available format names
      */
     public Set<String> getAvailableFormats() {
         return formatters.keySet();
     }
-    
+
     /**
      * Calculates the exit code based on the validation result.
-     * 
-     * @param result the validation result
+     *
+     * @param result
+     *            the validation result
      * @return 0 if no errors, 1 if errors found
      */
     public static int calculateExitCode(ValidationResult result) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/ColorScheme.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/ColorScheme.java
@@ -15,85 +15,85 @@ public class ColorScheme {
     private static final String ANSI_GRAY = "\u001B[90m";
     private static final String ANSI_BOLD = "\u001B[1m";
     private static final String ANSI_DIM = "\u001B[2m";
-    
+
     private final boolean useColors;
-    
+
     public ColorScheme(boolean useColors) {
         this.useColors = useColors;
     }
-    
+
     public String colorize(String text, Severity severity) {
         if (!useColors) {
             return text;
         }
-        
+
         return switch (severity) {
             case ERROR -> ANSI_RED + text + ANSI_RESET;
             case WARN -> ANSI_YELLOW + text + ANSI_RESET;
             case INFO -> ANSI_BLUE + text + ANSI_RESET;
         };
     }
-    
+
     public String error(String text) {
         return useColors ? ANSI_RED + text + ANSI_RESET : text;
     }
-    
+
     public String warning(String text) {
         return useColors ? ANSI_YELLOW + text + ANSI_RESET : text;
     }
-    
+
     public String info(String text) {
         return useColors ? ANSI_BLUE + text + ANSI_RESET : text;
     }
-    
+
     public String success(String text) {
         return useColors ? ANSI_GREEN + text + ANSI_RESET : text;
     }
-    
+
     public String code(String text) {
         return useColors ? ANSI_CYAN + text + ANSI_RESET : text;
     }
-    
+
     public String contextLine(String text) {
         return useColors ? ANSI_DIM + text + ANSI_RESET : text;
     }
-    
+
     public String contextLineNumber(String lineNum) {
         return useColors ? ANSI_GRAY + lineNum + ANSI_RESET : lineNum;
     }
-    
+
     public String errorLineNumber(String lineNum) {
         return useColors ? ANSI_RED + ANSI_BOLD + lineNum + ANSI_RESET : lineNum;
     }
-    
+
     public String errorMarker(String marker) {
         return useColors ? ANSI_RED + marker + ANSI_RESET : marker;
     }
-    
+
     public String suggestion(String text) {
         return useColors ? ANSI_GREEN + text + ANSI_RESET : text;
     }
-    
+
     public String suggestionIcon(String icon) {
         return useColors ? ANSI_YELLOW + icon + ANSI_RESET : icon;
     }
-    
+
     public String separator(String separator) {
         return useColors ? ANSI_GRAY + separator + ANSI_RESET : separator;
     }
-    
+
     public String header(String text) {
         return useColors ? ANSI_BOLD + text + ANSI_RESET : text;
     }
-    
+
     public String errorBar(String bar) {
         return useColors ? ANSI_RED + bar + ANSI_RESET : bar;
     }
-    
+
     public String warningBar(String bar) {
         return useColors ? ANSI_YELLOW + bar + ANSI_RESET : bar;
     }
-    
+
     public String infoBar(String bar) {
         return useColors ? ANSI_BLUE + bar + ANSI_RESET : bar;
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/FileContentCache.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/FileContentCache.java
@@ -13,14 +13,14 @@ import java.util.Map;
  */
 public class FileContentCache {
     private final Map<String, List<String>> cache = new HashMap<>();
-    
+
     /**
      * Gets the lines of a file, reading from cache if available.
      */
     public List<String> getFileLines(String filename) {
         return cache.computeIfAbsent(filename, this::readFileLines);
     }
-    
+
     private List<String> readFileLines(String filename) {
         try {
             Path path = Paths.get(filename);
@@ -32,7 +32,7 @@ public class FileContentCache {
         }
         return List.of();
     }
-    
+
     /**
      * Clears the cache to free memory.
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/GroupingEngine.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/GroupingEngine.java
@@ -14,11 +14,11 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
  */
 public class GroupingEngine {
     private final ErrorGroupingConfig config;
-    
+
     public GroupingEngine(ErrorGroupingConfig config) {
         this.config = Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
     }
-    
+
     /**
      * Groups validation messages by rule ID.
      */
@@ -27,20 +27,20 @@ public class GroupingEngine {
             // Return all messages as ungrouped
             return new MessageGroups(List.of(), messages);
         }
-        
+
         // Group by rule ID
         Map<String, List<ValidationMessage>> byRuleId = new HashMap<>();
         for (ValidationMessage msg : messages) {
             byRuleId.computeIfAbsent(msg.getRuleId(), k -> new ArrayList<>()).add(msg);
         }
-        
+
         List<MessageGroup> groups = new ArrayList<>();
         List<ValidationMessage> ungrouped = new ArrayList<>();
-        
+
         // Separate into groups and ungrouped based on threshold
         for (Map.Entry<String, List<ValidationMessage>> entry : byRuleId.entrySet()) {
             List<ValidationMessage> ruleMessages = entry.getValue();
-            
+
             if (ruleMessages.size() >= config.getThreshold()) {
                 // Create a group
                 groups.add(new MessageGroup(entry.getKey(), ruleMessages));
@@ -49,10 +49,10 @@ public class GroupingEngine {
                 ungrouped.addAll(ruleMessages);
             }
         }
-        
+
         // Sort groups by size (largest first)
         groups.sort((a, b) -> Integer.compare(b.size(), a.size()));
-        
+
         return new MessageGroups(groups, ungrouped);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/HighlightRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/HighlightRenderer.java
@@ -16,61 +16,52 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 public class HighlightRenderer {
     private static final String PLACEHOLDER_START = "«";
     private static final String PLACEHOLDER_END = "»";
-    
+
     private final DisplayConfig config;
     private final ColorScheme colorScheme;
-    
+
     public HighlightRenderer(DisplayConfig config) {
         this.config = Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
         this.colorScheme = new ColorScheme(config.isUseColors());
     }
-    
+
     /**
      * Renders source context with error highlighting.
      */
-    public void renderWithHighlight(SourceContext context, 
-                                  ValidationMessage message, 
-                                  PrintWriter writer) {
-        
+    public void renderWithHighlight(SourceContext context, ValidationMessage message, PrintWriter writer) {
+
         List<SourceContext.ContextLine> lines = context.getLines();
         for (int i = 0; i < lines.size(); i++) {
             SourceContext.ContextLine line = lines.get(i);
-            
+
             // Check if this is a placeholder line for block.occurrence.min
-            if (line.isErrorLine() && line.getContent().isEmpty() && 
-                "block.occurrence.min".equals(message.getRuleId()) &&
-                message.getMissingValueHint() != null &&
-                message.getMissingValueHint().contains("\n")) {
-                
+            if (line.isErrorLine() && line.getContent().isEmpty() && "block.occurrence.min".equals(message.getRuleId())
+                    && message.getMissingValueHint() != null && message.getMissingValueHint().contains("\n")) {
+
                 // Split multi-line placeholder into separate lines
                 String[] placeholderLines = message.getMissingValueHint().split("\n");
-                
+
                 // Render each line of the multi-line placeholder
                 for (int j = 0; j < placeholderLines.length; j++) {
                     String placeholderContent = placeholderLines[j];
-                    
+
                     // Create context line for each placeholder line
-                    SourceContext.ContextLine placeholderLine = 
-                        new SourceContext.ContextLine(
-                            line.getNumber() + j, 
-                            placeholderContent,
-                            true // Mark as error line
-                        );
-                    
+                    SourceContext.ContextLine placeholderLine = new SourceContext.ContextLine(line.getNumber() + j,
+                            placeholderContent, true // Mark as error line
+                    );
+
                     // Render with line number and placeholder markers
                     renderPlaceholderLine(placeholderLine, writer, j == 0, j == placeholderLines.length - 1);
                 }
                 continue; // Skip the original empty line
             }
-            
+
             renderLine(line, message, writer);
         }
     }
-    
-    private void renderPlaceholderLine(SourceContext.ContextLine line, 
-                                      PrintWriter writer,
-                                      boolean isFirstLine,
-                                      boolean isLastLine) {
+
+    private void renderPlaceholderLine(SourceContext.ContextLine line, PrintWriter writer, boolean isFirstLine,
+            boolean isLastLine) {
         // Line number prefix
         String linePrefix = "";
         if (config.isShowLineNumbers()) {
@@ -79,7 +70,7 @@ public class HighlightRenderer {
                 linePrefix = colorScheme.contextLineNumber(linePrefix);
             }
         }
-        
+
         // Add placeholder markers only on first and last lines
         String content = line.getContent();
         if (isFirstLine) {
@@ -88,16 +79,14 @@ public class HighlightRenderer {
         if (isLastLine) {
             content = content + PLACEHOLDER_END;
         }
-        
+
         // Color the entire placeholder content
         String highlighted = colorScheme.error(content);
-        
+
         writer.println(linePrefix + highlighted);
     }
-    
-    private void renderLine(SourceContext.ContextLine line, 
-                          ValidationMessage message,
-                          PrintWriter writer) {
+
+    private void renderLine(SourceContext.ContextLine line, ValidationMessage message, PrintWriter writer) {
         // Line number prefix
         String linePrefix = "";
         if (config.isShowLineNumbers()) {
@@ -108,19 +97,14 @@ public class HighlightRenderer {
                 linePrefix = colorScheme.contextLineNumber(lineNum) + " | ";
             }
         }
-        
+
         // Line content
         if (line.isErrorLine()) {
-            String highlightedContent = highlightErrorInLine(
-                line.getContent(), 
-                message,
-                line.getNumber()
-            );
+            String highlightedContent = highlightErrorInLine(line.getContent(), message, line.getNumber());
             writer.println(linePrefix + highlightedContent);
-            
+
             // Add underline/marker if configured
-            if (config.getHighlightStyle() == HighlightStyle.UNDERLINE && 
-                shouldShowUnderline(message)) {
+            if (config.getHighlightStyle() == HighlightStyle.UNDERLINE && shouldShowUnderline(message)) {
                 renderUnderline(line, message, writer);
             }
         } else {
@@ -128,11 +112,10 @@ public class HighlightRenderer {
             writer.println(linePrefix + colorScheme.contextLine(line.getContent()));
         }
     }
-    
+
     private String highlightErrorInLine(String line, ValidationMessage message, int lineNum) {
         // For missing values: insert placeholder
-        if (message.getErrorType() == ErrorType.MISSING_VALUE && 
-            message.getMissingValueHint() != null) {
+        if (message.getErrorType() == ErrorType.MISSING_VALUE && message.getMissingValueHint() != null) {
             // For section.min-occurrences, insert placeholder on empty lines
             if ("section.min-occurrences".equals(message.getRuleId())) {
                 if (line.isEmpty()) {
@@ -225,44 +208,44 @@ public class HighlightRenderer {
                 return insertPlaceholder(line, message);
             }
         }
-        
+
         // For invalid values: keep original (will be underlined)
         return line;
     }
-    
+
     private String insertPlaceholderWithSpace(String line, ValidationMessage message) {
         // Special handling for sentence placeholders - always add space before
         int col = message.getLocation().getStartColumn();
-        
+
         // Generate placeholder with leading space
         String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
         String placeholder = " " + colorScheme.error(placeholderText);
-        
+
         if (col <= 0 || col > line.length() + 1) {
             // Append at end if column is invalid
             return line + placeholder;
         }
-        
+
         // Insert at specific position (col is 1-based)
         if (col > line.length()) {
             // Insert at end of line
             return line + placeholder;
         }
-        
+
         String before = line.substring(0, col - 1);
         String after = line.substring(col - 1);
-        
+
         return before + placeholder + after;
     }
-    
+
     private String insertPlaceholderBeforePunctuation(String line, ValidationMessage message) {
         // Special handling for inserting placeholder before punctuation marks
         int col = message.getLocation().getStartColumn();
-        
+
         // Generate placeholder with leading space
         String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
         String placeholder = " " + colorScheme.error(placeholderText);
-        
+
         if (col <= 0 || col > line.length() + 1) {
             // Invalid column, try to find punctuation at end of line
             if (line.matches(".*[.!?]+$")) {
@@ -272,7 +255,7 @@ public class HighlightRenderer {
                     punctStart--;
                 }
                 punctStart++; // Move to first punctuation character
-                
+
                 String before = line.substring(0, punctStart);
                 String after = line.substring(punctStart);
                 return before + placeholder + after;
@@ -280,27 +263,27 @@ public class HighlightRenderer {
             // No punctuation found, append at end
             return line + placeholder;
         }
-        
+
         // Insert at specific position (col is 1-based)
         if (col > line.length()) {
             // Position beyond line end, append
             return line + placeholder;
         }
-        
+
         // Insert before punctuation at specified position
         String before = line.substring(0, col - 1);
         String after = line.substring(col - 1);
-        
+
         return before + placeholder + after;
     }
-    
+
     private String insertPlaceholder(String line, ValidationMessage message) {
         // For section.min-occurrences errors with empty lines, show placeholder at start
         if ("section.min-occurrences".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For block.occurrence.min errors with empty lines, show placeholder at start
         if ("block.occurrence.min".equals(message.getRuleId()) && line.isEmpty()) {
             // Only handle single-line placeholders here
@@ -312,147 +295,147 @@ public class HighlightRenderer {
             // For multi-line placeholders, return empty line (will be handled later)
             return line;
         }
-        
+
         // For paragraph.lines.min errors with empty lines, show placeholder at start
         if ("paragraph.lines.min".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For metadata.required errors with empty lines, show placeholder at start
         if ("metadata.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For video.caption.required errors with empty lines, show placeholder at start
         if ("video.caption.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For audio.title.required errors with empty lines, show placeholder at start
         if ("audio.title.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For table.caption.required errors with empty lines, show placeholder at start
         if ("table.caption.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For table.header.required errors with empty lines, show placeholder at start
         if ("table.header.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For example.caption.required errors with empty lines, show placeholder at start
         if ("example.caption.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For example.collapsible.required errors with empty lines, show placeholder at start
         if ("example.collapsible.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For admonition.title.required errors with empty lines, show placeholder at start
         if ("admonition.title.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For admonition.content.required errors with empty lines, show placeholder at start
         if ("admonition.content.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For admonition.icon.required errors with empty lines, show placeholder at start
         if ("admonition.icon.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For sidebar.title.required errors with empty lines, show placeholder at start
         if ("sidebar.title.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For sidebar.content.required errors with empty lines, show placeholder at start
         if ("sidebar.content.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For sidebar.position.required errors with empty lines, show placeholder at start
         if ("sidebar.position.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
-        // For verse.author.required and verse.attribution.required errors, 
+
+        // For verse.author.required and verse.attribution.required errors,
         // insert placeholder with comma inline in the [verse] line
-        if ("verse.author.required".equals(message.getRuleId()) || 
-            "verse.attribution.required".equals(message.getRuleId())) {
+        if ("verse.author.required".equals(message.getRuleId())
+                || "verse.attribution.required".equals(message.getRuleId())) {
             // Insert at position 7 with comma
             if (line.startsWith("[verse")) {
-                String before = line.substring(0, 6);  // "[verse"
-                String after = line.substring(6);      // "]" or existing content
+                String before = line.substring(0, 6); // "[verse"
+                String after = line.substring(6); // "]" or existing content
                 String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
                 return before + "," + colorScheme.error(placeholderText) + after;
             }
         }
-        
+
         // For verse.content.required errors with empty lines, show placeholder at start
         if ("verse.content.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For dlist.descriptions.required errors, append placeholder to term line
         if ("dlist.descriptions.required".equals(message.getRuleId())) {
             // This is special - append to the term line
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return line + " " + colorScheme.error(placeholderText);
         }
-        
+
         // For pass.content.required errors with empty lines, show placeholder at start
         if ("pass.content.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For pass.reason.required errors with empty lines, show placeholder at start
         if ("pass.reason.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For pass.type.required errors with empty lines, show placeholder at start
         if ("pass.type.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For literal.title.required errors with empty lines, show placeholder at start
         if ("literal.title.required".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For ulist.items.min errors with empty lines, show placeholder at start
         if ("ulist.items.min".equals(message.getRuleId()) && line.isEmpty()) {
             String placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
             return colorScheme.error(placeholderText);
         }
-        
+
         // For ulist.markerStyle errors, replace the existing marker
         if ("ulist.markerStyle".equals(message.getRuleId())) {
             int col = message.getLocation().getStartColumn();
@@ -464,9 +447,9 @@ public class HighlightRenderer {
                 return before + colorScheme.error(placeholderText) + after;
             }
         }
-        
+
         int col = message.getLocation().getStartColumn();
-        
+
         // Generate complete placeholder based on context
         String placeholderText;
         PlaceholderContext context = message.getPlaceholderContext();
@@ -476,71 +459,69 @@ public class HighlightRenderer {
             // Fallback to simple placeholder
             placeholderText = PLACEHOLDER_START + message.getMissingValueHint() + PLACEHOLDER_END;
         }
-        
+
         String placeholder = colorScheme.error(placeholderText);
-        
+
         if (col <= 0 || col > line.length() + 1) {
             // Append at end if column is invalid
             return line + placeholder;
         }
-        
+
         // Insert at specific position (col is 1-based)
         if (col > line.length()) {
             // Insert at end of line
             return line + placeholder;
         }
-        
+
         String before = line.substring(0, col - 1);
         String after = line.substring(col - 1);
-        
+
         return before + placeholder + after;
     }
-    
+
     private boolean shouldShowUnderline(ValidationMessage message) {
         // Don't underline for missing values (already shown with placeholder)
         if (message.getErrorType() == ErrorType.MISSING_VALUE) {
             return false;
         }
-        
+
         // Show underline for ALL other error types
         return true;
     }
-    
-    private void renderUnderline(SourceContext.ContextLine line, 
-                               ValidationMessage message, 
-                               PrintWriter writer) {
+
+    private void renderUnderline(SourceContext.ContextLine line, ValidationMessage message, PrintWriter writer) {
         int startCol = message.getLocation().getStartColumn();
         int endCol = message.getLocation().getEndColumn();
-        
+
         // Validate columns
         if (startCol < 0) {
             return;
         }
-        
+
         // Default to column 1 if not specified
         if (startCol == 0) {
             startCol = 1;
         }
-        
+
         if (endCol <= 0 || endCol < startCol) {
             endCol = Math.min(line.getContent().length(), startCol + 20);
         }
-        
+
         StringBuilder underline = new StringBuilder();
-        
+
         // Padding for line number
         if (config.isShowLineNumbers()) {
-            underline.append("    ");   // 4 spaces for line number
-            underline.append(" | ");    // 3 spaces for " | "
+            underline.append("    "); // 4 spaces for line number
+            underline.append(" | "); // 3 spaces for " | "
         }
-        
+
         // Spaces before error
         underline.append(" ".repeat(Math.max(0, startCol - 1)));
-        
+
         // Underline characters
         int length = Math.min(endCol - startCol + 1, config.getMaxLineWidth());
         underline.append(colorScheme.errorMarker("~".repeat(length)));
-        
+
         writer.println(underline);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageGroup.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageGroup.java
@@ -13,17 +13,16 @@ public final class MessageGroup {
     private final String ruleId;
     private final List<ValidationMessage> messages;
     private final String commonDescription;
-    
+
     public MessageGroup(String ruleId, List<ValidationMessage> messages) {
         this.ruleId = Objects.requireNonNull(ruleId, "[" + getClass().getName() + "] ruleId must not be null");
-        this.messages = new ArrayList<>(Objects.requireNonNull(messages, "[" + getClass().getName() + "] messages must not be null"));
-        
+        this.messages = new ArrayList<>(
+                Objects.requireNonNull(messages, "[" + getClass().getName() + "] messages must not be null"));
+
         // Extract common description from first message
-        this.commonDescription = messages.isEmpty() ? 
-            "Unknown error" : 
-            extractCommonDescription(messages.get(0));
+        this.commonDescription = messages.isEmpty() ? "Unknown error" : extractCommonDescription(messages.get(0));
     }
-    
+
     private String extractCommonDescription(ValidationMessage firstMessage) {
         String msg = firstMessage.getMessage();
         // Try to extract the generic part of the message
@@ -38,19 +37,19 @@ public final class MessageGroup {
         }
         return msg;
     }
-    
+
     public String getRuleId() {
         return ruleId;
     }
-    
+
     public List<ValidationMessage> getMessages() {
         return new ArrayList<>(messages);
     }
-    
+
     public String getCommonDescription() {
         return commonDescription;
     }
-    
+
     public int size() {
         return messages.size();
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageGroups.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageGroups.java
@@ -12,24 +12,26 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 public final class MessageGroups {
     private final List<MessageGroup> groups;
     private final List<ValidationMessage> ungroupedMessages;
-    
+
     public MessageGroups(List<MessageGroup> groups, List<ValidationMessage> ungroupedMessages) {
-        this.groups = new ArrayList<>(Objects.requireNonNull(groups, "[" + getClass().getName() + "] groups must not be null"));
-        this.ungroupedMessages = new ArrayList<>(Objects.requireNonNull(ungroupedMessages, "[" + getClass().getName() + "] ungroupedMessages must not be null"));
+        this.groups = new ArrayList<>(
+                Objects.requireNonNull(groups, "[" + getClass().getName() + "] groups must not be null"));
+        this.ungroupedMessages = new ArrayList<>(Objects.requireNonNull(ungroupedMessages,
+                "[" + getClass().getName() + "] ungroupedMessages must not be null"));
     }
-    
+
     public List<MessageGroup> getGroups() {
         return new ArrayList<>(groups);
     }
-    
+
     public List<ValidationMessage> getUngroupedMessages() {
         return new ArrayList<>(ungroupedMessages);
     }
-    
+
     public boolean hasGroups() {
         return !groups.isEmpty();
     }
-    
+
     public int getTotalMessages() {
         int total = ungroupedMessages.size();
         for (MessageGroup group : groups) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/MessageRenderer.java
@@ -16,7 +16,7 @@ public class MessageRenderer {
     private final HighlightRenderer highlightRenderer;
     private final SuggestionRenderer suggestionRenderer;
     private final ColorScheme colorScheme;
-    
+
     public MessageRenderer(OutputConfiguration config) {
         this.config = Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
         this.contextRenderer = new ContextRenderer(config.getDisplay());
@@ -24,7 +24,7 @@ public class MessageRenderer {
         this.suggestionRenderer = new SuggestionRenderer(config.getSuggestions(), config.getDisplay());
         this.colorScheme = new ColorScheme(config.getDisplay().isUseColors());
     }
-    
+
     public void render(ValidationMessage message, PrintWriter writer) {
         // Format depends on OutputFormat
         switch (config.getFormat()) {
@@ -33,84 +33,74 @@ public class MessageRenderer {
             case COMPACT -> renderCompact(message, writer);
         }
     }
-    
+
     private void renderEnhanced(ValidationMessage message, PrintWriter writer) {
         // Header with severity and message
         String severityLabel = formatSeverity(message);
         String header = severityLabel + ": " + message.getMessage() + " [" + message.getRuleId() + "]";
         writer.println(colorScheme.colorize(header, message.getSeverity()));
-        
+
         // File location
         writer.println("  File: " + message.getLocation().formatLocation());
-        
+
         // Actual and expected values
         if (message.getActualValue().isPresent() || message.getExpectedValue().isPresent()) {
-            message.getActualValue().ifPresent(value -> 
-                writer.println("  Actual: " + value));
-            message.getExpectedValue().ifPresent(value -> 
-                writer.println("  Expected: " + value));
+            message.getActualValue().ifPresent(value -> writer.println("  Actual: " + value));
+            message.getExpectedValue().ifPresent(value -> writer.println("  Expected: " + value));
         }
-        
+
         // Stack trace if available
         if (message.getCause().isPresent()) {
             writer.println();
             renderStackTrace(message.getCause().get(), writer);
         }
-        
+
         // Source context with highlighting
         if (config.getDisplay().getContextLines() > 0) {
             writer.println();
             SourceContext context = contextRenderer.getContext(message);
             highlightRenderer.renderWithHighlight(context, message, writer);
         }
-        
+
         // Suggestions
         if (config.getSuggestions().isEnabled() && message.hasSuggestions()) {
             writer.println();
             suggestionRenderer.render(message.getSuggestions(), writer);
         }
     }
-    
+
     private void renderSimple(ValidationMessage message, PrintWriter writer) {
         String severityLabel = formatSeverity(message);
         String location = String.format("  Line %d", message.getLocation().getStartLine());
-        
+
         if (message.getLocation().getStartColumn() > 0) {
             location += String.format(", Column %d", message.getLocation().getStartColumn());
         }
-        
+
         writer.println(location + ": " + severityLabel + " " + message.getMessage());
-        
+
         if (config.getDisplay().isShowLineNumbers()) {
             writer.println("    Rule: " + message.getRuleId());
         }
-        
+
         if (message.getActualValue().isPresent() || message.getExpectedValue().isPresent()) {
-            message.getActualValue().ifPresent(value -> 
-                writer.println("    Actual: " + value));
-            message.getExpectedValue().ifPresent(value -> 
-                writer.println("    Expected: " + value));
+            message.getActualValue().ifPresent(value -> writer.println("    Actual: " + value));
+            message.getExpectedValue().ifPresent(value -> writer.println("    Expected: " + value));
         }
-        
+
         // Stack trace if available
         if (message.getCause().isPresent()) {
             writer.println();
             renderStackTrace(message.getCause().get(), writer);
         }
     }
-    
+
     private void renderCompact(ValidationMessage message, PrintWriter writer) {
         // Single-line output for CI/CD
         StringBuilder compact = new StringBuilder();
-        compact.append(message.getLocation().formatLocation())
-               .append(": ")
-               .append(message.getSeverity())
-               .append(": ")
-               .append(message.getMessage())
-               .append(" [")
-               .append(message.getRuleId())
-               .append("]");
-        
+        compact.append(message.getLocation().formatLocation()).append(": ").append(message.getSeverity()).append(": ")
+                .append(message.getMessage()).append(" [").append(message.getRuleId()).append("]");
+
         // Add actual/expected values inline if present
         if (message.getActualValue().isPresent() || message.getExpectedValue().isPresent()) {
             compact.append(" (");
@@ -125,7 +115,7 @@ public class MessageRenderer {
             }
             compact.append(")");
         }
-        
+
         // Add inline fix suggestion if available
         if (message.hasSuggestions() && !message.getSuggestions().isEmpty()) {
             String fixedValue = message.getSuggestions().get(0).getFixedValue();
@@ -133,10 +123,10 @@ public class MessageRenderer {
                 compact.append(" → ").append(fixedValue);
             }
         }
-        
+
         writer.println(compact);
     }
-    
+
     private String formatSeverity(ValidationMessage message) {
         return switch (message.getSeverity()) {
             case ERROR -> colorScheme.error("[ERROR]");
@@ -144,13 +134,13 @@ public class MessageRenderer {
             case INFO -> colorScheme.info("[INFO]");
         };
     }
-    
+
     private void renderStackTrace(Throwable throwable, PrintWriter writer) {
         writer.println("  Stack Trace:");
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         throwable.printStackTrace(pw);
-        
+
         // Indent each line of the stack trace
         String[] lines = sw.toString().split("\n");
         for (String line : lines) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SourceContext.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SourceContext.java
@@ -12,36 +12,37 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 public final class SourceContext {
     private final List<ContextLine> lines;
     private final SourceLocation errorLocation;
-    
+
     public SourceContext(List<String> fileLines, int startLineNumber, SourceLocation errorLocation) {
-        this.errorLocation = Objects.requireNonNull(errorLocation, "[" + getClass().getName() + "] errorLocation must not be null");
+        this.errorLocation = Objects.requireNonNull(errorLocation,
+                "[" + getClass().getName() + "] errorLocation must not be null");
         this.lines = new ArrayList<>();
-        
+
         int lineNum = startLineNumber;
         for (String content : fileLines) {
-            boolean isErrorLine = lineNum >= errorLocation.getStartLine() && 
-                                 lineNum <= errorLocation.getEndLine();
+            boolean isErrorLine = lineNum >= errorLocation.getStartLine() && lineNum <= errorLocation.getEndLine();
             lines.add(new ContextLine(lineNum, content, isErrorLine));
             lineNum++;
         }
     }
-    
+
     /**
      * Constructor for pre-built context lines.
      */
     public SourceContext(List<ContextLine> contextLines, SourceLocation originalLocation) {
         this.lines = new ArrayList<>(contextLines);
-        this.errorLocation = Objects.requireNonNull(originalLocation, "[" + getClass().getName() + "] originalLocation must not be null");
+        this.errorLocation = Objects.requireNonNull(originalLocation,
+                "[" + getClass().getName() + "] originalLocation must not be null");
     }
-    
+
     public List<ContextLine> getLines() {
         return new ArrayList<>(lines);
     }
-    
+
     public SourceLocation getErrorLocation() {
         return errorLocation;
     }
-    
+
     /**
      * Represents a single line in the source context.
      */
@@ -49,21 +50,21 @@ public final class SourceContext {
         private final int number;
         private final String content;
         private final boolean errorLine;
-        
+
         public ContextLine(int number, String content, boolean errorLine) {
             this.number = number;
             this.content = Objects.requireNonNull(content, "[" + getClass().getName() + "] content must not be null");
             this.errorLine = errorLine;
         }
-        
+
         public int getNumber() {
             return number;
         }
-        
+
         public String getContent() {
             return content;
         }
-        
+
         public boolean isErrorLine() {
             return errorLine;
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SuggestionRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SuggestionRenderer.java
@@ -14,12 +14,12 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 public class SuggestionRenderer {
     private final SuggestionsConfig config;
     private final ColorScheme colorScheme;
-    
+
     public SuggestionRenderer(SuggestionsConfig config, DisplayConfig displayConfig) {
         this.config = Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
         this.colorScheme = new ColorScheme(displayConfig.isUseColors());
     }
-    
+
     /**
      * Renders a list of suggestions.
      */
@@ -27,51 +27,51 @@ public class SuggestionRenderer {
         if (!config.isEnabled() || suggestions.isEmpty()) {
             return;
         }
-        
+
         // Suggestion header
         writer.print("  " + colorScheme.suggestionIcon("💡 "));
         writer.println("Suggested fix" + (suggestions.size() > 1 ? "es:" : ":"));
-        
+
         // Render each suggestion (up to max)
         int count = 0;
         for (Suggestion suggestion : suggestions) {
             if (++count > config.getMaxPerError()) {
                 break;
             }
-            
+
             renderSuggestion(suggestion, count, suggestions.size(), writer);
         }
     }
-    
+
     private void renderSuggestion(Suggestion suggestion, int index, int total, PrintWriter writer) {
         // Prefix for multiple suggestions
         String prefix = total > 1 ? String.format("  %d. ", index) : "  ";
-        
+
         // Description
         writer.println(prefix + colorScheme.suggestion(suggestion.getDescription()));
-        
+
         // Fixed value if available
         if (suggestion.hasFixedValue()) {
             String indent = total > 1 ? "     " : "  ";
             writer.println(indent + colorScheme.code(suggestion.getFixedValue()));
         }
-        
+
         // Explanation if available
         if (suggestion.getExplanation() != null) {
             String indent = total > 1 ? "     " : "  ";
             writer.println(indent + suggestion.getExplanation());
         }
-        
+
         // Examples if configured
         if (config.isShowExamples() && suggestion.hasExamples()) {
             renderExamples(suggestion.getExamples(), total > 1, writer);
         }
     }
-    
+
     private void renderExamples(List<String> examples, boolean numbered, PrintWriter writer) {
         String indent = numbered ? "     " : "  ";
         writer.println(indent + "Examples:");
-        
+
         for (String example : examples) {
             writer.println(indent + "- " + colorScheme.code(example));
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/console/SummaryRenderer.java
@@ -20,12 +20,12 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 public class SummaryRenderer {
     private final SummaryConfig config;
     private final ColorScheme colorScheme;
-    
+
     public SummaryRenderer(SummaryConfig config, DisplayConfig displayConfig) {
         this.config = Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
         this.colorScheme = new ColorScheme(displayConfig.isUseColors());
     }
-    
+
     /**
      * Renders the validation summary.
      */
@@ -33,45 +33,45 @@ public class SummaryRenderer {
         if (!config.isEnabled()) {
             return;
         }
-        
+
         writer.println();
         AsciiBoxDrawer boxDrawer = new AsciiBoxDrawer(DisplayConstants.DEFAULT_BOX_WIDTH, writer);
         boxDrawer.drawTop();
         boxDrawer.drawTitle("Validation Summary");
         boxDrawer.drawBottom();
-        
+
         if (config.isShowStatistics()) {
             renderStatistics(result, writer);
         }
-        
+
         if (config.isShowMostCommon()) {
             renderMostCommonIssues(result, writer);
         }
-        
+
         if (config.isShowFileList()) {
             renderFileList(result, writer);
         }
-        
+
         renderSummaryLine(result, writer);
-        
+
         boxDrawer.drawTop();
     }
-    
+
     private void renderStatistics(ValidationResult result, PrintWriter writer) {
         // File statistics
         int totalFiles = getUniqueFileCount(result);
         int filesWithErrors = getFilesWithErrorCount(result);
-        
+
         writer.println("  Total files scanned:     " + totalFiles);
         writer.println("  Files with errors:       " + filesWithErrors);
         writer.println();
-        
+
         // Error counts with visual bars
         int errors = result.getErrorCount();
         int warnings = result.getWarningCount();
         int infos = result.getInfoCount();
         int total = errors + warnings + infos;
-        
+
         if (total > 0) {
             writer.println("  Errors:   " + colorScheme.error(String.valueOf(errors)));
             writer.println("  Warnings: " + colorScheme.warning(String.valueOf(warnings)));
@@ -79,92 +79,75 @@ public class SummaryRenderer {
             writer.println();
         }
     }
-    
+
     private void renderMostCommonIssues(ValidationResult result, PrintWriter writer) {
-        Map<String, Long> issueFrequency = result.getMessages().stream()
-            .collect(Collectors.groupingBy(
-                ValidationMessage::getRuleId,
-                LinkedHashMap::new,
-                Collectors.counting()
-            ));
-        
+        Map<String, Long> issueFrequency = result.getMessages().stream().collect(
+                Collectors.groupingBy(ValidationMessage::getRuleId, LinkedHashMap::new, Collectors.counting()));
+
         if (issueFrequency.isEmpty()) {
             return;
         }
-        
+
         writer.println("  Most common issues:");
-        
+
         // Get top 5 issues
-        issueFrequency.entrySet().stream()
-            .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-            .limit(5)
-            .forEach(entry -> {
-                String ruleId = entry.getKey();
-                long count = entry.getValue();
-                
-                // Try to get a description from the first message with this rule
-                String description = result.getMessages().stream()
-                    .filter(msg -> msg.getRuleId().equals(ruleId))
-                    .findFirst()
-                    .map(msg -> extractShortDescription(msg.getMessage()))
-                    .orElse(ruleId);
-                
-                writer.printf("  - %s (%d occurrence%s)%n",
-                    description,
-                    count,
-                    count == 1 ? "" : "s"
-                );
-            });
-        
+        issueFrequency.entrySet().stream().sorted(Map.Entry.<String, Long>comparingByValue().reversed()).limit(5)
+                .forEach(entry -> {
+                    String ruleId = entry.getKey();
+                    long count = entry.getValue();
+
+                    // Try to get a description from the first message with this rule
+                    String description = result.getMessages().stream().filter(msg -> msg.getRuleId().equals(ruleId))
+                            .findFirst().map(msg -> extractShortDescription(msg.getMessage())).orElse(ruleId);
+
+                    writer.printf("  - %s (%d occurrence%s)%n", description, count, count == 1 ? "" : "s");
+                });
+
         writer.println();
     }
-    
+
     private void renderFileList(ValidationResult result, PrintWriter writer) {
         Map<String, List<ValidationMessage>> byFile = result.getMessagesByFile();
-        
+
         if (byFile.isEmpty()) {
             return;
         }
-        
+
         writer.println("  Files with issues:");
-        byFile.entrySet().stream()
-            .sorted(Map.Entry.comparingByKey())
-            .forEach(entry -> {
-                String filename = entry.getKey();
-                List<ValidationMessage> messages = entry.getValue();
-                
-                long errorCount = messages.stream()
+        byFile.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> {
+            String filename = entry.getKey();
+            List<ValidationMessage> messages = entry.getValue();
+
+            long errorCount = messages.stream()
                     .filter(msg -> msg.getSeverity() == com.dataliquid.asciidoc.linter.config.common.Severity.ERROR)
                     .count();
-                long warnCount = messages.stream()
+            long warnCount = messages.stream()
                     .filter(msg -> msg.getSeverity() == com.dataliquid.asciidoc.linter.config.common.Severity.WARN)
                     .count();
-                
-                writer.printf("  - %s: ", filename);
-                if (errorCount > 0) {
-                    writer.print(colorScheme.error(errorCount + " error" + (errorCount == 1 ? "" : "s")));
-                    if (warnCount > 0) {
-                        writer.print(", ");
-                    }
-                }
+
+            writer.printf("  - %s: ", filename);
+            if (errorCount > 0) {
+                writer.print(colorScheme.error(errorCount + " error" + (errorCount == 1 ? "" : "s")));
                 if (warnCount > 0) {
-                    writer.print(colorScheme.warning(warnCount + " warning" + (warnCount == 1 ? "" : "s")));
+                    writer.print(", ");
                 }
-                writer.println();
-            });
+            }
+            if (warnCount > 0) {
+                writer.print(colorScheme.warning(warnCount + " warning" + (warnCount == 1 ? "" : "s")));
+            }
+            writer.println();
+        });
         writer.println();
     }
-    
+
     private void renderSummaryLine(ValidationResult result, PrintWriter writer) {
         int errors = result.getErrorCount();
         int warnings = result.getWarningCount();
         int infos = result.getInfoCount();
-        
-        String summary = String.format("Summary: %d error%s, %d warning%s, %d info message%s",
-            errors, errors == 1 ? "" : "s",
-            warnings, warnings == 1 ? "" : "s",
-            infos, infos == 1 ? "" : "s");
-        
+
+        String summary = String.format("Summary: %d error%s, %d warning%s, %d info message%s", errors,
+                errors == 1 ? "" : "s", warnings, warnings == 1 ? "" : "s", infos, infos == 1 ? "" : "s");
+
         // Color based on severity
         if (errors > 0) {
             summary = colorScheme.error(summary);
@@ -173,39 +156,36 @@ public class SummaryRenderer {
         } else {
             summary = colorScheme.success(summary);
         }
-        
+
         writer.println();
         writer.println(summary);
         writer.println("Validation completed in " + result.getValidationTimeMillis() + "ms");
     }
-    
-    
+
     private int getUniqueFileCount(ValidationResult result) {
         // Use the actual scanned file count from ValidationResult
         return result.getScannedFileCount();
     }
-    
+
     private int getFilesWithErrorCount(ValidationResult result) {
         return (int) result.getMessages().stream()
-            .filter(msg -> msg.getSeverity() == com.dataliquid.asciidoc.linter.config.common.Severity.ERROR)
-            .map(msg -> msg.getLocation().getFilename())
-            .distinct()
-            .count();
+                .filter(msg -> msg.getSeverity() == com.dataliquid.asciidoc.linter.config.common.Severity.ERROR)
+                .map(msg -> msg.getLocation().getFilename()).distinct().count();
     }
-    
+
     private String extractShortDescription(String message) {
         // Extract only the first line to avoid showing stack traces in summary
         if (message == null) {
             return "";
         }
-        
+
         // Find the first newline
         int newlineIndex = message.indexOf('\n');
         if (newlineIndex > 0) {
             // Return only the first line (before stack trace)
             return message.substring(0, newlineIndex).trim();
         }
-        
+
         // No newline found, return the full message
         return message.trim();
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/BlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/BlockValidator.java
@@ -25,36 +25,36 @@ import com.dataliquid.asciidoc.linter.validator.block.BlockValidationContext;
 import com.dataliquid.asciidoc.linter.validator.block.BlockValidatorFactory;
 
 /**
- * Main validator for blocks within sections.
- * Orchestrates block type validation and occurrence validation.
+ * Main validator for blocks within sections. Orchestrates block type validation and occurrence validation.
  */
 public final class BlockValidator {
-    
+
     private final BlockValidatorFactory validatorFactory;
     private final BlockTypeDetector typeDetector;
     private final BlockOccurrenceValidator occurrenceValidator;
-    
+
     public BlockValidator() {
         this.validatorFactory = new BlockValidatorFactory();
         this.typeDetector = new BlockTypeDetector();
         this.occurrenceValidator = new BlockOccurrenceValidator();
     }
-    
+
     /**
      * Validates all blocks at document level (level 0) against the configuration.
-     * 
-     * @param document the AsciiDoc document to validate
-     * @param config the section configuration containing block rules (level 0)
-     * @param filename the filename for error reporting
+     *
+     * @param document
+     *            the AsciiDoc document to validate
+     * @param config
+     *            the section configuration containing block rules (level 0)
+     * @param filename
+     *            the filename for error reporting
      * @return validation result containing all messages
      */
-    public ValidationResult validate(Document document, 
-                                   SectionConfig config,
-                                   String filename) {
+    public ValidationResult validate(Document document, SectionConfig config, String filename) {
         Objects.requireNonNull(document, "[" + getClass().getName() + "] document must not be null");
         Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
         Objects.requireNonNull(filename, "[" + getClass().getName() + "] filename must not be null");
-        
+
         // Use the generic validation method with a document container
         BlockContainer container = BlockContainer.fromDocument(document);
         BlockValidationContext context = new BlockValidationContext(document, filename);
@@ -64,115 +64,101 @@ public final class BlockValidator {
 
     /**
      * Validates all blocks within a section against the configuration.
-     * 
-     * @param section the AsciiDoc section to validate
-     * @param config the section configuration containing block rules
-     * @param filename the filename for error reporting
+     *
+     * @param section
+     *            the AsciiDoc section to validate
+     * @param config
+     *            the section configuration containing block rules
+     * @param filename
+     *            the filename for error reporting
      * @return validation result containing all messages
      */
-    public ValidationResult validate(Section section, 
-                                   SectionConfig config,
-                                   String filename) {
+    public ValidationResult validate(Section section, SectionConfig config, String filename) {
         Objects.requireNonNull(section, "[" + getClass().getName() + "] section must not be null");
         Objects.requireNonNull(config, "[" + getClass().getName() + "] config must not be null");
         Objects.requireNonNull(filename, "[" + getClass().getName() + "] filename must not be null");
-        
+
         // Use the generic validation method with a section container
         BlockContainer container = BlockContainer.fromSection(section);
         BlockValidationContext context = new BlockValidationContext(section, filename);
         return validateContainer(container, config, context, filename);
     }
-    
+
     /**
      * Generic validation method for any block container.
      */
-    private ValidationResult validateContainer(BlockContainer container,
-                                             SectionConfig config,
-                                             BlockValidationContext context,
-                                             String filename) {
+    private ValidationResult validateContainer(BlockContainer container, SectionConfig config,
+            BlockValidationContext context, String filename) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // No block validation if no blocks configured
         if (config.allowedBlocks() == null || config.allowedBlocks().isEmpty()) {
-            return ValidationResult.builder()
-                .addMessages(messages)
-                .build();
+            return ValidationResult.builder().addMessages(messages).build();
         }
-        
+
         // First pass: validate individual blocks and track occurrences
         validateContainerBlocks(container, config, context, messages);
-        
+
         // Second pass: validate occurrences
         messages.addAll(occurrenceValidator.validate(context, config.allowedBlocks()));
-        
+
         // Third pass: validate block order based on order attribute
         validateBlockOrder(container, config, context, messages);
-        
-        return ValidationResult.builder()
-            .addMessages(messages)
-            .build();
+
+        return ValidationResult.builder().addMessages(messages).build();
     }
-    
+
     /**
      * Validates individual blocks from the container and tracks them in the context.
      */
-    private void validateContainerBlocks(BlockContainer container,
-                                       SectionConfig config,
-                                       BlockValidationContext context,
-                                       List<ValidationMessage> messages) {
-        
+    private void validateContainerBlocks(BlockContainer container, SectionConfig config, BlockValidationContext context,
+            List<ValidationMessage> messages) {
+
         // Get all blocks from the container (handles preamble expansion automatically)
         List<StructuralNode> blocks = container.getBlocks();
-        
+
         if (blocks.isEmpty()) {
             return;
         }
-        
+
         for (StructuralNode block : blocks) {
             try {
                 // Skip sections - they are handled by SectionValidator
                 if (block instanceof Section) {
                     continue;
                 }
-                
+
                 // Detect block type
                 BlockType actualType = typeDetector.detectType(block);
-                
+
                 if (actualType == null) {
                     // Unknown block type - add validation message
-                    messages.add(ValidationMessage.builder()
-                        .severity(Severity.ERROR)
-                        .ruleId(TYPE_UNKNOWN)
-                        .location(context.createLocation(block))
-                        .message("Unknown block type: " + block.getContext())
-                        .actualValue(block.getContext())
-                        .expectedValue("Valid AsciiDoc block type")
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(Severity.ERROR).ruleId(TYPE_UNKNOWN)
+                            .location(context.createLocation(block))
+                            .message("Unknown block type: " + block.getContext()).actualValue(block.getContext())
+                            .expectedValue("Valid AsciiDoc block type").build());
                     continue;
                 }
-                
+
                 // Find matching configuration
                 Block blockConfig = findBlockConfig(actualType, block, config.allowedBlocks());
-                
+
                 if (blockConfig == null) {
                     // Block type not allowed
-                    messages.add(ValidationMessage.builder()
-                        .severity(Severity.ERROR)
-                        .ruleId(TYPE_NOT_ALLOWED)
-                        .location(context.createLocation(block))
-                        .message("Block type not allowed in " + container.getContainerType())
-                        .actualValue(actualType.toString())
-                        .expectedValue("One of the allowed block types")
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(Severity.ERROR).ruleId(TYPE_NOT_ALLOWED)
+                            .location(context.createLocation(block))
+                            .message("Block type not allowed in " + container.getContainerType())
+                            .actualValue(actualType.toString()).expectedValue("One of the allowed block types")
+                            .build());
                     continue;
                 }
-                
+
                 // Track the block
                 context.trackBlock(blockConfig, block);
-                
+
                 // Debug only for document container
                 // Track the block
-                
+
                 // Validate if we have a validator for this type
                 BlockTypeValidator validator = validatorFactory.getValidator(actualType);
                 if (validator != null) {
@@ -180,27 +166,21 @@ public final class BlockValidator {
                 }
             } catch (Exception e) {
                 // Handle validation exceptions gracefully
-                messages.add(ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId(VALIDATION_ERROR)
-                    .location(context.createLocation(block))
-                    .message("Error validating block: " + e.getMessage())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(Severity.ERROR).ruleId(VALIDATION_ERROR)
+                        .location(context.createLocation(block)).message("Error validating block: " + e.getMessage())
+                        .build());
             }
         }
     }
 
     /**
      * Finds the configuration for a specific block.
-     * 
-     * Matching logic:
-     * 1. If block has a name attribute, try to find config with matching name and type
-     * 2. Otherwise, find any config with matching type
-     * 3. Config names are for identification only and don't prevent matching unnamed blocks
+     *
+     * Matching logic: 1. If block has a name attribute, try to find config with matching name and type 2. Otherwise,
+     * find any config with matching type 3. Config names are for identification only and don't prevent matching unnamed
+     * blocks
      */
-    private Block findBlockConfig(BlockType type, 
-                                        StructuralNode block,
-                                        List<Block> configs) {
+    private Block findBlockConfig(BlockType type, StructuralNode block, List<Block> configs) {
         // First try to match by name attribute if block has one
         Object nameAttr = block.getAttribute("name");
         if (nameAttr != null) {
@@ -211,101 +191,95 @@ public final class BlockValidator {
                 }
             }
         }
-        
+
         // Then match by type only (config name is just for identification)
         for (Block config : configs) {
             if (config.getType() == type) {
                 return config;
             }
         }
-        
+
         return null;
     }
-    
+
     /**
-     * Special version of findBlockConfig that tracks which configs have already been matched.
-     * This ensures each config is only matched once when multiple blocks of the same type exist.
+     * Special version of findBlockConfig that tracks which configs have already been matched. This ensures each config
+     * is only matched once when multiple blocks of the same type exist.
      */
-    private Block findBlockConfigForOrder(BlockType type, 
-                                         StructuralNode block,
-                                         List<Block> configs,
-                                         Set<Block> alreadyMatched) {
+    private Block findBlockConfigForOrder(BlockType type, StructuralNode block, List<Block> configs,
+            Set<Block> alreadyMatched) {
         // First try to match by name attribute if block has one
         Object nameAttr = block.getAttribute("name");
         if (nameAttr != null) {
             String blockName = nameAttr.toString();
             for (Block config : configs) {
-                if (config.getType() == type && 
-                    blockName.equals(config.getName()) && 
-                    !alreadyMatched.contains(config)) {
+                if (config.getType() == type && blockName.equals(config.getName())
+                        && !alreadyMatched.contains(config)) {
                     return config;
                 }
             }
         }
-        
+
         // Then match by type only, but skip already matched configs
         for (Block config : configs) {
             if (config.getType() == type && !alreadyMatched.contains(config)) {
                 return config;
             }
         }
-        
+
         return null;
     }
-    
+
     /**
      * Validates block order based on the order attribute in block configurations.
      */
-    private void validateBlockOrder(BlockContainer container, SectionConfig config, 
-                                   BlockValidationContext context,
-                                   List<ValidationMessage> messages) {
-        List<Block> orderedBlocks = config.allowedBlocks().stream()
-            .filter(block -> block.getOrder() != null)
-            .sorted((b1, b2) -> b1.getOrder().compareTo(b2.getOrder()))
-            .collect(Collectors.toList());
-        
+    private void validateBlockOrder(BlockContainer container, SectionConfig config, BlockValidationContext context,
+            List<ValidationMessage> messages) {
+        List<Block> orderedBlocks = config.allowedBlocks().stream().filter(block -> block.getOrder() != null)
+                .sorted((b1, b2) -> b1.getOrder().compareTo(b2.getOrder())).collect(Collectors.toList());
+
         if (orderedBlocks.isEmpty()) {
             return; // No order constraints
         }
-        
+
         List<StructuralNode> blocks = container.getBlocks();
         List<Block> matchedBlockConfigs = new ArrayList<>();
         Set<Block> alreadyMatched = new HashSet<>();
-        
+
         // First, match each document block to its configuration
         for (StructuralNode block : blocks) {
             if (block instanceof Section) {
                 continue;
             }
-            
+
             BlockType type = typeDetector.detectType(block);
             if (type == null) {
                 continue;
             }
-            
+
             Block blockConfig = findBlockConfigForOrder(type, block, config.allowedBlocks(), alreadyMatched);
             if (blockConfig != null && blockConfig.getOrder() != null) {
                 matchedBlockConfigs.add(blockConfig);
                 alreadyMatched.add(blockConfig);
             }
         }
-        
+
         // Now check if the matched blocks are in the correct order
         for (int i = 0; i < matchedBlockConfigs.size() - 1; i++) {
             Block current = matchedBlockConfigs.get(i);
             Block next = matchedBlockConfigs.get(i + 1);
-            
+
             if (current.getOrder() > next.getOrder()) {
                 // Find the actual block positions for error reporting
                 int currentBlockIndex = -1;
                 int nextBlockIndex = -1;
-                
+
                 for (int j = 0; j < blocks.size(); j++) {
                     StructuralNode block = blocks.get(j);
                     if (block instanceof Section) {
                         continue;
                     }
-                    
+
                     BlockType type = typeDetector.detectType(block);
                     if (type != null) {
                         Block blockCfg = findBlockConfig(type, block, config.allowedBlocks());
@@ -316,19 +290,16 @@ public final class BlockValidator {
                         }
                     }
                 }
-                
+
                 String currentKey = current.getName() != null ? current.getName() : current.getType().toString();
                 String nextKey = next.getName() != null ? next.getName() : next.getType().toString();
-                
-                messages.add(ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId(ORDER)
-                    .location(context.createLocation(blocks.get(currentBlockIndex)))
-                    .message("Block order violation: '" + currentKey + "' (order=" + current.getOrder() + 
-                            ") appears after '" + nextKey + "' (order=" + next.getOrder() + ")")
-                    .actualValue(currentKey + " at position " + i)
-                    .expectedValue(currentKey + " should appear before " + nextKey)
-                    .build());
+
+                messages.add(ValidationMessage.builder().severity(Severity.ERROR).ruleId(ORDER)
+                        .location(context.createLocation(blocks.get(currentBlockIndex)))
+                        .message("Block order violation: '" + currentKey + "' (order=" + current.getOrder()
+                                + ") appears after '" + nextKey + "' (order=" + next.getOrder() + ")")
+                        .actualValue(currentKey + " at position " + i)
+                        .expectedValue(currentKey + " should appear before " + nextKey).build());
             }
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/ErrorType.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/ErrorType.java
@@ -8,27 +8,27 @@ public enum ErrorType {
      * A required value is missing.
      */
     MISSING_VALUE,
-    
+
     /**
      * A value doesn't match the expected pattern.
      */
     INVALID_PATTERN,
-    
+
     /**
      * A value is outside the allowed range.
      */
     OUT_OF_RANGE,
-    
+
     /**
      * A value is not in the allowed set.
      */
     INVALID_ENUM,
-    
+
     /**
      * Multiple validation failures.
      */
     MULTIPLE_ERRORS,
-    
+
     /**
      * Generic validation error.
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/PlaceholderContext.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/PlaceholderContext.java
@@ -1,115 +1,117 @@
 package com.dataliquid.asciidoc.linter.validator;
 
 /**
- * Context information for placeholder insertion in error messages.
- * This helps the renderer determine the correct syntax for placeholders.
+ * Context information for placeholder insertion in error messages. This helps the renderer determine the correct syntax
+ * for placeholders.
  */
 public class PlaceholderContext {
-    
+
     public enum PlaceholderType {
-        ATTRIBUTE_VALUE,      // e.g., width=«100»
-        ATTRIBUTE_IN_LIST,    // e.g., ,width=«100»
-        SIMPLE_VALUE,         // e.g., «language»
-        LIST_VALUE,           // e.g., ,«language»
-        INSERT_BEFORE         // Insert before the given position (e.g., before ])
+        ATTRIBUTE_VALUE, // e.g., width=«100»
+        ATTRIBUTE_IN_LIST, // e.g., ,width=«100»
+        SIMPLE_VALUE, // e.g., «language»
+        LIST_VALUE, // e.g., ,«language»
+        INSERT_BEFORE // Insert before the given position (e.g., before ])
     }
-    
+
     private final PlaceholderType type;
     private final String attributeName;
     private final boolean isFirstAttribute;
     private final boolean hasExistingAttributes;
-    
+
     private PlaceholderContext(Builder builder) {
         this.type = builder.type;
         this.attributeName = builder.attributeName;
         this.isFirstAttribute = builder.isFirstAttribute;
         this.hasExistingAttributes = builder.hasExistingAttributes;
     }
-    
+
     public PlaceholderType getType() {
         return type;
     }
-    
+
     public String getAttributeName() {
         return attributeName;
     }
-    
+
     public boolean isFirstAttribute() {
         return isFirstAttribute;
     }
-    
+
     public boolean hasExistingAttributes() {
         return hasExistingAttributes;
     }
-    
+
     /**
      * Generates the complete placeholder string based on context.
-     * @param value The placeholder value (without delimiters)
+     *
+     * @param value
+     *            The placeholder value (without delimiters)
      * @return The complete placeholder with appropriate syntax
      */
     public String generatePlaceholder(String value) {
         String placeholder = "«" + value + "»";
-        
+
         switch (type) {
-            case ATTRIBUTE_VALUE:
+            case ATTRIBUTE_VALUE :
                 return attributeName + "=" + placeholder;
-                
-            case ATTRIBUTE_IN_LIST:
+
+            case ATTRIBUTE_IN_LIST :
                 return "," + attributeName + "=" + placeholder;
-                
-            case LIST_VALUE:
+
+            case LIST_VALUE :
                 return "," + placeholder;
-                
-            case SIMPLE_VALUE:
-            default:
+
+            case SIMPLE_VALUE :
+            default :
                 return placeholder;
         }
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     public static class Builder {
         private PlaceholderType type = PlaceholderType.SIMPLE_VALUE;
         private String attributeName;
         private boolean isFirstAttribute = false;
         private boolean hasExistingAttributes = false;
-        
+
         public Builder type(PlaceholderType type) {
             this.type = type;
             return this;
         }
-        
+
         public Builder attributeName(String attributeName) {
             this.attributeName = attributeName;
             return this;
         }
-        
+
         public Builder isFirstAttribute(boolean isFirstAttribute) {
             this.isFirstAttribute = isFirstAttribute;
             return this;
         }
-        
+
         public Builder hasExistingAttributes(boolean hasExistingAttributes) {
             this.hasExistingAttributes = hasExistingAttributes;
             return this;
         }
-        
+
         public PlaceholderContext build() {
             return new PlaceholderContext(this);
         }
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         PlaceholderContext that = (PlaceholderContext) o;
-        return isFirstAttribute == that.isFirstAttribute &&
-                hasExistingAttributes == that.hasExistingAttributes &&
-                type == that.type &&
-                java.util.Objects.equals(attributeName, that.attributeName);
+        return isFirstAttribute == that.isFirstAttribute && hasExistingAttributes == that.hasExistingAttributes
+                && type == that.type && java.util.Objects.equals(attributeName, that.attributeName);
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/RuleIds.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/RuleIds.java
@@ -1,15 +1,15 @@
 package com.dataliquid.asciidoc.linter.validator;
 
 /**
- * Central repository for all validation rule IDs.
- * This class provides constants for rule IDs used across all validators
+ * Central repository for all validation rule IDs. This class provides constants for rule IDs used across all validators
  * to ensure consistency and maintainability.
  */
 public final class RuleIds {
-    
+
     // Prevent instantiation
-    private RuleIds() {}
-    
+    private RuleIds() {
+    }
+
     /**
      * Rule IDs for general block validation
      */
@@ -24,7 +24,7 @@ public final class RuleIds {
         public static final String OCCURRENCE_MIN = "block.occurrence.min";
         public static final String OCCURRENCE_MAX = "block.occurrence.max";
     }
-    
+
     /**
      * Rule IDs for section validation
      */
@@ -37,7 +37,7 @@ public final class RuleIds {
         public static final String LEVEL0_MISSING = "section.level0.missing";
         public static final String ORDER = "section.order";
     }
-    
+
     /**
      * Rule IDs for metadata validation
      */
@@ -49,7 +49,7 @@ public final class RuleIds {
         public static final String LENGTH_MAX = "metadata.length.max";
         public static final String ORDER = "metadata.order";
     }
-    
+
     /**
      * Rule IDs for admonition block validation
      */
@@ -68,7 +68,7 @@ public final class RuleIds {
         public static final String ICON_REQUIRED = "admonition.icon.required";
         public static final String ICON_PATTERN = "admonition.icon.pattern";
     }
-    
+
     /**
      * Rule IDs for audio block validation
      */
@@ -82,7 +82,7 @@ public final class RuleIds {
         public static final String TITLE_MIN_LENGTH = "audio.title.minLength";
         public static final String TITLE_MAX_LENGTH = "audio.title.maxLength";
     }
-    
+
     /**
      * Rule IDs for description list (dlist) validation
      */
@@ -95,7 +95,7 @@ public final class RuleIds {
         public static final String DESCRIPTIONS_REQUIRED = "dlist.descriptions.required";
         public static final String DESCRIPTIONS_PATTERN = "dlist.descriptions.pattern";
     }
-    
+
     /**
      * Rule IDs for example block validation
      */
@@ -107,7 +107,7 @@ public final class RuleIds {
         public static final String COLLAPSIBLE_REQUIRED = "example.collapsible.required";
         public static final String COLLAPSIBLE_ALLOWED = "example.collapsible.allowed";
     }
-    
+
     /**
      * Rule IDs for image block validation
      */
@@ -124,7 +124,7 @@ public final class RuleIds {
         public static final String ALT_MIN_LENGTH = "image.alt.minLength";
         public static final String ALT_MAX_LENGTH = "image.alt.maxLength";
     }
-    
+
     /**
      * Rule IDs for listing block validation
      */
@@ -138,7 +138,7 @@ public final class RuleIds {
         public static final String CALLOUTS_NOT_ALLOWED = "listing.callouts.notAllowed";
         public static final String CALLOUTS_MAX = "listing.callouts.max";
     }
-    
+
     /**
      * Rule IDs for literal block validation
      */
@@ -149,7 +149,7 @@ public final class RuleIds {
         public static final String INDENTATION_CONSISTENT = "literal.indentation.consistent";
         public static final String LINES_MIN = "literal.lines.min";
     }
-    
+
     /**
      * Rule IDs for paragraph block validation
      */
@@ -165,7 +165,7 @@ public final class RuleIds {
         public static final String SENTENCE_WORDS_MIN = "paragraph.sentence.words.min";
         public static final String SENTENCE_WORDS_MAX = "paragraph.sentence.words.max";
     }
-    
+
     /**
      * Rule IDs for pass block validation
      */
@@ -179,7 +179,7 @@ public final class RuleIds {
         public static final String REASON_MIN_LENGTH = "pass.reason.minLength";
         public static final String REASON_MAX_LENGTH = "pass.reason.maxLength";
     }
-    
+
     /**
      * Rule IDs for quote block validation
      */
@@ -198,7 +198,7 @@ public final class RuleIds {
         public static final String CONTENT_LINES_MIN = "quote.content.lines.min";
         public static final String CONTENT_LINES_MAX = "quote.content.lines.max";
     }
-    
+
     /**
      * Rule IDs for sidebar block validation
      */
@@ -215,7 +215,7 @@ public final class RuleIds {
         public static final String POSITION_REQUIRED = "sidebar.position.required";
         public static final String POSITION_ALLOWED = "sidebar.position.allowed";
     }
-    
+
     /**
      * Rule IDs for table block validation
      */
@@ -233,7 +233,7 @@ public final class RuleIds {
         public static final String FORMAT_STYLE = "table.format.style";
         public static final String FORMAT_BORDERS = "table.format.borders";
     }
-    
+
     /**
      * Rule IDs for unordered list validation
      */
@@ -243,7 +243,7 @@ public final class RuleIds {
         public static final String NESTING_LEVEL_MAX = "ulist.nestingLevel.max";
         public static final String MARKER_STYLE = "ulist.markerStyle";
     }
-    
+
     /**
      * Rule IDs for verse block validation
      */
@@ -261,7 +261,7 @@ public final class RuleIds {
         public static final String CONTENT_MAX_LENGTH = "verse.content.maxLength";
         public static final String CONTENT_PATTERN = "verse.content.pattern";
     }
-    
+
     /**
      * Rule IDs for video block validation
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/SectionValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/SectionValidator.java
@@ -29,7 +29,8 @@ public final class SectionValidator {
     private final FileContentCache fileCache;
 
     private SectionValidator(Builder builder) {
-        this.configuration = Objects.requireNonNull(builder.configuration, "[" + getClass().getName() + "] configuration must not be null");
+        this.configuration = Objects.requireNonNull(builder.configuration,
+                "[" + getClass().getName() + "] configuration must not be null");
         this.sectionOccurrences = new HashMap<>();
         this.rootSections = configuration.sections() != null ? configuration.sections() : Collections.emptyList();
         this.fileCache = new FileContentCache();
@@ -39,31 +40,31 @@ public final class SectionValidator {
         // FIXME: refactor to more clear architecture design
         return validate(document, extractFilename(document));
     }
-    
+
     public ValidationResult validate(Document document, String filename) {
         long startTime = System.currentTimeMillis();
         ValidationResult.Builder resultBuilder = ValidationResult.builder().startTime(startTime);
-        
+
         // Validate document title as level 0 section
         validateDocumentTitle(document, filename, resultBuilder);
-        
-        List<StructuralNode> sections = document.getBlocks().stream()
-            .filter(block -> block instanceof Section)
-            .collect(Collectors.toList());
-        
+
+        List<StructuralNode> sections = document.getBlocks().stream().filter(block -> block instanceof Section)
+                .collect(Collectors.toList());
+
         validateRootSections(sections, filename, resultBuilder);
-        
+
         validateMinMaxOccurrences(filename, resultBuilder);
-        
+
         validateSectionOrder(sections, filename, resultBuilder);
-        
+
         return resultBuilder.complete().build();
     }
 
-    private void validateRootSections(List<StructuralNode> sections, String filename, ValidationResult.Builder resultBuilder) {
+    private void validateRootSections(List<StructuralNode> sections, String filename,
+            ValidationResult.Builder resultBuilder) {
         // Determine which configs to use for level 1 sections
         List<SectionConfig> level1Configs = determineLevel1Configs();
-        
+
         for (StructuralNode node : sections) {
             if (node instanceof Section) {
                 Section section = (Section) node;
@@ -71,7 +72,7 @@ public final class SectionValidator {
             }
         }
     }
-    
+
     private List<SectionConfig> determineLevel1Configs() {
         // Check if level 0 config has subsections defined
         for (SectionConfig config : rootSections) {
@@ -79,86 +80,75 @@ public final class SectionValidator {
                 return config.subsections();
             }
         }
-        
+
         // Fallback: use all non-level-0 configs from root
-        return rootSections.stream()
-            .filter(config -> config.level() != 0)
-            .collect(Collectors.toList());
+        return rootSections.stream().filter(config -> config.level() != 0).collect(Collectors.toList());
     }
 
-    private void validateSection(Section section, List<SectionConfig> allowedConfigs, 
-                                String filename, ValidationResult.Builder resultBuilder, 
-                                SectionConfig parentConfig) {
-        
+    private void validateSection(Section section, List<SectionConfig> allowedConfigs, String filename,
+            ValidationResult.Builder resultBuilder, SectionConfig parentConfig) {
+
         int level = section.getLevel();
         String title = section.getTitle();
-        
+
         SectionConfig matchingConfig = findMatchingConfig(section, allowedConfigs);
-        
+
         if (matchingConfig == null && !allowedConfigs.isEmpty()) {
             // Check if there are configs for this level with pattern mismatches
             List<SectionConfig> levelConfigs = findConfigsForLevel(level, allowedConfigs);
-            
+
             SourceLocation location = createLocation(filename, section);
-            
+
             if (!levelConfigs.isEmpty()) {
                 // There are configs for this level, but title doesn't match any patterns
                 // Find the first config with a pattern to show in error message
                 SectionConfig configWithPattern = levelConfigs.stream()
-                    .filter(config -> config.title() != null && 
-                           config.title().pattern() != null)
-                    .findFirst()
-                    .orElse(levelConfigs.get(0));
-                
+                        .filter(config -> config.title() != null && config.title().pattern() != null).findFirst()
+                        .orElse(levelConfigs.get(0));
+
                 String expectedPattern = null;
                 if (configWithPattern.title() != null && configWithPattern.title().pattern() != null) {
                     expectedPattern = "Pattern: " + configWithPattern.title().pattern();
                 }
-                
+
                 ValidationMessage message = ValidationMessage.builder()
-                    .severity(configWithPattern.title() != null && configWithPattern.title().severity() != null ? 
-                            configWithPattern.title().severity() : Severity.ERROR)
-                    .ruleId(TITLE_PATTERN)
-                    .location(location)
-                    .message("Section title does not match required pattern")
-                    .actualValue(title)
-                    .expectedValue(expectedPattern != null ? expectedPattern : "One of configured patterns")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Adjust section title to match required pattern")
-                        .addExample("== Introduction")
-                        .addExample("== Getting Started")
-                        .addExample("== Configuration")
-                        .explanation("Section titles must follow the configured naming pattern for consistency")
-                        .build())
-                    .build();
+                        .severity(configWithPattern.title() != null && configWithPattern.title().severity() != null
+                                ? configWithPattern.title().severity()
+                                : Severity.ERROR)
+                        .ruleId(TITLE_PATTERN).location(location)
+                        .message("Section title does not match required pattern").actualValue(title)
+                        .expectedValue(expectedPattern != null ? expectedPattern : "One of configured patterns")
+                        .addSuggestion(Suggestion.builder()
+                                .description("Adjust section title to match required pattern")
+                                .addExample("== Introduction").addExample("== Getting Started")
+                                .addExample("== Configuration")
+                                .explanation("Section titles must follow the configured naming pattern for consistency")
+                                .build())
+                        .build();
                 resultBuilder.addMessage(message);
             } else {
                 // No configs for this level at all
-                ValidationMessage message = ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId(UNEXPECTED)
-                    .location(location)
-                    .message("Section not allowed at level " + level + ": '" + title + "'")
-                    .actualValue(title)
-                    .expectedValue("No sections configured for level " + level)
-                    .addSuggestion(Suggestion.builder()
-                        .description("Remove unexpected section or move to appropriate level")
-                        .addExample("Remove this section if not needed")
-                        .addExample("Move section to a different document structure level")
-                        .addExample("Configure this section in your validation rules")
-                        .explanation("This section level is not allowed in the current document structure")
-                        .build())
-                    .build();
+                ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId(UNEXPECTED)
+                        .location(location).message("Section not allowed at level " + level + ": '" + title + "'")
+                        .actualValue(title).expectedValue("No sections configured for level " + level)
+                        .addSuggestion(Suggestion.builder()
+                                .description("Remove unexpected section or move to appropriate level")
+                                .addExample("Remove this section if not needed")
+                                .addExample("Move section to a different document structure level")
+                                .addExample("Configure this section in your validation rules")
+                                .explanation("This section level is not allowed in the current document structure")
+                                .build())
+                        .build();
                 resultBuilder.addMessage(message);
             }
             // Don't return - still need to validate subsections
         }
-        
+
         if (matchingConfig != null) {
             trackOccurrence(matchingConfig);
-            
+
             validateTitle(section, matchingConfig.title(), filename, resultBuilder);
-            
+
             validateLevel(section, matchingConfig, filename, resultBuilder);
         } else {
             // Even without a pattern match, we need to track occurrences for min/max validation
@@ -167,16 +157,15 @@ public final class SectionValidator {
                 trackOccurrence(configForTracking);
             }
         }
-        
+
         // Always validate subsections
-        List<StructuralNode> subsections = section.getBlocks().stream()
-            .filter(block -> block instanceof Section)
-            .collect(Collectors.toList());
-        
+        List<StructuralNode> subsections = section.getBlocks().stream().filter(block -> block instanceof Section)
+                .collect(Collectors.toList());
+
         for (StructuralNode subsection : subsections) {
             // Determine which configs to use for subsections
             List<SectionConfig> subsectionConfigs;
-            
+
             if (matchingConfig != null && matchingConfig.subsections() != null) {
                 // Use the subsections from the matching config
                 subsectionConfigs = matchingConfig.subsections();
@@ -185,65 +174,54 @@ public final class SectionValidator {
                 // Look for configs that have subsections defined and could be parent configs
                 subsectionConfigs = determineSubsectionConfigsFromParent(allowedConfigs, level);
             }
-            
-            validateSection((Section) subsection, subsectionConfigs, 
-                           filename, resultBuilder, matchingConfig);
+
+            validateSection((Section) subsection, subsectionConfigs, filename, resultBuilder, matchingConfig);
         }
     }
 
-    private void validateTitle(Section section, TitleConfig titleConfig, 
-                              String filename, ValidationResult.Builder resultBuilder) {
+    private void validateTitle(Section section, TitleConfig titleConfig, String filename,
+            ValidationResult.Builder resultBuilder) {
         if (titleConfig == null) {
             return;
         }
-        
+
         String title = section.getTitle();
         SourceLocation location = createLocation(filename, section);
-        
+
         if (titleConfig.pattern() != null) {
             Pattern pattern = Pattern.compile(titleConfig.pattern());
             if (!pattern.matcher(title).matches()) {
-                ValidationMessage message = ValidationMessage.builder()
-                    .severity(titleConfig.severity())
-                    .ruleId(TITLE_PATTERN)
-                    .location(location)
-                    .message("Section title does not match required pattern")
-                    .actualValue(title)
-                    .expectedValue("Pattern: " + titleConfig.pattern())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Format section title to match pattern")
-                        .addExample("Use consistent capitalization")
-                        .addExample("Follow naming conventions")
-                        .addExample("Check pattern: " + titleConfig.pattern())
-                        .explanation("Section titles must match the configured regex pattern")
-                        .build())
-                    .build();
+                ValidationMessage message = ValidationMessage.builder().severity(titleConfig.severity())
+                        .ruleId(TITLE_PATTERN).location(location)
+                        .message("Section title does not match required pattern").actualValue(title)
+                        .expectedValue("Pattern: " + titleConfig.pattern())
+                        .addSuggestion(Suggestion.builder().description("Format section title to match pattern")
+                                .addExample("Use consistent capitalization").addExample("Follow naming conventions")
+                                .addExample("Check pattern: " + titleConfig.pattern())
+                                .explanation("Section titles must match the configured regex pattern").build())
+                        .build();
                 resultBuilder.addMessage(message);
             }
         }
     }
 
-    private void validateLevel(Section section, SectionConfig config, 
-                              String filename, ValidationResult.Builder resultBuilder) {
+    private void validateLevel(Section section, SectionConfig config, String filename,
+            ValidationResult.Builder resultBuilder) {
         int actualLevel = section.getLevel();
         int expectedLevel = config.level();
-        
+
         if (actualLevel != expectedLevel) {
             SourceLocation location = createLocation(filename, section);
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId(LEVEL)
-                .location(location)
-                .message("Section level mismatch")
-                .actualValue(String.valueOf(actualLevel))
-                .expectedValue(String.valueOf(expectedLevel))
-                .addSuggestion(Suggestion.builder()
-                    .description("Adjust section heading level")
-                    .fixedValue("=".repeat(expectedLevel + 1) + " " + section.getTitle())
-                    .addExample("=".repeat(expectedLevel + 1) + " Section Title")
-                    .explanation("Section must be at level " + expectedLevel + " (use " + "=".repeat(expectedLevel + 1) + ")")
-                    .build())
-                .build();
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId(LEVEL)
+                    .location(location).message("Section level mismatch").actualValue(String.valueOf(actualLevel))
+                    .expectedValue(String.valueOf(expectedLevel))
+                    .addSuggestion(Suggestion.builder().description("Adjust section heading level")
+                            .fixedValue("=".repeat(expectedLevel + 1) + " " + section.getTitle())
+                            .addExample("=".repeat(expectedLevel + 1) + " Section Title")
+                            .explanation("Section must be at level " + expectedLevel + " (use "
+                                    + "=".repeat(expectedLevel + 1) + ")")
+                            .build())
+                    .build();
             resultBuilder.addMessage(message);
         }
     }
@@ -255,80 +233,65 @@ public final class SectionValidator {
         }
     }
 
-    private void validateOccurrenceForConfig(SectionConfig config, String filename, 
-                                            ValidationResult.Builder resultBuilder) {
+    private void validateOccurrenceForConfig(SectionConfig config, String filename,
+            ValidationResult.Builder resultBuilder) {
         validateOccurrenceForConfig(config, filename, resultBuilder, null);
     }
-    
-    private void validateOccurrenceForConfig(SectionConfig config, String filename, 
-                                            ValidationResult.Builder resultBuilder,
-                                            SectionConfig parentConfig) {
+
+    private void validateOccurrenceForConfig(SectionConfig config, String filename,
+            ValidationResult.Builder resultBuilder, SectionConfig parentConfig) {
         String key = createOccurrenceKey(config);
         int occurrences = sectionOccurrences.getOrDefault(key, 0);
-        
+
         if (config.occurrence() != null && occurrences < config.occurrence().min()) {
-            SourceLocation location = SourceLocation.builder()
-                .filename(filename)
-                .startLine(1)
-                .endLine(1)
-                .startColumn(0)  // No column for section errors
-                .endColumn(0)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename(filename).startLine(1).endLine(1).startColumn(0) // No
+                                                                                                                         // column
+                                                                                                                         // for
+                                                                                                                         // section
+                                                                                                                         // errors
+                    .endColumn(0).build();
+
             // Generate section placeholder based on level
             String sectionPlaceholder = "=".repeat(config.level() + 1) + " " + config.name();
-            
+
             // Build context message
             String context = "";
             if (parentConfig != null) {
                 context = " (expected in " + parentConfig.name() + " at level " + parentConfig.level() + ")";
             }
-            
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId(MIN_OCCURRENCES)
-                .location(location)
-                .message("Missing required section '" + config.name() + "' at level " + config.level() + context)
-                .actualValue(String.valueOf(occurrences) + " occurrences")
-                .expectedValue("At least " + config.occurrence().min() + " occurrence(s)")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(sectionPlaceholder)
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add required section")
-                    .fixedValue(sectionPlaceholder)
-                    .addExample(sectionPlaceholder + "\nContent for " + config.name())
-                    .explanation("This section is required by the document structure configuration")
-                    .build())
-                .build();
+
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId(MIN_OCCURRENCES)
+                    .location(location)
+                    .message("Missing required section '" + config.name() + "' at level " + config.level() + context)
+                    .actualValue(String.valueOf(occurrences) + " occurrences")
+                    .expectedValue("At least " + config.occurrence().min() + " occurrence(s)")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint(sectionPlaceholder)
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add required section")
+                            .fixedValue(sectionPlaceholder)
+                            .addExample(sectionPlaceholder + "\nContent for " + config.name())
+                            .explanation("This section is required by the document structure configuration").build())
+                    .build();
             resultBuilder.addMessage(message);
         }
-        
+
         if (config.occurrence() != null && occurrences > config.occurrence().max()) {
-            SourceLocation location = SourceLocation.builder()
-                .filename(filename)
-                .line(1)
-                .build();
-            
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId(MAX_OCCURRENCES)
-                .location(location)
-                .message("Too many occurrences of section: " + config.name())
-                .actualValue(String.valueOf(occurrences))
-                .expectedValue("At most " + config.occurrence().max())
-                .addSuggestion(Suggestion.builder()
-                    .description("Remove or consolidate duplicate sections")
-                    .addExample("Merge duplicate '" + config.name() + "' sections")
-                    .addExample("Remove unnecessary repetitions")
-                    .explanation("Maximum " + config.occurrence().max() + " occurrence(s) allowed for this section")
-                    .build())
-                .build();
+            SourceLocation location = SourceLocation.builder().filename(filename).line(1).build();
+
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId(MAX_OCCURRENCES)
+                    .location(location).message("Too many occurrences of section: " + config.name())
+                    .actualValue(String.valueOf(occurrences)).expectedValue("At most " + config.occurrence().max())
+                    .addSuggestion(Suggestion.builder().description("Remove or consolidate duplicate sections")
+                            .addExample("Merge duplicate '" + config.name() + "' sections")
+                            .addExample("Remove unnecessary repetitions")
+                            .explanation(
+                                    "Maximum " + config.occurrence().max() + " occurrence(s) allowed for this section")
+                            .build())
+                    .build();
             resultBuilder.addMessage(message);
         }
-        
+
         // Recursively validate subsection occurrences
         if (config.subsections() != null) {
             for (SectionConfig subsection : config.subsections()) {
@@ -337,47 +300,42 @@ public final class SectionValidator {
         }
     }
 
-    private void validateDocumentTitleConfig(String title, TitleConfig titleConfig, 
-                                            SourceLocation location, ValidationResult.Builder resultBuilder) {
+    private void validateDocumentTitleConfig(String title, TitleConfig titleConfig, SourceLocation location,
+            ValidationResult.Builder resultBuilder) {
         if (titleConfig.pattern() != null) {
             Pattern pattern = Pattern.compile(titleConfig.pattern());
             if (!pattern.matcher(title).matches()) {
-                ValidationMessage message = ValidationMessage.builder()
-                    .severity(titleConfig.severity())
-                    .ruleId(TITLE_PATTERN)
-                    .location(location)
-                    .message("Document title does not match required pattern")
-                    .actualValue(title)
-                    .expectedValue("Pattern: " + titleConfig.pattern())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Format document title to match pattern")
-                        .addExample("= Project Documentation")
-                        .addExample("= User Guide")
-                        .addExample("= API Reference")
-                        .explanation("Document title must match the configured pattern: " + titleConfig.pattern())
-                        .build())
-                    .build();
+                ValidationMessage message = ValidationMessage.builder().severity(titleConfig.severity())
+                        .ruleId(TITLE_PATTERN).location(location)
+                        .message("Document title does not match required pattern").actualValue(title)
+                        .expectedValue("Pattern: " + titleConfig.pattern())
+                        .addSuggestion(Suggestion.builder().description("Format document title to match pattern")
+                                .addExample("= Project Documentation").addExample("= User Guide")
+                                .addExample("= API Reference")
+                                .explanation(
+                                        "Document title must match the configured pattern: " + titleConfig.pattern())
+                                .build())
+                        .build();
                 resultBuilder.addMessage(message);
             }
         }
     }
-    
+
     private void validateDocumentTitle(Document document, String filename, ValidationResult.Builder resultBuilder) {
         // Find level 0 section config (document title)
-        SectionConfig titleConfig = rootSections.stream()
-            .filter(config -> config.level() == 0)
-            .findFirst()
-            .orElse(null);
-        
+        SectionConfig titleConfig = rootSections.stream().filter(config -> config.level() == 0).findFirst()
+                .orElse(null);
+
         if (titleConfig == null) {
             return; // No level 0 validation configured
         }
-        
+
         String documentTitle = document.getTitle();
         SourceLocation location = createDocumentTitleLocation(filename, documentTitle);
-        
+
         // Check if title is required
-        if (titleConfig.occurrence() != null && titleConfig.occurrence().min() > 0 && (documentTitle == null || documentTitle.trim().isEmpty())) {
+        if (titleConfig.occurrence() != null && titleConfig.occurrence().min() > 0
+                && (documentTitle == null || documentTitle.trim().isEmpty())) {
             // If the config has a name, skip this validation - the min-occurrences check will handle it
             // and provide a better error message with placeholder
             if (titleConfig.name() != null) {
@@ -385,54 +343,42 @@ public final class SectionValidator {
                 sectionOccurrences.put(configKey, 0);
                 return;
             }
-            
+
             // Otherwise, use the original validation for backward compatibility
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId(LEVEL0_MISSING)
-                .location(location)
-                .message("Document title is required")
-                .actualValue("No title")
-                .expectedValue("Document title")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("= Document Title")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add document title")
-                    .fixedValue("= Document Title")
-                    .addExample("= User Guide")
-                    .addExample("= API Documentation")
-                    .addExample("= Installation Guide")
-                    .explanation("Every AsciiDoc document should have a title at the beginning")
-                    .build())
-                .build();
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId(LEVEL0_MISSING)
+                    .location(location).message("Document title is required").actualValue("No title")
+                    .expectedValue("Document title").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("= Document Title")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add document title").fixedValue("= Document Title")
+                            .addExample("= User Guide").addExample("= API Documentation")
+                            .addExample("= Installation Guide")
+                            .explanation("Every AsciiDoc document should have a title at the beginning").build())
+                    .build();
             resultBuilder.addMessage(message);
             return;
         }
-        
+
         // Validate title pattern if title exists
         if (documentTitle != null && titleConfig.title() != null) {
             validateDocumentTitleConfig(documentTitle, titleConfig.title(), location, resultBuilder);
         }
-        
+
         // Track occurrence for min/max validation
         String configKey = createOccurrenceKey(titleConfig);
         sectionOccurrences.put(configKey, documentTitle != null ? 1 : 0);
     }
-    
-    private void validateSectionOrder(List<StructuralNode> sections, String filename, 
-                                     ValidationResult.Builder resultBuilder) {
-        List<SectionConfig> orderedConfigs = rootSections.stream()
-            .filter(config -> config.order() != null)
-            .sorted(Comparator.comparing(SectionConfig::order))
-            .collect(Collectors.toList());
-        
+
+    private void validateSectionOrder(List<StructuralNode> sections, String filename,
+            ValidationResult.Builder resultBuilder) {
+        List<SectionConfig> orderedConfigs = rootSections.stream().filter(config -> config.order() != null)
+                .sorted(Comparator.comparing(SectionConfig::order)).collect(Collectors.toList());
+
         if (orderedConfigs.isEmpty()) {
             return;
         }
-        
+
         Map<String, Integer> actualOrder = new HashMap<>();
         for (int i = 0; i < sections.size(); i++) {
             if (sections.get(i) instanceof Section) {
@@ -443,34 +389,27 @@ public final class SectionValidator {
                 }
             }
         }
-        
+
         for (int i = 0; i < orderedConfigs.size() - 1; i++) {
             SectionConfig current = orderedConfigs.get(i);
             SectionConfig next = orderedConfigs.get(i + 1);
-            
+
             Integer currentPos = actualOrder.get(current.name());
             Integer nextPos = actualOrder.get(next.name());
-            
+
             if (currentPos != null && nextPos != null && currentPos > nextPos) {
-                SourceLocation location = SourceLocation.builder()
-                    .filename(filename)
-                    .line(1)
-                    .build();
-                
-                ValidationMessage message = ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId(ORDER)
-                    .location(location)
-                    .message("Section order violation")
-                    .actualValue(current.name() + " appears after " + next.name())
-                    .expectedValue(current.name() + " should appear before " + next.name())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Reorder sections according to configuration")
-                        .addExample("Move '" + current.name() + "' before '" + next.name() + "'")
-                        .addExample("Rearrange sections to match expected order")
-                        .explanation("Sections must appear in the configured order for document consistency")
-                        .build())
-                    .build();
+                SourceLocation location = SourceLocation.builder().filename(filename).line(1).build();
+
+                ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId(ORDER)
+                        .location(location).message("Section order violation")
+                        .actualValue(current.name() + " appears after " + next.name())
+                        .expectedValue(current.name() + " should appear before " + next.name())
+                        .addSuggestion(Suggestion.builder().description("Reorder sections according to configuration")
+                                .addExample("Move '" + current.name() + "' before '" + next.name() + "'")
+                                .addExample("Rearrange sections to match expected order")
+                                .explanation("Sections must appear in the configured order for document consistency")
+                                .build())
+                        .build();
                 resultBuilder.addMessage(message);
             }
         }
@@ -479,12 +418,12 @@ public final class SectionValidator {
     private SectionConfig findMatchingConfig(Section section, List<SectionConfig> configs) {
         String title = section.getTitle();
         int level = section.getLevel();
-        
+
         for (SectionConfig config : configs) {
             if (config.level() != level) {
                 continue;
             }
-            
+
             if (config.title() != null && config.title().pattern() != null) {
                 Pattern pattern = Pattern.compile(config.title().pattern());
                 if (pattern.matcher(title).matches()) {
@@ -494,27 +433,24 @@ public final class SectionValidator {
                 return config;
             }
         }
-        
+
         return null;
     }
-    
+
     private List<SectionConfig> findConfigsForLevel(int level, List<SectionConfig> configs) {
-        return configs.stream()
-            .filter(config -> config.level() == level)
-            .collect(Collectors.toList());
+        return configs.stream().filter(config -> config.level() == level).collect(Collectors.toList());
     }
-    
+
     private SectionConfig findConfigForOccurrenceTracking(Section section, List<SectionConfig> configs) {
         int level = section.getLevel();
-        
+
         // Find the first config that matches the level and has a name (for occurrence tracking)
-        return configs.stream()
-            .filter(config -> config.level() == level && config.name() != null)
-            .findFirst()
-            .orElse(null);
+        return configs.stream().filter(config -> config.level() == level && config.name() != null).findFirst()
+                .orElse(null);
     }
-    
-    private List<SectionConfig> determineSubsectionConfigsFromParent(List<SectionConfig> parentConfigs, int parentLevel) {
+
+    private List<SectionConfig> determineSubsectionConfigsFromParent(List<SectionConfig> parentConfigs,
+            int parentLevel) {
         // When a parent section doesn't match its pattern, we still need to find the right configs for its subsections
         // First, check if any of the parent-level configs have subsections defined
         for (SectionConfig config : parentConfigs) {
@@ -522,15 +458,15 @@ public final class SectionValidator {
                 return config.subsections();
             }
         }
-        
+
         // If no subsections found in parent-level configs, return configs for the next level
         int subsectionLevel = parentLevel + 1;
         List<SectionConfig> subsectionConfigs = findConfigsForLevel(subsectionLevel, parentConfigs);
-        
+
         if (!subsectionConfigs.isEmpty()) {
             return subsectionConfigs;
         }
-        
+
         // Last resort: return original configs
         return parentConfigs;
     }
@@ -551,79 +487,62 @@ public final class SectionValidator {
         }
         return "unknown";
     }
-    
+
     private SourceLocation createDocumentTitleLocation(String filename, String title) {
         List<String> fileLines = fileCache.getFileLines(filename);
-        
+
         if (fileLines.isEmpty()) {
-            return SourceLocation.builder()
-                .filename(filename)
-                .line(1)
-                .build();
+            return SourceLocation.builder().filename(filename).line(1).build();
         }
-        
+
         // Document title is typically on line 1
         String firstLine = fileLines.get(0);
-        
+
         // Document title has format: = Title
         if (firstLine.startsWith("= ") && title != null) {
             int titleStart = 2; // After "= "
             int titleEnd = titleStart + title.length() - 1;
-            
-            return SourceLocation.builder()
-                .filename(filename)
-                .startLine(1)
-                .endLine(1)
-                .startColumn(titleStart + 1) // Convert to 1-based
-                .endColumn(titleEnd + 1)     // Convert to 1-based
-                .build();
+
+            return SourceLocation.builder().filename(filename).startLine(1).endLine(1).startColumn(titleStart + 1) // Convert
+                                                                                                                   // to
+                                                                                                                   // 1-based
+                    .endColumn(titleEnd + 1) // Convert to 1-based
+                    .build();
         }
-        
+
         // Fallback
-        return SourceLocation.builder()
-            .filename(filename)
-            .line(1)
-            .build();
+        return SourceLocation.builder().filename(filename).line(1).build();
     }
 
     private SourceLocation createLocation(String filename, Section section) {
         int lineNumber = section.getSourceLocation() != null ? section.getSourceLocation().getLineNumber() : 1;
         List<String> fileLines = fileCache.getFileLines(filename);
-        
+
         if (fileLines.isEmpty() || lineNumber <= 0 || lineNumber > fileLines.size()) {
-            return SourceLocation.builder()
-                .filename(filename)
-                .line(lineNumber)
-                .build();
+            return SourceLocation.builder().filename(filename).line(lineNumber).build();
         }
-        
+
         String line = fileLines.get(lineNumber - 1);
         String title = section.getTitle();
         int level = section.getLevel();
-        
+
         // Find the title position in the line
         // Section titles have format: == Title or === Title etc.
         String prefix = "=".repeat(level + 1) + " ";
         int prefixIndex = line.indexOf(prefix);
-        
+
         if (prefixIndex >= 0 && title != null) {
             int titleStart = prefixIndex + prefix.length();
             int titleEnd = titleStart + title.length() - 1;
-            
-            return SourceLocation.builder()
-                .filename(filename)
-                .startLine(lineNumber)
-                .endLine(lineNumber)
-                .startColumn(titleStart + 1) // Convert to 1-based
-                .endColumn(titleEnd + 1)     // Convert to 1-based
-                .build();
+
+            return SourceLocation.builder().filename(filename).startLine(lineNumber).endLine(lineNumber)
+                    .startColumn(titleStart + 1) // Convert to 1-based
+                    .endColumn(titleEnd + 1) // Convert to 1-based
+                    .build();
         }
-        
+
         // Fallback if we can't find the exact position
-        return SourceLocation.builder()
-            .filename(filename)
-            .line(lineNumber)
-            .build();
+        return SourceLocation.builder().filename(filename).line(lineNumber).build();
     }
 
     public static Builder builder() {

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/SourceLocation.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/SourceLocation.java
@@ -11,7 +11,8 @@ public final class SourceLocation {
     private final String sourceLine;
 
     private SourceLocation(Builder builder) {
-        this.filename = Objects.requireNonNull(builder.filename, "[" + getClass().getName() + "] filename must not be null");
+        this.filename = Objects.requireNonNull(builder.filename,
+                "[" + getClass().getName() + "] filename must not be null");
         this.startLine = builder.startLine;
         this.startColumn = builder.startColumn;
         this.endLine = builder.endLine;
@@ -61,15 +62,14 @@ public final class SourceLocation {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         SourceLocation that = (SourceLocation) o;
-        return startLine == that.startLine &&
-                startColumn == that.startColumn &&
-                endLine == that.endLine &&
-                endColumn == that.endColumn &&
-                Objects.equals(filename, that.filename) &&
-                Objects.equals(sourceLine, that.sourceLine);
+        return startLine == that.startLine && startColumn == that.startColumn && endLine == that.endLine
+                && endColumn == that.endColumn && Objects.equals(filename, that.filename)
+                && Objects.equals(sourceLine, that.sourceLine);
     }
 
     @Override

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/SourcePosition.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/SourcePosition.java
@@ -1,66 +1,73 @@
 package com.dataliquid.asciidoc.linter.validator;
 
 /**
- * Represents the position of an element in the source text.
- * This class is used to precisely locate elements (URLs, titles, content, etc.)
- * within AsciiDoc source files for accurate error reporting.
- * 
- * <p>All positions use 1-based indexing (first column/line is 1, not 0).</p>
+ * Represents the position of an element in the source text. This class is used to precisely locate elements (URLs,
+ * titles, content, etc.) within AsciiDoc source files for accurate error reporting.
+ *
+ * <p>
+ * All positions use 1-based indexing (first column/line is 1, not 0).
+ * </p>
  */
 public class SourcePosition {
     /**
      * The starting column position (1-based).
      */
     public final int startColumn;
-    
+
     /**
      * The ending column position (1-based, inclusive).
      */
     public final int endColumn;
-    
+
     /**
      * The line number where the element is located (1-based).
      */
     public final int lineNumber;
-    
+
     /**
      * Creates a new SourcePosition.
-     * 
-     * @param startColumn the starting column (1-based)
-     * @param endColumn the ending column (1-based, inclusive)
-     * @param lineNumber the line number (1-based)
+     *
+     * @param startColumn
+     *            the starting column (1-based)
+     * @param endColumn
+     *            the ending column (1-based, inclusive)
+     * @param lineNumber
+     *            the line number (1-based)
      */
     public SourcePosition(int startColumn, int endColumn, int lineNumber) {
         this.startColumn = startColumn;
         this.endColumn = endColumn;
         this.lineNumber = lineNumber;
     }
-    
+
     /**
      * Creates a SourcePosition for a single point (start and end are the same).
-     * 
-     * @param column the column position (1-based)
-     * @param lineNumber the line number (1-based)
+     *
+     * @param column
+     *            the column position (1-based)
+     * @param lineNumber
+     *            the line number (1-based)
      * @return a new SourcePosition
      */
     public static SourcePosition point(int column, int lineNumber) {
         return new SourcePosition(column, column, lineNumber);
     }
-    
+
     /**
      * Creates a SourcePosition spanning an entire line.
-     * 
-     * @param lineLength the length of the line
-     * @param lineNumber the line number (1-based)
+     *
+     * @param lineLength
+     *            the length of the line
+     * @param lineNumber
+     *            the line number (1-based)
      * @return a new SourcePosition
      */
     public static SourcePosition entireLine(int lineLength, int lineNumber) {
         return new SourcePosition(1, lineLength, lineNumber);
     }
-    
+
     @Override
     public String toString() {
-        return String.format("SourcePosition[line=%d, columns=%d-%d]", 
-            lineNumber, startColumn, endColumn);
+        return String.format("SourcePosition[line=%d, columns=%d-%d]", lineNumber, startColumn, endColumn);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/Suggestion.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/Suggestion.java
@@ -13,99 +13,100 @@ public final class Suggestion {
     private final String explanation;
     private final boolean preferred;
     private final List<String> examples;
-    
+
     private Suggestion(Builder builder) {
-        this.description = Objects.requireNonNull(builder.description, "[" + getClass().getName() + "] description must not be null");
+        this.description = Objects.requireNonNull(builder.description,
+                "[" + getClass().getName() + "] description must not be null");
         this.fixedValue = builder.fixedValue;
         this.explanation = builder.explanation;
         this.preferred = builder.preferred;
         this.examples = new ArrayList<>(builder.examples);
     }
-    
+
     public String getDescription() {
         return description;
     }
-    
+
     public String getFixedValue() {
         return fixedValue;
     }
-    
+
     public boolean hasFixedValue() {
         return fixedValue != null && !fixedValue.isEmpty();
     }
-    
+
     public String getExplanation() {
         return explanation;
     }
-    
+
     public boolean isPreferred() {
         return preferred;
     }
-    
+
     public List<String> getExamples() {
         return new ArrayList<>(examples);
     }
-    
+
     public boolean hasExamples() {
         return !examples.isEmpty();
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         Suggestion that = (Suggestion) o;
-        return preferred == that.preferred &&
-                Objects.equals(description, that.description) &&
-                Objects.equals(fixedValue, that.fixedValue) &&
-                Objects.equals(explanation, that.explanation) &&
-                Objects.equals(examples, that.examples);
+        return preferred == that.preferred && Objects.equals(description, that.description)
+                && Objects.equals(fixedValue, that.fixedValue) && Objects.equals(explanation, that.explanation)
+                && Objects.equals(examples, that.examples);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(description, fixedValue, explanation, preferred, examples);
     }
-    
+
     public static Builder builder() {
         return new Builder();
     }
-    
+
     public static final class Builder {
         private String description;
         private String fixedValue;
         private String explanation;
         private boolean preferred;
         private final List<String> examples = new ArrayList<>();
-        
+
         private Builder() {
         }
-        
+
         public Builder description(String description) {
             this.description = description;
             return this;
         }
-        
+
         public Builder fixedValue(String fixedValue) {
             this.fixedValue = fixedValue;
             return this;
         }
-        
+
         public Builder explanation(String explanation) {
             this.explanation = explanation;
             return this;
         }
-        
+
         public Builder preferred(boolean preferred) {
             this.preferred = preferred;
             return this;
         }
-        
+
         public Builder addExample(String example) {
             this.examples.add(example);
             return this;
         }
-        
+
         public Builder examples(List<String> examples) {
             this.examples.clear();
             if (examples != null) {
@@ -113,7 +114,7 @@ public final class Suggestion {
             }
             return this;
         }
-        
+
         public Suggestion build() {
             return new Suggestion(this);
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/ValidationMessage.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/ValidationMessage.java
@@ -15,7 +15,7 @@ public final class ValidationMessage {
     private final String attributeName;
     private final String actualValue;
     private final String expectedValue;
-    
+
     // Enhanced fields for improved console output
     private final ErrorType errorType;
     private final String missingValueHint;
@@ -25,10 +25,13 @@ public final class ValidationMessage {
     private final Throwable cause;
 
     private ValidationMessage(Builder builder) {
-        this.severity = Objects.requireNonNull(builder.severity, "[" + getClass().getName() + "] severity must not be null");
+        this.severity = Objects.requireNonNull(builder.severity,
+                "[" + getClass().getName() + "] severity must not be null");
         this.ruleId = Objects.requireNonNull(builder.ruleId, "[" + getClass().getName() + "] ruleId must not be null");
-        this.message = Objects.requireNonNull(builder.message, "[" + getClass().getName() + "] message must not be null");
-        this.location = Objects.requireNonNull(builder.location, "[" + getClass().getName() + "] location must not be null");
+        this.message = Objects.requireNonNull(builder.message,
+                "[" + getClass().getName() + "] message must not be null");
+        this.location = Objects.requireNonNull(builder.location,
+                "[" + getClass().getName() + "] location must not be null");
         this.attributeName = builder.attributeName;
         this.actualValue = builder.actualValue;
         this.expectedValue = builder.expectedValue;
@@ -67,43 +70,39 @@ public final class ValidationMessage {
     public Optional<String> getExpectedValue() {
         return Optional.ofNullable(expectedValue);
     }
-    
+
     public ErrorType getErrorType() {
         return errorType;
     }
-    
+
     public String getMissingValueHint() {
         return missingValueHint;
     }
-    
+
     public PlaceholderContext getPlaceholderContext() {
         return placeholderContext;
     }
-    
+
     public List<Suggestion> getSuggestions() {
         return new ArrayList<>(suggestions);
     }
-    
+
     public boolean hasSuggestions() {
         return !suggestions.isEmpty();
     }
-    
+
     public List<String> getContextLines() {
         return new ArrayList<>(contextLines);
     }
-    
+
     public Optional<Throwable> getCause() {
         return Optional.ofNullable(cause);
     }
 
     public String format() {
         StringBuilder sb = new StringBuilder();
-        sb.append(location.formatLocation())
-          .append(": [")
-          .append(severity)
-          .append("] ")
-          .append(message);
-        
+        sb.append(location.formatLocation()).append(": [").append(severity).append("] ").append(message);
+
         if (actualValue != null || expectedValue != null) {
             sb.append("\n");
             if (actualValue != null) {
@@ -116,34 +115,30 @@ public final class ValidationMessage {
                 sb.append("  Expected: ").append(expectedValue);
             }
         }
-        
+
         return sb.toString();
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         ValidationMessage that = (ValidationMessage) o;
-        return severity == that.severity &&
-                Objects.equals(ruleId, that.ruleId) &&
-                Objects.equals(message, that.message) &&
-                Objects.equals(location, that.location) &&
-                Objects.equals(attributeName, that.attributeName) &&
-                Objects.equals(actualValue, that.actualValue) &&
-                Objects.equals(expectedValue, that.expectedValue) &&
-                errorType == that.errorType &&
-                Objects.equals(missingValueHint, that.missingValueHint) &&
-                Objects.equals(placeholderContext, that.placeholderContext) &&
-                Objects.equals(suggestions, that.suggestions) &&
-                Objects.equals(contextLines, that.contextLines) &&
-                Objects.equals(cause, that.cause);
+        return severity == that.severity && Objects.equals(ruleId, that.ruleId) && Objects.equals(message, that.message)
+                && Objects.equals(location, that.location) && Objects.equals(attributeName, that.attributeName)
+                && Objects.equals(actualValue, that.actualValue) && Objects.equals(expectedValue, that.expectedValue)
+                && errorType == that.errorType && Objects.equals(missingValueHint, that.missingValueHint)
+                && Objects.equals(placeholderContext, that.placeholderContext)
+                && Objects.equals(suggestions, that.suggestions) && Objects.equals(contextLines, that.contextLines)
+                && Objects.equals(cause, that.cause);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(severity, ruleId, message, location, attributeName, actualValue, 
-                          expectedValue, errorType, missingValueHint, placeholderContext, suggestions, contextLines, cause);
+        return Objects.hash(severity, ruleId, message, location, attributeName, actualValue, expectedValue, errorType,
+                missingValueHint, placeholderContext, suggestions, contextLines, cause);
     }
 
     @Override
@@ -207,29 +202,29 @@ public final class ValidationMessage {
             this.expectedValue = expectedValue;
             return this;
         }
-        
+
         public Builder errorType(ErrorType errorType) {
             this.errorType = errorType;
             return this;
         }
-        
+
         public Builder missingValueHint(String missingValueHint) {
             this.missingValueHint = missingValueHint;
             return this;
         }
-        
+
         public Builder placeholderContext(PlaceholderContext placeholderContext) {
             this.placeholderContext = placeholderContext;
             return this;
         }
-        
+
         public Builder addSuggestion(Suggestion suggestion) {
             if (suggestion != null) {
                 this.suggestions.add(suggestion);
             }
             return this;
         }
-        
+
         public Builder suggestions(List<Suggestion> suggestions) {
             this.suggestions.clear();
             if (suggestions != null) {
@@ -237,14 +232,14 @@ public final class ValidationMessage {
             }
             return this;
         }
-        
+
         public Builder addContextLine(String line) {
             if (line != null) {
                 this.contextLines.add(line);
             }
             return this;
         }
-        
+
         public Builder contextLines(List<String> contextLines) {
             this.contextLines.clear();
             if (contextLines != null) {
@@ -252,7 +247,7 @@ public final class ValidationMessage {
             }
             return this;
         }
-        
+
         public Builder cause(Throwable cause) {
             this.cause = cause;
             return this;

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/ValidationResult.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/ValidationResult.java
@@ -40,28 +40,17 @@ public final class ValidationResult {
     }
 
     public List<ValidationMessage> getMessagesBySeverity(Severity severity) {
-        return messages.stream()
-                .filter(msg -> msg.getSeverity() == severity)
-                .collect(Collectors.toList());
+        return messages.stream().filter(msg -> msg.getSeverity() == severity).collect(Collectors.toList());
     }
 
     public Map<String, List<ValidationMessage>> getMessagesByFile() {
-        return messages.stream()
-                .collect(Collectors.groupingBy(
-                    msg -> msg.getLocation().getFilename(),
-                    TreeMap::new,
-                    Collectors.toList()
-                ));
+        return messages.stream().collect(
+                Collectors.groupingBy(msg -> msg.getLocation().getFilename(), TreeMap::new, Collectors.toList()));
     }
 
     public Map<Integer, List<ValidationMessage>> getMessagesByLine(String filename) {
-        return messages.stream()
-                .filter(msg -> msg.getLocation().getFilename().equals(filename))
-                .collect(Collectors.groupingBy(
-                    msg -> msg.getLocation().getStartLine(),
-                    TreeMap::new,
-                    Collectors.toList()
-                ));
+        return messages.stream().filter(msg -> msg.getLocation().getFilename().equals(filename)).collect(
+                Collectors.groupingBy(msg -> msg.getLocation().getStartLine(), TreeMap::new, Collectors.toList()));
     }
 
     public boolean isValid() {
@@ -75,27 +64,21 @@ public final class ValidationResult {
     public boolean hasWarnings() {
         return messages.stream().anyMatch(msg -> msg.getSeverity() == Severity.WARN);
     }
-    
+
     public boolean hasMessages() {
         return !messages.isEmpty();
     }
 
     public int getErrorCount() {
-        return (int) messages.stream()
-                .filter(msg -> msg.getSeverity() == Severity.ERROR)
-                .count();
+        return (int) messages.stream().filter(msg -> msg.getSeverity() == Severity.ERROR).count();
     }
 
     public int getWarningCount() {
-        return (int) messages.stream()
-                .filter(msg -> msg.getSeverity() == Severity.WARN)
-                .count();
+        return (int) messages.stream().filter(msg -> msg.getSeverity() == Severity.WARN).count();
     }
 
     public int getInfoCount() {
-        return (int) messages.stream()
-                .filter(msg -> msg.getSeverity() == Severity.INFO)
-                .count();
+        return (int) messages.stream().filter(msg -> msg.getSeverity() == Severity.INFO).count();
     }
 
     public long getValidationTimeMillis() {
@@ -111,13 +94,12 @@ public final class ValidationResult {
             System.out.println("No validation issues found.");
         } else {
             Map<String, List<ValidationMessage>> messagesByFile = getMessagesByFile();
-            
+
             for (Map.Entry<String, List<ValidationMessage>> entry : messagesByFile.entrySet()) {
                 List<ValidationMessage> fileMessages = entry.getValue();
-                fileMessages.sort(Comparator
-                    .comparing((ValidationMessage msg) -> msg.getLocation().getStartLine())
-                    .thenComparing(msg -> msg.getLocation().getStartColumn()));
-                
+                fileMessages.sort(Comparator.comparing((ValidationMessage msg) -> msg.getLocation().getStartLine())
+                        .thenComparing(msg -> msg.getLocation().getStartColumn()));
+
                 for (ValidationMessage msg : fileMessages) {
                     System.out.println(msg.format());
                     System.out.println();
@@ -125,9 +107,8 @@ public final class ValidationResult {
             }
         }
 
-        System.out.println("Summary: " + getErrorCount() + " errors, " + 
-                         getWarningCount() + " warnings, " + 
-                         getInfoCount() + " info messages");
+        System.out.println("Summary: " + getErrorCount() + " errors, " + getWarningCount() + " warnings, "
+                + getInfoCount() + " info messages");
         System.out.println("Validation completed in " + getValidationTimeMillis() + "ms");
     }
 

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AbstractBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AbstractBlockValidator.java
@@ -13,71 +13,73 @@ import com.dataliquid.asciidoc.linter.report.console.FileContentCache;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
- * Abstract base class for block validators using Template Method pattern.
- * Provides common validation logic and helper methods to reduce code duplication.
+ * Abstract base class for block validators using Template Method pattern. Provides common validation logic and helper
+ * methods to reduce code duplication.
  *
- * @param <T> The specific block configuration type
+ * @param <T>
+ *            The specific block configuration type
  */
 public abstract class AbstractBlockValidator<T extends Block> implements BlockTypeValidator {
-    
+
     /**
-     * Shared file content cache for accessing source file content.
-     * Used by subclasses to find exact positions in source files for error reporting.
+     * Shared file content cache for accessing source file content. Used by subclasses to find exact positions in source
+     * files for error reporting.
      */
     protected final FileContentCache fileCache = new FileContentCache();
-    
+
     /**
-     * Returns the specific block configuration class type.
-     * Used for safe casting of the generic Block to the specific type.
+     * Returns the specific block configuration class type. Used for safe casting of the generic Block to the specific
+     * type.
      *
      * @return the class of the specific block configuration
      */
     protected abstract Class<T> getBlockConfigClass();
-    
+
     /**
-     * Performs block-specific validations.
-     * This method should contain all validation logic specific to the block type.
+     * Performs block-specific validations. This method should contain all validation logic specific to the block type.
      *
-     * @param node the AsciiDoc node to validate
-     * @param config the specific block configuration
-     * @param context the validation context
+     * @param node
+     *            the AsciiDoc node to validate
+     * @param config
+     *            the specific block configuration
+     * @param context
+     *            the validation context
      * @return list of validation messages
      */
-    protected abstract List<ValidationMessage> performSpecificValidations(
-            StructuralNode node, T config, BlockValidationContext context);
-    
+    protected abstract List<ValidationMessage> performSpecificValidations(StructuralNode node, T config,
+            BlockValidationContext context);
+
     @Override
-    public final List<ValidationMessage> validate(StructuralNode node, Block config, 
-                                                 BlockValidationContext context) {
+    public final List<ValidationMessage> validate(StructuralNode node, Block config, BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Safe cast to specific type
         if (!getBlockConfigClass().isInstance(config)) {
             return messages;
         }
-        
+
         T typedConfig = getBlockConfigClass().cast(config);
-        
+
         // Delegate to specific validation
         messages.addAll(performSpecificValidations(node, typedConfig, context));
-        
+
         return messages;
     }
-    
+
     // Common helper methods
-    
+
     /**
-     * Extracts text content from a structural node.
-     * Handles both direct content and nested blocks.
+     * Extracts text content from a structural node. Handles both direct content and nested blocks.
      *
-     * @param node the node to extract content from
+     * @param node
+     *            the node to extract content from
      * @return the text content or empty string if none
      */
     protected String getBlockContent(StructuralNode node) {
         if (node.getContent() instanceof String) {
             return (String) node.getContent();
         }
-        
+
         // Handle nested blocks
         if (node.getBlocks() != null && !node.getBlocks().isEmpty()) {
             StringBuilder content = new StringBuilder();
@@ -91,14 +93,15 @@ public abstract class AbstractBlockValidator<T extends Block> implements BlockTy
             }
             return content.toString().trim();
         }
-        
+
         return "";
     }
-    
+
     /**
      * Counts lines in text content.
      *
-     * @param content the text content
+     * @param content
+     *            the text content
      * @return number of lines
      */
     protected int countLines(String content) {
@@ -107,87 +110,94 @@ public abstract class AbstractBlockValidator<T extends Block> implements BlockTy
         }
         return content.split("\n").length;
     }
-    
+
     /**
-     * Resolves severity with fallback.
-     * If specific severity is null, uses the fallback severity.
+     * Resolves severity with fallback. If specific severity is null, uses the fallback severity.
      *
-     * @param specific the specific severity (may be null)
-     * @param fallback the fallback severity
+     * @param specific
+     *            the specific severity (may be null)
+     * @param fallback
+     *            the fallback severity
      * @return resolved severity
      */
     protected Severity resolveSeverity(Severity specific, Severity fallback) {
         return specific != null ? specific : fallback;
     }
-    
+
     /**
      * Creates a validation message for required field violations.
      *
-     * @param fieldName the name of the required field
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param fieldName
+     *            the name of the required field
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message
      */
     protected ValidationMessage createRequiredFieldMessage(String fieldName, Severity severity,
-                                                         BlockValidationContext context, 
-                                                         StructuralNode node) {
-        return ValidationMessage.builder()
-            .severity(severity)
-            .ruleId(getSupportedType().toValue() + "." + fieldName + ".required")
-            .location(context.createLocation(node))
-            .message("Literal block must have a " + fieldName)
-            .actualValue("No " + fieldName)
-            .expectedValue(fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1) + " required")
-            .build();
+            BlockValidationContext context, StructuralNode node) {
+        return ValidationMessage.builder().severity(severity)
+                .ruleId(getSupportedType().toValue() + "." + fieldName + ".required")
+                .location(context.createLocation(node)).message("Literal block must have a " + fieldName)
+                .actualValue("No " + fieldName)
+                .expectedValue(fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1) + " required").build();
     }
-    
+
     /**
      * Creates a validation message for pattern violations.
      *
-     * @param fieldName the name of the field
-     * @param value the actual value
-     * @param pattern the expected pattern
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param fieldName
+     *            the name of the field
+     * @param value
+     *            the actual value
+     * @param pattern
+     *            the expected pattern
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message
      */
-    protected ValidationMessage createPatternViolationMessage(String fieldName, String value, 
-                                                            String pattern, Severity severity,
-                                                            BlockValidationContext context, 
-                                                            StructuralNode node) {
-        return ValidationMessage.builder()
-            .severity(severity)
-            .ruleId(getSupportedType().toValue() + "." + fieldName + ".pattern")
-            .location(context.createLocation(node))
-            .message(fieldName + " does not match pattern: " + pattern + 
-                    ". Actual: " + (value != null ? value : "null"))
-            .build();
+    protected ValidationMessage createPatternViolationMessage(String fieldName, String value, String pattern,
+            Severity severity, BlockValidationContext context, StructuralNode node) {
+        return ValidationMessage.builder().severity(severity)
+                .ruleId(getSupportedType().toValue() + "." + fieldName + ".pattern")
+                .location(context.createLocation(node)).message(fieldName + " does not match pattern: " + pattern
+                        + ". Actual: " + (value != null ? value : "null"))
+                .build();
     }
-    
+
     /**
      * Creates a validation message for length violations.
      *
-     * @param fieldName the name of the field
-     * @param actualLength the actual length
-     * @param minLength the minimum length (may be null)
-     * @param maxLength the maximum length (may be null)
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param fieldName
+     *            the name of the field
+     * @param actualLength
+     *            the actual length
+     * @param minLength
+     *            the minimum length (may be null)
+     * @param maxLength
+     *            the maximum length (may be null)
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message
      */
-    protected ValidationMessage createLengthViolationMessage(String fieldName, int actualLength,
-                                                           Integer minLength, Integer maxLength, 
-                                                           Severity severity,
-                                                           BlockValidationContext context, 
-                                                           StructuralNode node) {
+    protected ValidationMessage createLengthViolationMessage(String fieldName, int actualLength, Integer minLength,
+            Integer maxLength, Severity severity, BlockValidationContext context, StructuralNode node) {
         StringBuilder message = new StringBuilder(fieldName);
         String ruleIdSuffix;
         String expectedValue;
         String actualValue = actualLength + " characters";
-        
+
         if (minLength != null && actualLength < minLength) {
             message.append(" is too short");
             ruleIdSuffix = "minLength";
@@ -200,125 +210,134 @@ public abstract class AbstractBlockValidator<T extends Block> implements BlockTy
             // Should not happen, but handle gracefully
             return null;
         }
-        
-        return ValidationMessage.builder()
-            .severity(severity)
-            .ruleId(getSupportedType().toValue() + "." + fieldName + "." + ruleIdSuffix)
-            .location(context.createLocation(node))
-            .message(message.toString())
-            .actualValue(actualValue)
-            .expectedValue(expectedValue)
-            .build();
+
+        return ValidationMessage.builder().severity(severity)
+                .ruleId(getSupportedType().toValue() + "." + fieldName + "." + ruleIdSuffix)
+                .location(context.createLocation(node)).message(message.toString()).actualValue(actualValue)
+                .expectedValue(expectedValue).build();
     }
-    
+
     /**
      * Validates a required field.
      *
-     * @param value the value to check
-     * @param fieldName the name of the field
-     * @param required whether the field is required
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param value
+     *            the value to check
+     * @param fieldName
+     *            the name of the field
+     * @param required
+     *            whether the field is required
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message if validation fails, null otherwise
      */
-    protected ValidationMessage validateRequired(String value, String fieldName, 
-                                               boolean required, Severity severity,
-                                               BlockValidationContext context, 
-                                               StructuralNode node) {
+    protected ValidationMessage validateRequired(String value, String fieldName, boolean required, Severity severity,
+            BlockValidationContext context, StructuralNode node) {
         if (required && (value == null || value.trim().isEmpty())) {
             return createRequiredFieldMessage(fieldName, severity, context, node);
         }
         return null;
     }
-    
+
     /**
      * Validates a value against a pattern.
      *
-     * @param value the value to validate
-     * @param patternStr the pattern string
-     * @param fieldName the name of the field
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param value
+     *            the value to validate
+     * @param patternStr
+     *            the pattern string
+     * @param fieldName
+     *            the name of the field
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message if validation fails, null otherwise
      */
-    protected ValidationMessage validatePattern(String value, String patternStr, 
-                                              String fieldName, Severity severity,
-                                              BlockValidationContext context, 
-                                              StructuralNode node) {
+    protected ValidationMessage validatePattern(String value, String patternStr, String fieldName, Severity severity,
+            BlockValidationContext context, StructuralNode node) {
         if (value != null && patternStr != null) {
             try {
                 Pattern pattern = Pattern.compile(patternStr);
                 if (!pattern.matcher(value).matches()) {
-                    return createPatternViolationMessage(fieldName, value, patternStr, 
-                                                       severity, context, node);
+                    return createPatternViolationMessage(fieldName, value, patternStr, severity, context, node);
                 }
             } catch (PatternSyntaxException e) {
-                return ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId(getSupportedType().toValue() + "." + fieldName + ".pattern.invalid")
-                    .location(context.createLocation(node))
-                    .message("Invalid pattern for " + fieldName + ": " + e.getMessage())
-                    .build();
+                return ValidationMessage.builder().severity(Severity.ERROR)
+                        .ruleId(getSupportedType().toValue() + "." + fieldName + ".pattern.invalid")
+                        .location(context.createLocation(node))
+                        .message("Invalid pattern for " + fieldName + ": " + e.getMessage()).build();
             }
         }
         return null;
     }
-    
+
     /**
      * Validates string length constraints.
      *
-     * @param value the value to validate
-     * @param minLength minimum length constraint
-     * @param maxLength maximum length constraint
-     * @param fieldName the name of the field
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param value
+     *            the value to validate
+     * @param minLength
+     *            minimum length constraint
+     * @param maxLength
+     *            maximum length constraint
+     * @param fieldName
+     *            the name of the field
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message if validation fails, null otherwise
      */
-    protected ValidationMessage validateLength(String value, Integer minLength, Integer maxLength,
-                                             String fieldName, Severity severity,
-                                             BlockValidationContext context, 
-                                             StructuralNode node) {
+    protected ValidationMessage validateLength(String value, Integer minLength, Integer maxLength, String fieldName,
+            Severity severity, BlockValidationContext context, StructuralNode node) {
         if (value != null && (minLength != null || maxLength != null)) {
             int length = value.length();
-            if ((minLength != null && length < minLength) || 
-                (maxLength != null && length > maxLength)) {
-                return createLengthViolationMessage(fieldName, length, minLength, maxLength, 
-                                                  severity, context, node);
+            if ((minLength != null && length < minLength) || (maxLength != null && length > maxLength)) {
+                return createLengthViolationMessage(fieldName, length, minLength, maxLength, severity, context, node);
             }
         }
         return null;
     }
-    
+
     /**
      * Validates numeric constraints.
      *
-     * @param value the value to validate
-     * @param min minimum constraint
-     * @param max maximum constraint
-     * @param fieldName the name of the field
-     * @param severity the severity level
-     * @param context the validation context
-     * @param node the node being validated
+     * @param value
+     *            the value to validate
+     * @param min
+     *            minimum constraint
+     * @param max
+     *            maximum constraint
+     * @param fieldName
+     *            the name of the field
+     * @param severity
+     *            the severity level
+     * @param context
+     *            the validation context
+     * @param node
+     *            the node being validated
      * @return validation message if validation fails, null otherwise
      */
-    protected ValidationMessage validateMinMax(int value, Integer min, Integer max,
-                                             String fieldName, Severity severity,
-                                             BlockValidationContext context, 
-                                             StructuralNode node) {
+    protected ValidationMessage validateMinMax(int value, Integer min, Integer max, String fieldName, Severity severity,
+            BlockValidationContext context, StructuralNode node) {
         if ((min != null && value < min) || (max != null && value > max)) {
             StringBuilder message = new StringBuilder(fieldName);
             String ruleIdSuffix;
             String actualValue;
             String expectedValue;
-            
+
             // Special handling for line count
             boolean isLineCount = fieldName.toLowerCase().contains("line");
             String unit = isLineCount ? " lines" : "";
-            
+
             if (min != null && value < min) {
                 message.append(" is too small");
                 ruleIdSuffix = "min";
@@ -332,7 +351,7 @@ public abstract class AbstractBlockValidator<T extends Block> implements BlockTy
             } else {
                 return null;
             }
-            
+
             // Construct rule ID - for lines, use "lines.min" or "lines.max"
             String ruleIdBase;
             if (isLineCount) {
@@ -340,24 +359,21 @@ public abstract class AbstractBlockValidator<T extends Block> implements BlockTy
             } else {
                 ruleIdBase = getSupportedType().toValue() + "." + fieldName.toLowerCase().replace(" ", "");
             }
-            
-            return ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(ruleIdBase + "." + ruleIdSuffix)
-                .location(context.createLocation(node))
-                .message(message.toString())
-                .actualValue(actualValue)
-                .expectedValue(expectedValue)
-                .build();
+
+            return ValidationMessage.builder().severity(severity).ruleId(ruleIdBase + "." + ruleIdSuffix)
+                    .location(context.createLocation(node)).message(message.toString()).actualValue(actualValue)
+                    .expectedValue(expectedValue).build();
         }
         return null;
     }
-    
+
     /**
      * Helper method to add a validation message to the list if not null.
      *
-     * @param messages the list to add to
-     * @param message the message to add (may be null)
+     * @param messages
+     *            the list to add to
+     * @param message
+     *            the message to add (may be null)
      */
     protected void addIfNotNull(List<ValidationMessage> messages, ValidationMessage message) {
         if (message != null) {

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AudioBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/AudioBlockValidator.java
@@ -21,362 +21,296 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for audio blocks in AsciiDoc documents.
- * 
- * <p>This validator validates audio blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/audio-block.yaml}.
- * The YAML configuration is parsed into {@link AudioBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * This validator validates audio blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/audio-block.yaml}. The YAML configuration is parsed into {@link AudioBlock}
+ * objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>url</b>: Validates audio URL/path (required, pattern matching, severity support)</li>
- *   <li><b>options.autoplay</b>: Validates autoplay option (allowed/disallowed, severity support)</li>
- *   <li><b>options.controls</b>: Validates controls requirement (required, severity support)</li>
- *   <li><b>options.loop</b>: Validates loop option (allowed/disallowed, severity support)</li>
- *   <li><b>title</b>: Validates title/description (required, length constraints, severity support)</li>
+ * <li><b>url</b>: Validates audio URL/path (required, pattern matching, severity support)</li>
+ * <li><b>options.autoplay</b>: Validates autoplay option (allowed/disallowed, severity support)</li>
+ * <li><b>options.controls</b>: Validates controls requirement (required, severity support)</li>
+ * <li><b>options.loop</b>: Validates loop option (allowed/disallowed, severity support)</li>
+ * <li><b>title</b>: Validates title/description (required, length constraints, severity support)</li>
  * </ul>
- * 
- * <p>Note: Audio block nested configurations support individual severity levels.
- * If not specified, they fall back to the block-level severity.</p>
- * 
+ *
+ * <p>
+ * Note: Audio block nested configurations support individual severity levels. If not specified, they fall back to the
+ * block-level severity.
+ * </p>
+ *
  * @see AudioBlock
  * @see BlockTypeValidator
  */
 public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock> {
-    
+
     @Override
     public BlockType getSupportedType() {
         return BlockType.AUDIO;
     }
-    
+
     @Override
     protected Class<AudioBlock> getBlockConfigClass() {
         return AudioBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               AudioBlock audioConfig,
-                                                               BlockValidationContext context) {
-        
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, AudioBlock audioConfig,
+            BlockValidationContext context) {
+
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Get audio attributes
         String audioUrl = getAudioUrl(block);
         String title = getTitle(block);
-        
+
         // Validate URL
         if (audioConfig.getUrl() != null) {
             validateUrl(audioUrl, audioConfig.getUrl(), context, block, messages, audioConfig);
         }
-        
+
         // Validate options
         if (audioConfig.getOptions() != null) {
             validateOptions(block, audioConfig.getOptions(), context, messages, audioConfig);
         }
-        
+
         // Validate title
         if (audioConfig.getTitle() != null) {
             validateTitle(title, audioConfig.getTitle(), context, block, messages, audioConfig);
         }
-        
+
         return messages;
     }
-    
+
     private String getAudioUrl(StructuralNode block) {
         // Try different ways to get audio URL
         Object target = block.getAttribute(TARGET);
         if (target != null) {
             return target.toString();
         }
-        
+
         // For audio blocks, the content might contain the path
         if (block.getContent() != null) {
             return block.getContent().toString();
         }
-        
+
         return null;
     }
-    
+
     private String getTitle(StructuralNode block) {
         // First try the title attribute
         String title = block.getTitle();
         if (title != null && !title.trim().isEmpty()) {
             return title;
         }
-        
+
         // Then try the caption attribute
         Object caption = block.getAttribute(CAPTION);
         if (caption != null) {
             return caption.toString();
         }
-        
+
         return null;
     }
-    
-    private void validateUrl(String url, AudioBlock.UrlConfig urlConfig,
-                           BlockValidationContext context,
-                           StructuralNode block,
-                           List<ValidationMessage> messages,
-                           AudioBlock audioConfig) {
-        
+
+    private void validateUrl(String url, AudioBlock.UrlConfig urlConfig, BlockValidationContext context,
+            StructuralNode block, List<ValidationMessage> messages, AudioBlock audioConfig) {
+
         Severity severity = resolveSeverity(urlConfig.getSeverity(), audioConfig.getSeverity());
-        
+
         // Check if URL is required
         if (urlConfig.isRequired() && (url == null || url.trim().isEmpty())) {
             SourcePosition pos = findSourcePosition(block, context, url);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(URL_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Audio URL is required but not provided")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("target")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add audio URL")
-                    .fixedValue("audio.mp3")
-                    .addExample("audio::music.mp3[]")
-                    .addExample("audio::sounds/notification.ogg[]")
-                    .addExample("audio::https://example.com/audio.wav[]")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(URL_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Audio URL is required but not provided").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("target")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add audio URL").fixedValue("audio.mp3")
+                            .addExample("audio::music.mp3[]").addExample("audio::sounds/notification.ogg[]")
+                            .addExample("audio::https://example.com/audio.wav[]").build())
+                    .build());
             return;
         }
-        
+
         if (url != null && !url.trim().isEmpty() && urlConfig.getPattern() != null) {
             // Validate URL pattern
             if (!urlConfig.getPattern().matcher(url).matches()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(URL_PATTERN)
-                    .location(context.createLocation(block))
-                    .message("Audio URL does not match required pattern")
-                    .actualValue(url)
-                    .expectedValue("Pattern: " + urlConfig.getPattern().pattern())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use valid audio URL format")
-                        .addExample("audio::file.mp3[]")
-                        .addExample("audio::sounds/music.wav[]")
-                        .explanation("URL must match pattern: " + urlConfig.getPattern().pattern())
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(URL_PATTERN)
+                        .location(context.createLocation(block)).message("Audio URL does not match required pattern")
+                        .actualValue(url).expectedValue("Pattern: " + urlConfig.getPattern().pattern())
+                        .addSuggestion(Suggestion.builder().description("Use valid audio URL format")
+                                .addExample("audio::file.mp3[]").addExample("audio::sounds/music.wav[]")
+                                .explanation("URL must match pattern: " + urlConfig.getPattern().pattern()).build())
+                        .build());
             }
         }
     }
-    
+
     private void validateOptions(StructuralNode block, AudioBlock.OptionsConfig optionsConfig,
-                               BlockValidationContext context,
-                               List<ValidationMessage> messages,
-                               AudioBlock audioConfig) {
-        
+            BlockValidationContext context, List<ValidationMessage> messages, AudioBlock audioConfig) {
+
         // Validate autoplay
         if (optionsConfig.getAutoplay() != null) {
             validateAutoplay(block, optionsConfig.getAutoplay(), context, messages, audioConfig);
         }
-        
+
         // Validate controls
         if (optionsConfig.getControls() != null) {
             validateControls(block, optionsConfig.getControls(), context, messages, audioConfig);
         }
-        
+
         // Validate loop
         if (optionsConfig.getLoop() != null) {
             validateLoop(block, optionsConfig.getLoop(), context, messages, audioConfig);
         }
     }
-    
+
     private void validateAutoplay(StructuralNode block, AudioBlock.AutoplayConfig autoplayConfig,
-                                BlockValidationContext context,
-                                List<ValidationMessage> messages,
-                                AudioBlock audioConfig) {
-        
+            BlockValidationContext context, List<ValidationMessage> messages, AudioBlock audioConfig) {
+
         Severity severity = resolveSeverity(autoplayConfig.getSeverity(), audioConfig.getSeverity());
-        
+
         boolean hasAutoplay = hasOption(block, AUTOPLAY);
-        
+
         if (!autoplayConfig.isAllowed() && hasAutoplay) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(OPTIONS_AUTOPLAY_NOT_ALLOWED)
-                .location(context.createLocation(block))
-                .message("Audio autoplay is not allowed")
-                .actualValue("autoplay enabled")
-                .expectedValue("autoplay must not be used")
-                .addSuggestion(Suggestion.builder()
-                    .description("Remove autoplay option")
-                    .addExample("audio::file.mp3[options=controls]")
-                    .addExample("Remove 'autoplay' from options attribute")
-                    .explanation("Autoplay can be disruptive for users")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(OPTIONS_AUTOPLAY_NOT_ALLOWED)
+                    .location(context.createLocation(block)).message("Audio autoplay is not allowed")
+                    .actualValue("autoplay enabled").expectedValue("autoplay must not be used")
+                    .addSuggestion(Suggestion.builder().description("Remove autoplay option")
+                            .addExample("audio::file.mp3[options=controls]")
+                            .addExample("Remove 'autoplay' from options attribute")
+                            .explanation("Autoplay can be disruptive for users").build())
+                    .build());
         }
     }
-    
+
     private void validateControls(StructuralNode block, AudioBlock.ControlsConfig controlsConfig,
-                                BlockValidationContext context,
-                                List<ValidationMessage> messages,
-                                AudioBlock audioConfig) {
-        
+            BlockValidationContext context, List<ValidationMessage> messages, AudioBlock audioConfig) {
+
         Severity severity = resolveSeverity(controlsConfig.getSeverity(), audioConfig.getSeverity());
-        
+
         boolean hasControls = !hasOption(block, NOCONTROLS);
-        
+
         if (controlsConfig.isRequired() && !hasControls) {
             SourcePosition pos = findSourcePosition(block, context);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(OPTIONS_CONTROLS_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Audio controls are required but not enabled")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("controls")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
-                    .attributeName("options")
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Enable audio controls")
-                    .addExample("audio::file.mp3[options=controls]")
-                    .addExample("audio::file.mp3[opts=controls]")
-                    .explanation("Controls allow users to play/pause the audio")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(OPTIONS_CONTROLS_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Audio controls are required but not enabled").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("controls")
+                    .placeholderContext(PlaceholderContext.builder()
+                            .type(PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE).attributeName("options").build())
+                    .addSuggestion(Suggestion.builder().description("Enable audio controls")
+                            .addExample("audio::file.mp3[options=controls]")
+                            .addExample("audio::file.mp3[opts=controls]")
+                            .explanation("Controls allow users to play/pause the audio").build())
+                    .build());
         }
     }
-    
-    private void validateLoop(StructuralNode block, AudioBlock.LoopConfig loopConfig,
-                            BlockValidationContext context,
-                            List<ValidationMessage> messages,
-                            AudioBlock audioConfig) {
-        
+
+    private void validateLoop(StructuralNode block, AudioBlock.LoopConfig loopConfig, BlockValidationContext context,
+            List<ValidationMessage> messages, AudioBlock audioConfig) {
+
         Severity severity = resolveSeverity(loopConfig.getSeverity(), audioConfig.getSeverity());
-        
+
         boolean hasLoop = hasOption(block, LOOP);
-        
+
         if (!loopConfig.isAllowed() && hasLoop) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(OPTIONS_LOOP_NOT_ALLOWED)
-                .location(context.createLocation(block))
-                .message("Audio loop is not allowed")
-                .actualValue("loop enabled")
-                .expectedValue("loop must not be used")
-                .addSuggestion(Suggestion.builder()
-                    .description("Remove loop option")
-                    .addExample("audio::file.mp3[options=controls]")
-                    .addExample("Remove 'loop' from options attribute")
-                    .explanation("Looping audio can be annoying for users")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(OPTIONS_LOOP_NOT_ALLOWED)
+                    .location(context.createLocation(block)).message("Audio loop is not allowed")
+                    .actualValue("loop enabled").expectedValue("loop must not be used")
+                    .addSuggestion(Suggestion.builder().description("Remove loop option")
+                            .addExample("audio::file.mp3[options=controls]")
+                            .addExample("Remove 'loop' from options attribute")
+                            .explanation("Looping audio can be annoying for users").build())
+                    .build());
         }
     }
-    
+
     private boolean hasOption(StructuralNode block, String option) {
         Object opts = block.getAttribute(OPTS);
         if (opts != null) {
             String optsStr = opts.toString();
             return optsStr.contains(option);
         }
-        
+
         // Also check individual attribute
         Object attr = block.getAttribute(option);
         return attr != null && !"false".equals(attr.toString());
     }
-    
-    private void validateTitle(String title, AudioBlock.TitleConfig titleConfig,
-                             BlockValidationContext context,
-                             StructuralNode block,
-                             List<ValidationMessage> messages,
-                             AudioBlock audioConfig) {
-        
+
+    private void validateTitle(String title, AudioBlock.TitleConfig titleConfig, BlockValidationContext context,
+            StructuralNode block, List<ValidationMessage> messages, AudioBlock audioConfig) {
+
         Severity severity = resolveSeverity(titleConfig.getSeverity(), audioConfig.getSeverity());
-        
+
         if (titleConfig.isRequired() && (title == null || title.trim().isEmpty())) {
             SourcePosition pos = findTitlePosition(block, context);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TITLE_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Audio title is required but not provided")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(".Audio Title")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add a title for the audio")
-                    .addExample(".Background Music\naudio::music.mp3[]")
-                    .addExample(".Podcast Episode\naudio::episode-01.mp3[]")
-                    .explanation("Titles help identify audio content")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Audio title is required but not provided").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint(".Audio Title")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add a title for the audio")
+                            .addExample(".Background Music\naudio::music.mp3[]")
+                            .addExample(".Podcast Episode\naudio::episode-01.mp3[]")
+                            .explanation("Titles help identify audio content").build())
+                    .build());
             return;
         }
-        
+
         if (title != null && !title.trim().isEmpty()) {
             // Validate min length
             if (titleConfig.getMinLength() != null && title.length() < titleConfig.getMinLength()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(TITLE_MIN_LENGTH)
-                    .location(context.createLocation(block))
-                    .message("Audio title is too short")
-                    .actualValue(title.length() + " characters")
-                    .expectedValue("At least " + titleConfig.getMinLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Provide a more descriptive title")
-                        .addExample("Instead of 'Audio', use 'Introduction Speech'")
-                        .addExample("Instead of 'Sound', use 'Background Music Track'")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_MIN_LENGTH)
+                        .location(context.createLocation(block)).message("Audio title is too short")
+                        .actualValue(title.length() + " characters")
+                        .expectedValue("At least " + titleConfig.getMinLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Provide a more descriptive title")
+                                .addExample("Instead of 'Audio', use 'Introduction Speech'")
+                                .addExample("Instead of 'Sound', use 'Background Music Track'").build())
+                        .build());
             }
-            
+
             // Validate max length
             if (titleConfig.getMaxLength() != null && title.length() > titleConfig.getMaxLength()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(TITLE_MAX_LENGTH)
-                    .location(context.createLocation(block))
-                    .message("Audio title is too long")
-                    .actualValue(title.length() + " characters")
-                    .expectedValue("At most " + titleConfig.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten the title while keeping it descriptive")
-                        .addExample(String.format("Keep title under %d characters", titleConfig.getMaxLength()))
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_MAX_LENGTH)
+                        .location(context.createLocation(block)).message("Audio title is too long")
+                        .actualValue(title.length() + " characters")
+                        .expectedValue("At most " + titleConfig.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder()
+                                .description("Shorten the title while keeping it descriptive")
+                                .addExample(String.format("Keep title under %d characters", titleConfig.getMaxLength()))
+                                .build())
+                        .build());
             }
         }
     }
-    
+
     /**
      * Finds the column position of URL in audio macro.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context, String url) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for audio:: macro pattern
         int audioStart = sourceLine.indexOf("audio::");
         if (audioStart >= 0) {
@@ -384,7 +318,7 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
             if (urlEnd == -1) {
                 urlEnd = sourceLine.length();
             }
-            
+
             if (url != null && !url.isEmpty()) {
                 // Find the specific URL position
                 int urlStart = sourceLine.indexOf(url, audioStart + 7);
@@ -396,26 +330,27 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
                 return new SourcePosition(audioStart + 8, audioStart + 8, lineNum);
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
     /**
      * Finds the column position for controls attribute in audio macro.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for attributes bracket
         int bracketStart = sourceLine.indexOf("[");
         if (bracketStart >= 0) {
@@ -424,10 +359,10 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
                 return new SourcePosition(bracketEnd + 1, bracketEnd + 1, lineNum);
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
     /**
      * Finds the column position for title in audio macro.
      */
@@ -435,14 +370,12 @@ public final class AudioBlockValidator extends AbstractBlockValidator<AudioBlock
         if (block.getSourceLocation() == null) {
             return new SourcePosition(1, 1, 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
-        
+
         // Title is typically on the line before the audio macro
         // Return position for the line before the audio
         return new SourcePosition(1, 1, lineNum);
     }
-    
-    
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockAttributes.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockAttributes.java
@@ -1,15 +1,15 @@
 package com.dataliquid.asciidoc.linter.validator.block;
 
 /**
- * Central repository for all AsciiDoc block attribute names.
- * This class provides constants for attribute names used across all block validators
- * to ensure consistency and maintainability.
+ * Central repository for all AsciiDoc block attribute names. This class provides constants for attribute names used
+ * across all block validators to ensure consistency and maintainability.
  */
 public final class BlockAttributes {
-    
+
     // Prevent instantiation
-    private BlockAttributes() {}
-    
+    private BlockAttributes() {
+    }
+
     // Common Attributes
     public static final String TARGET = "target";
     public static final String CAPTION = "caption";
@@ -23,36 +23,36 @@ public final class BlockAttributes {
     public static final String OPTS = "opts";
     public static final String POSITION = "position";
     public static final String ALT = "alt";
-    
+
     // Dimension Attributes
     public static final String WIDTH = "width";
     public static final String HEIGHT = "height";
-    
+
     // Quote/Verse Attributes
     public static final String ATTRIBUTION = "attribution";
     public static final String AUTHOR = "author";
     public static final String CITETITLE = "citetitle";
     public static final String SOURCE = "source";
-    
+
     // Numbered attributes (used in quote/verse blocks)
     public static final String ATTR_1 = "1";
     public static final String ATTR_2 = "2";
     public static final String ATTR_3 = "3";
-    
+
     // Media Control Attributes
     public static final String POSTER = "poster";
     public static final String CONTROLS = "controls";
     public static final String NOCONTROLS = "nocontrols";
     public static final String AUTOPLAY = "autoplay";
     public static final String LOOP = "loop";
-    
+
     // Code Attributes
     public static final String LANGUAGE = "language";
-    
+
     // Example Block Attributes
     public static final String COLLAPSIBLE = "collapsible";
     public static final String COLLAPSIBLE_OPTION = "collapsible-option";
-    
+
     // Table Attributes
     public static final String FRAME = "frame";
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockContainer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockContainer.java
@@ -14,26 +14,26 @@ import org.asciidoctor.ast.StructuralNode;
 public final class BlockContainer {
     private final StructuralNode node;
     private final String containerType;
-    
+
     private BlockContainer(StructuralNode node, String containerType) {
         this.node = Objects.requireNonNull(node, "Node must not be null");
         this.containerType = Objects.requireNonNull(containerType, "Container type must not be null");
     }
-    
+
     /**
      * Creates a BlockContainer from a Document.
      */
     public static BlockContainer fromDocument(Document document) {
         return new BlockContainer(document, "document");
     }
-    
+
     /**
      * Creates a BlockContainer from a Section.
      */
     public static BlockContainer fromSection(Section section) {
         return new BlockContainer(section, "section");
     }
-    
+
     /**
      * Gets all blocks from the container, handling preamble expansion for documents.
      */
@@ -57,19 +57,19 @@ public final class BlockContainer {
             return nodeBlocks != null ? nodeBlocks : new ArrayList<>();
         }
     }
-    
+
     /**
-     * Gets blocks from a document, expanding preamble if present.
-     * Only returns blocks at the document level, not blocks within sections.
+     * Gets blocks from a document, expanding preamble if present. Only returns blocks at the document level, not blocks
+     * within sections.
      */
     private List<StructuralNode> getDocumentBlocks(Document document) {
         List<StructuralNode> blocks = new ArrayList<>();
         List<StructuralNode> docBlocks = document.getBlocks();
-        
+
         if (docBlocks == null) {
             return blocks;
         }
-        
+
         // First, check if there's a preamble - it contains the document-level blocks
         for (StructuralNode child : docBlocks) {
             if (child != null && child.getContext() != null && child.getContext().equals("preamble")) {
@@ -82,7 +82,7 @@ public final class BlockContainer {
                 return blocks;
             }
         }
-        
+
         // If no preamble, look for blocks before the first section
         for (StructuralNode child : docBlocks) {
             if (child instanceof Section) {
@@ -93,31 +93,31 @@ public final class BlockContainer {
                 blocks.add(child);
             }
         }
-        
+
         return blocks;
     }
-    
+
     /**
      * Gets the wrapped node.
      */
     public StructuralNode getNode() {
         return node;
     }
-    
+
     /**
      * Gets the container type (document or section).
      */
     public String getContainerType() {
         return containerType;
     }
-    
+
     /**
      * Checks if this is a document container.
      */
     public boolean isDocument() {
         return node instanceof Document;
     }
-    
+
     /**
      * Checks if this is a section container.
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockEndCalculator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockEndCalculator.java
@@ -5,99 +5,99 @@ import org.asciidoctor.ast.StructuralNode;
 import com.dataliquid.asciidoc.linter.report.console.FileContentCache;
 
 /**
- * Utility class to calculate the actual end line of blocks by analyzing source files.
- * Provides generic support for all AsciiDoc block types.
+ * Utility class to calculate the actual end line of blocks by analyzing source files. Provides generic support for all
+ * AsciiDoc block types.
  */
 public class BlockEndCalculator {
     private final FileContentCache fileCache;
-    
+
     public BlockEndCalculator(FileContentCache fileCache) {
         this.fileCache = fileCache;
     }
-    
+
     /**
-     * Calculates the actual end line of a block by analyzing the source file.
-     * Works generically for ALL block types.
-     * 
-     * @param block the block to analyze
-     * @param filename the source file name
+     * Calculates the actual end line of a block by analyzing the source file. Works generically for ALL block types.
+     *
+     * @param block
+     *            the block to analyze
+     * @param filename
+     *            the source file name
      * @return the 1-based line number where the block ends
      */
     public int calculateBlockEndLine(StructuralNode block, String filename) {
         if (block.getSourceLocation() == null) {
             return 1;
         }
-        
+
         int startLine = block.getSourceLocation().getLineNumber();
         List<String> fileLines = fileCache.getFileLines(filename);
-        
+
         if (fileLines.isEmpty() || startLine > fileLines.size()) {
             return startLine;
         }
-        
+
         // Generic detection based on block context
         String context = block.getContext();
-        
+
         switch (context) {
             // List blocks
-            case "dlist":
+            case "dlist" :
                 return findDlistEnd(fileLines, startLine);
-            case "ulist":
-            case "olist":
-            case "colist":
+            case "ulist" :
+            case "olist" :
+            case "colist" :
                 return findListEnd(fileLines, startLine, context);
-                
+
             // Delimited blocks
-            case "listing":
-            case "literal":
-            case "example":
-            case "sidebar":
-            case "quote":
-            case "verse":
-            case "pass":
-            case "open":
-            case "comment":
-            case "admonition":
+            case "listing" :
+            case "literal" :
+            case "example" :
+            case "sidebar" :
+            case "quote" :
+            case "verse" :
+            case "pass" :
+            case "open" :
+            case "comment" :
+            case "admonition" :
                 return findDelimitedBlockEnd(fileLines, startLine, context);
-                
+
             // Table blocks
-            case "table":
+            case "table" :
                 return findTableEnd(fileLines, startLine);
-                
+
             // Content blocks
-            case "paragraph":
+            case "paragraph" :
                 return findParagraphEnd(fileLines, startLine);
-                
+
             // Media blocks (single line)
-            case "image":
-            case "video":
-            case "audio":
+            case "image" :
+            case "video" :
+            case "audio" :
                 return startLine;
-                
+
             // Other blocks
-            case "stem":
-            case "toc":
-            case "preamble":
-            case "abstract":
+            case "stem" :
+            case "toc" :
+            case "preamble" :
+            case "abstract" :
                 return findSpecialBlockEnd(fileLines, startLine, context);
-                
-            default:
+
+            default :
                 // Generic fallback
                 return findGenericBlockEnd(fileLines, startLine);
         }
     }
-    
+
     /**
-     * Finds the end of a description list (dlist).
-     * Continues while finding :: patterns, stops at empty line or section.
+     * Finds the end of a description list (dlist). Continues while finding :: patterns, stops at empty line or section.
      */
     private int findDlistEnd(List<String> lines, int startLine) {
         int line = startLine - 1; // Convert to 0-based index
         int lastDlistLine = line; // Track the last actual dlist content line
-        
+
         while (line < lines.size()) {
             String currentLine = lines.get(line).trim();
-            
+
             if (currentLine.contains("::")) {
                 // This is a dlist term
                 lastDlistLine = line; // Update last dlist line
@@ -115,9 +115,7 @@ public class BlockEndCalculator {
                             // This empty line ends the dlist
                             return lastDlistLine + 1; // Return 1-based line number
                         }
-                    } else if (descLine.contains("::") || 
-                               descLine.startsWith("=") ||
-                               isBlockStart(descLine)) {
+                    } else if (descLine.contains("::") || descLine.startsWith("=") || isBlockStart(descLine)) {
                         break;
                     } else {
                         // This is part of the description
@@ -137,232 +135,245 @@ public class BlockEndCalculator {
                 line++;
             }
         }
-        
+
         // Return 1-based line number (the last line that was part of the dlist)
         return lastDlistLine + 1;
     }
-    
+
     /**
-     * Finds the end of delimited blocks (listing, literal, example, etc.).
-     * Searches for matching closing delimiter.
+     * Finds the end of delimited blocks (listing, literal, example, etc.). Searches for matching closing delimiter.
      */
     private int findDelimitedBlockEnd(List<String> lines, int startLine, String context) {
         String delimiter = getDelimiterForType(context);
         int line = startLine - 1; // Convert to 0-based
-        
+
         // Skip attributes and find opening delimiter
         while (line < lines.size() && !lines.get(line).trim().equals(delimiter)) {
             line++;
         }
-        
+
         if (line >= lines.size()) {
             return lines.size();
         }
-        
+
         // Skip opening delimiter
         line++;
-        
+
         // Find closing delimiter
         while (line < lines.size() && !lines.get(line).trim().equals(delimiter)) {
             line++;
         }
-        
+
         // Include the closing delimiter
         if (line < lines.size()) {
             line++;
         }
-        
+
         return line + 1; // Return 1-based
     }
-    
+
     /**
      * Returns the delimiter string for a block type.
      */
     private String getDelimiterForType(String type) {
         switch (type) {
-            case "listing": return "----";
-            case "literal": return "....";
-            case "example": return "====";
-            case "sidebar": return "****";
-            case "quote": 
-            case "verse": return "____";
-            case "pass": return "++++";
-            case "open": return "--";
-            case "comment": return "////";
-            case "admonition": return "====";
-            case "stem": return "++++";
-            default: return "----";
+            case "listing" :
+                return "----";
+            case "literal" :
+                return "....";
+            case "example" :
+                return "====";
+            case "sidebar" :
+                return "****";
+            case "quote" :
+            case "verse" :
+                return "____";
+            case "pass" :
+                return "++++";
+            case "open" :
+                return "--";
+            case "comment" :
+                return "////";
+            case "admonition" :
+                return "====";
+            case "stem" :
+                return "++++";
+            default :
+                return "----";
         }
     }
-    
+
     /**
-     * Finds the end of a table block.
-     * Searches for closing |===.
+     * Finds the end of a table block. Searches for closing |===.
      */
     private int findTableEnd(List<String> lines, int startLine) {
         int line = startLine - 1;
-        
+
         // Find opening |===
         while (line < lines.size() && !lines.get(line).trim().equals("|===")) {
             line++;
         }
-        
+
         // Skip to content
         line++;
-        
+
         // Find closing |===
         while (line < lines.size() && !lines.get(line).trim().equals("|===")) {
             line++;
         }
-        
+
         // Include closing delimiter
         if (line < lines.size()) {
             line++;
         }
-        
+
         return line + 1; // Return 1-based
     }
-    
+
     /**
-     * Finds the end of a paragraph.
-     * Stops at empty line or block start.
+     * Finds the end of a paragraph. Stops at empty line or block start.
      */
     private int findParagraphEnd(List<String> lines, int startLine) {
         int line = startLine - 1;
-        
+
         while (line < lines.size()) {
             String currentLine = lines.get(line).trim();
-            
+
             if (currentLine.isEmpty() || isBlockStart(currentLine)) {
                 break;
             }
             line++;
         }
-        
+
         return line > 0 ? line : 1; // Return 1-based
     }
-    
+
     /**
-     * Finds the end of lists (ulist, olist).
-     * Continues while list markers match pattern.
+     * Finds the end of lists (ulist, olist). Continues while list markers match pattern.
      */
     private int findListEnd(List<String> lines, int startLine, String listType) {
         int line = startLine - 1;
         String markerPattern = getListMarkerPattern(listType);
-        
+
         while (line < lines.size()) {
             String currentLine = lines.get(line).trim();
-            
+
             if (currentLine.isEmpty()) {
                 // Empty line ends list
                 break;
             }
-            
-            if (!matchesListMarker(currentLine, markerPattern) && 
-                !isContinuationLine(lines.get(line))) {
+
+            if (!matchesListMarker(currentLine, markerPattern) && !isContinuationLine(lines.get(line))) {
                 // Not a list item or continuation
                 break;
             }
-            
+
             line++;
         }
-        
+
         return line > 0 ? line : 1; // Return 1-based
     }
-    
+
     /**
      * Generic fallback for unknown block types.
      */
     private int findGenericBlockEnd(List<String> lines, int startLine) {
         int line = startLine - 1;
         int initialIndent = getIndentLevel(lines.get(line));
-        
+
         while (line < lines.size()) {
             String current = lines.get(line);
-            
+
             if (current.trim().isEmpty()) {
                 // Empty line likely ends block
                 break;
             }
-            
+
             if (isBlockStart(current)) {
                 // New block starts
                 break;
             }
-            
+
             if (getIndentLevel(current) < initialIndent && initialIndent > 0) {
                 // Dedent indicates end
                 break;
             }
-            
+
             line++;
         }
-        
+
         return line > 0 ? line : 1; // Return 1-based
     }
-    
+
     /**
      * Checks if a line starts a new block.
      */
     private boolean isBlockStart(String line) {
         String trimmed = line.trim();
-        return trimmed.startsWith("=") ||     // Section
-               trimmed.startsWith("image::") || // Image
-               trimmed.startsWith("video::") || // Video
-               trimmed.startsWith("audio::") || // Audio
-               trimmed.startsWith("include::") || // Include
-               trimmed.startsWith("[") ||      // Block attribute
-               trimmed.startsWith("|===") ||   // Table
-               trimmed.equals("----") ||        // Listing
-               trimmed.equals("....") ||        // Literal
-               trimmed.equals("====") ||        // Example
-               trimmed.equals("****") ||        // Sidebar
-               trimmed.equals("____") ||        // Quote/Verse
-               trimmed.equals("++++") ||        // Pass
-               trimmed.equals("--") ||          // Open
-               trimmed.equals("////");          // Comment
+        return trimmed.startsWith("=") || // Section
+                trimmed.startsWith("image::") || // Image
+                trimmed.startsWith("video::") || // Video
+                trimmed.startsWith("audio::") || // Audio
+                trimmed.startsWith("include::") || // Include
+                trimmed.startsWith("[") || // Block attribute
+                trimmed.startsWith("|===") || // Table
+                trimmed.equals("----") || // Listing
+                trimmed.equals("....") || // Literal
+                trimmed.equals("====") || // Example
+                trimmed.equals("****") || // Sidebar
+                trimmed.equals("____") || // Quote/Verse
+                trimmed.equals("++++") || // Pass
+                trimmed.equals("--") || // Open
+                trimmed.equals("////"); // Comment
     }
-    
+
     private String getListMarkerPattern(String listType) {
         switch (listType) {
-            case "ulist": return "[*\\-•‣⁃]";
-            case "olist": return "[0-9]+\\.|\\.|[a-zA-Z]\\.|[ivxIVX]+\\.";
-            case "colist": return "<[0-9]+>";
-            default: return "";
+            case "ulist" :
+                return "[*\\-•‣⁃]";
+            case "olist" :
+                return "[0-9]+\\.|\\.|[a-zA-Z]\\.|[ivxIVX]+\\.";
+            case "colist" :
+                return "<[0-9]+>";
+            default :
+                return "";
         }
     }
-    
+
     private boolean matchesListMarker(String line, String pattern) {
         if (pattern.isEmpty()) {
             return false;
         }
         return line.matches("^\\s*" + pattern + "\\s+.*");
     }
-    
+
     private boolean isContinuationLine(String line) {
         return line.startsWith(" ") || line.startsWith("\t") || line.startsWith("+");
     }
-    
+
     private int getIndentLevel(String line) {
         int indent = 0;
         for (char c : line.toCharArray()) {
-            if (c == ' ') indent++;
-            else if (c == '\t') indent += 4;
-            else break;
+            if (c == ' ')
+                indent++;
+            else if (c == '\t')
+                indent += 4;
+            else
+                break;
         }
         return indent;
     }
-    
+
     private int findSpecialBlockEnd(List<String> lines, int startLine, String context) {
         // Handle special blocks like stem, toc, etc.
         switch (context) {
-            case "stem":
+            case "stem" :
                 return findDelimitedBlockEnd(lines, startLine, context);
-            case "toc":
-            case "preamble":
-            case "abstract":
+            case "toc" :
+            case "preamble" :
+            case "abstract" :
                 return findParagraphEnd(lines, startLine);
-            default:
+            default :
                 return findGenericBlockEnd(lines, startLine);
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockOccurrenceValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockOccurrenceValidator.java
@@ -14,183 +14,165 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
  * Validates block occurrence rules (min/max occurrences).
  */
 public final class BlockOccurrenceValidator {
-    
+
     private final FileContentCache fileCache = new FileContentCache();
-    
+
     /**
      * Validates occurrence rules for all blocks in a section.
-     * 
-     * @param context the validation context containing tracked blocks
-     * @param blocks the configured blocks with their occurrence rules
+     *
+     * @param context
+     *            the validation context containing tracked blocks
+     * @param blocks
+     *            the configured blocks with their occurrence rules
      * @return list of validation messages
      */
-    public List<ValidationMessage> validate(BlockValidationContext context,
-                                          List<Block> blocks) {
+    public List<ValidationMessage> validate(BlockValidationContext context, List<Block> blocks) {
         Objects.requireNonNull(context, "[" + getClass().getName() + "] context must not be null");
         Objects.requireNonNull(blocks, "[" + getClass().getName() + "] blocks must not be null");
-        
+
         // Validate occurrences for all blocks
-        
+
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         for (Block block : blocks) {
             // Check if block has occurrence constraints
             if (block.getOccurrence() != null) {
                 validateOccurrences(block, context, messages);
             }
         }
-        
+
         return messages;
     }
-    
+
     /**
      * Validates occurrences for a specific block configuration.
      */
-    private void validateOccurrences(Block block,
-                                   BlockValidationContext context,
-                                   List<ValidationMessage> messages) {
-        
+    private void validateOccurrences(Block block, BlockValidationContext context, List<ValidationMessage> messages) {
+
         com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig occurrences = block.getOccurrence();
         int actualCount = context.getOccurrenceCount(block);
         String blockType = block.getType().toString().toLowerCase();
-        
+
         // Validate occurrence count
-        
+
         // Determine severity: use occurrence-specific severity if present, otherwise fall back to block severity
-        com.dataliquid.asciidoc.linter.config.common.Severity severity = occurrences.severity() != null 
-            ? occurrences.severity() 
-            : block.getSeverity();
-        
+        com.dataliquid.asciidoc.linter.config.common.Severity severity = occurrences.severity() != null
+                ? occurrences.severity()
+                : block.getSeverity();
+
         // Validate minimum occurrences
         if (actualCount < occurrences.min()) {
             // Generate placeholder for missing block
             String blockPlaceholder = generateBlockPlaceholder(blockType);
-            
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(OCCURRENCE_MIN)
-                .location(createSectionLocation(context))
-                .message("Too few occurrences of block: " + blockType)
-                .actualValue(String.valueOf(actualCount))
-                .expectedValue("At least " + occurrences.min() + " occurrences")
-                .errorType(com.dataliquid.asciidoc.linter.validator.ErrorType.MISSING_VALUE)
-                .missingValueHint(blockPlaceholder)
-                .placeholderContext(com.dataliquid.asciidoc.linter.validator.PlaceholderContext.builder()
-                    .type(com.dataliquid.asciidoc.linter.validator.PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .build());
+
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(OCCURRENCE_MIN)
+                    .location(createSectionLocation(context)).message("Too few occurrences of block: " + blockType)
+                    .actualValue(String.valueOf(actualCount))
+                    .expectedValue("At least " + occurrences.min() + " occurrences")
+                    .errorType(com.dataliquid.asciidoc.linter.validator.ErrorType.MISSING_VALUE)
+                    .missingValueHint(blockPlaceholder)
+                    .placeholderContext(com.dataliquid.asciidoc.linter.validator.PlaceholderContext.builder().type(
+                            com.dataliquid.asciidoc.linter.validator.PlaceholderContext.PlaceholderType.INSERT_BEFORE)
+                            .build())
+                    .build());
         }
-        
+
         // Validate maximum occurrences
         if (actualCount > occurrences.max()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(OCCURRENCE_MAX)
-                .location(createSectionLocation(context))
-                .message("Too many occurrences of block: " + blockType)
-                .actualValue(String.valueOf(actualCount))
-                .expectedValue("At most " + occurrences.max() + " occurrences")
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(OCCURRENCE_MAX)
+                    .location(createSectionLocation(context)).message("Too many occurrences of block: " + blockType)
+                    .actualValue(String.valueOf(actualCount))
+                    .expectedValue("At most " + occurrences.max() + " occurrences").build());
         }
-        
+
     }
-    
+
     /**
      * Generates a placeholder hint for a missing block.
      */
     private String generateBlockPlaceholder(String blockName) {
         // Basic placeholders for common block types
         switch (blockName.toLowerCase()) {
-            case "paragraph":
+            case "paragraph" :
                 return "Paragraph content";
-            case "listing":
+            case "listing" :
                 return "[source]\n----\nCode here\n----";
-            case "image":
+            case "image" :
                 return "image::filename.png[]";
-            case "table":
+            case "table" :
                 return "|===\n| Header 1 | Header 2\n| Data 1 | Data 2\n|===";
-            case "quote":
+            case "quote" :
                 return "[quote]\n____\nQuote content\n____";
-            case "example":
+            case "example" :
                 return "====\nExample content\n====";
-            case "sidebar":
+            case "sidebar" :
                 return "****\nSidebar content\n****";
-            case "verse":
+            case "verse" :
                 return "[verse]\n____\nVerse content\n____";
-            case "literal":
+            case "literal" :
                 return "....\nLiteral content\n....";
-            case "admonition":
+            case "admonition" :
                 return "[NOTE]\n====\nNote content\n====";
-            case "ulist":
+            case "ulist" :
                 return "* Item";
-            case "olist":
+            case "olist" :
                 return ". Item";
-            case "dlist":
+            case "dlist" :
                 return "Term:: Description";
-            default:
+            default :
                 return blockName + " content";
         }
     }
-    
+
     /**
      * Creates a location for the section.
      */
     private com.dataliquid.asciidoc.linter.validator.SourceLocation createSectionLocation(
             BlockValidationContext context) {
-        
+
         // Get the container (section or document)
         org.asciidoctor.ast.StructuralNode container = context.getContainer();
-        
+
         // Try to find the last line of the section/document content
         int insertLine = 1;
-        
+
         if (container != null && container.getSourceLocation() != null) {
             // Start with section/document start line
             insertLine = container.getSourceLocation().getLineNumber();
         }
-        
+
         // Get all blocks in the container
         java.util.List<org.asciidoctor.ast.StructuralNode> blocks = container.getBlocks();
-        
+
         // For sections, if there are no content blocks (only subsections), position after the section header
         if (container instanceof org.asciidoctor.ast.Section) {
             org.asciidoctor.ast.Section section = (org.asciidoctor.ast.Section) container;
-            if (blocks == null || blocks.isEmpty() || 
-                blocks.stream().allMatch(b -> b instanceof org.asciidoctor.ast.Section)) {
+            if (blocks == null || blocks.isEmpty()
+                    || blocks.stream().allMatch(b -> b instanceof org.asciidoctor.ast.Section)) {
                 // Position after the section header (accounting for blank line)
                 if (section.getSourceLocation() != null) {
                     insertLine = section.getSourceLocation().getLineNumber() + 2;
                 } else {
                     insertLine = 1; // Fallback for tests
                 }
-                return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .startLine(insertLine)
-                    .endLine(insertLine)
-                    .startColumn(0)
-                    .endColumn(0)
-                    .build();
+                return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder().filename(context.getFilename())
+                        .startLine(insertLine).endLine(insertLine).startColumn(0).endColumn(0).build();
             }
         }
-        
+
         // Check if this is a document container with no content blocks
         if (container instanceof org.asciidoctor.ast.Document) {
             org.asciidoctor.ast.Document doc = (org.asciidoctor.ast.Document) container;
             // If document has a title but no content blocks, position after title
-            if (doc.getTitle() != null && (blocks == null || blocks.isEmpty() || 
-                blocks.stream().allMatch(b -> b instanceof org.asciidoctor.ast.Section))) {
+            if (doc.getTitle() != null && (blocks == null || blocks.isEmpty()
+                    || blocks.stream().allMatch(b -> b instanceof org.asciidoctor.ast.Section))) {
                 // Position after the document title (typically line 2)
                 insertLine = 2;
-                return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .startLine(insertLine)
-                    .endLine(insertLine)
-                    .startColumn(0)
-                    .endColumn(0)
-                    .build();
+                return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder().filename(context.getFilename())
+                        .startLine(insertLine).endLine(insertLine).startColumn(0).endColumn(0).build();
             }
         }
-        
+
         if (blocks != null && !blocks.isEmpty()) {
             // Find the last non-section block
             org.asciidoctor.ast.StructuralNode lastBlock = null;
@@ -201,23 +183,19 @@ public final class BlockOccurrenceValidator {
                     break;
                 }
             }
-            
+
             if (lastBlock != null && lastBlock.getSourceLocation() != null) {
                 // Use BlockEndCalculator to get the actual end line of the block
                 BlockEndCalculator calculator = new BlockEndCalculator(fileCache);
                 insertLine = calculator.calculateBlockEndLine(lastBlock, context.getFilename());
-                
+
                 // Add 2 lines: one for empty line after block, one for new content
                 insertLine += 2;
             }
         }
-        
-        return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder()
-            .filename(context.getFilename())
-            .startLine(insertLine)
-            .endLine(insertLine)
-            .startColumn(0)  // No column for section errors
-            .endColumn(0)
-            .build();
+
+        return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder().filename(context.getFilename())
+                .startLine(insertLine).endLine(insertLine).startColumn(0) // No column for section errors
+                .endColumn(0).build();
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockOrderValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockOrderValidator.java
@@ -13,101 +13,93 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
  * Validates block order constraints within sections.
  */
 public final class BlockOrderValidator {
-    
+
     /**
      * Validates order constraints for blocks in a section.
-     * 
-     * @param context the validation context containing tracked blocks
-     * @param orderConfig the order configuration to validate
+     *
+     * @param context
+     *            the validation context containing tracked blocks
+     * @param orderConfig
+     *            the order configuration to validate
      * @return list of validation messages
      */
-    public List<ValidationMessage> validate(BlockValidationContext context,
-                                          OrderConfig orderConfig) {
+    public List<ValidationMessage> validate(BlockValidationContext context, OrderConfig orderConfig) {
         if (context == null || orderConfig == null) {
             return List.of();
         }
-        
+
         List<ValidationMessage> messages = new ArrayList<>();
         List<BlockValidationContext.BlockPosition> actualOrder = context.getBlockOrder();
-        
+
         // Validate fixed order
         if (orderConfig.fixedOrder() != null && !orderConfig.fixedOrder().isEmpty()) {
             validateFixedOrder(actualOrder, orderConfig, context, messages);
         }
-        
+
         // Validate before constraints
         if (orderConfig.before() != null && !orderConfig.before().isEmpty()) {
             validateBeforeConstraints(actualOrder, orderConfig, context, messages);
         }
-        
+
         // Validate after constraints
         if (orderConfig.after() != null && !orderConfig.after().isEmpty()) {
             validateAfterConstraints(actualOrder, orderConfig, context, messages);
         }
-        
+
         return messages;
     }
-    
+
     /**
      * Validates that blocks appear in a fixed order.
      */
-    private void validateFixedOrder(List<BlockValidationContext.BlockPosition> actualOrder,
-                                  OrderConfig orderConfig,
-                                  BlockValidationContext context,
-                                  List<ValidationMessage> messages) {
-        
+    private void validateFixedOrder(List<BlockValidationContext.BlockPosition> actualOrder, OrderConfig orderConfig,
+            BlockValidationContext context, List<ValidationMessage> messages) {
+
         List<String> expectedOrder = orderConfig.fixedOrder();
         int expectedIndex = 0;
-        
+
         for (BlockValidationContext.BlockPosition position : actualOrder) {
             String blockIdentifier = getBlockIdentifier(position.getConfig());
-            
+
             // Check if this block is in the expected order
             int foundIndex = expectedOrder.indexOf(blockIdentifier);
             if (foundIndex >= 0) {
                 if (foundIndex < expectedIndex) {
                     // Block appears out of order
-                    messages.add(ValidationMessage.builder()
-                        .severity(orderConfig.severity())
-                        .ruleId(ORDER_FIXED)
-                        .location(context.createLocation(position.getBlock()))
-                        .message("Block '" + blockIdentifier + "' appears out of order")
-                        .actualValue("Position " + (position.getIndex() + 1))
-                        .expectedValue("Should appear after '" + 
-                                     expectedOrder.get(expectedIndex - 1) + "'")
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(orderConfig.severity()).ruleId(ORDER_FIXED)
+                            .location(context.createLocation(position.getBlock()))
+                            .message("Block '" + blockIdentifier + "' appears out of order")
+                            .actualValue("Position " + (position.getIndex() + 1))
+                            .expectedValue("Should appear after '" + expectedOrder.get(expectedIndex - 1) + "'")
+                            .build());
                 } else {
                     expectedIndex = foundIndex + 1;
                 }
             }
         }
     }
-    
+
     /**
      * Validates before constraints (blockA must come before blockB).
      */
     private void validateBeforeConstraints(List<BlockValidationContext.BlockPosition> actualOrder,
-                                         OrderConfig orderConfig,
-                                         BlockValidationContext context,
-                                         List<ValidationMessage> messages) {
-        
+            OrderConfig orderConfig, BlockValidationContext context, List<ValidationMessage> messages) {
+
         for (OrderConfig.OrderConstraint constraint : orderConfig.before()) {
             validateBeforeConstraint(actualOrder, constraint, context, messages);
         }
     }
-    
+
     private void validateBeforeConstraint(List<BlockValidationContext.BlockPosition> actualOrder,
-                                        OrderConfig.OrderConstraint constraint,
-                                        BlockValidationContext context,
-                                        List<ValidationMessage> messages) {
-        
+            OrderConfig.OrderConstraint constraint, BlockValidationContext context, List<ValidationMessage> messages) {
+
         Integer firstPos = null;
         Integer secondPos = null;
-        
+
         // Find positions of both blocks
         for (BlockValidationContext.BlockPosition position : actualOrder) {
             String identifier = getBlockIdentifier(position.getConfig());
-            
+
             if (identifier.equals(constraint.first())) {
                 firstPos = position.getIndex();
             }
@@ -115,49 +107,39 @@ public final class BlockOrderValidator {
                 secondPos = position.getIndex();
             }
         }
-        
+
         // Validate constraint if both blocks exist
         if (firstPos != null && secondPos != null && firstPos > secondPos) {
-            messages.add(ValidationMessage.builder()
-                .severity(constraint.severity())
-                .ruleId(ORDER_BEFORE)
-                .location(createSectionLocation(context))
-                .message("Block '" + constraint.first() + "' must appear before '" + 
-                        constraint.second() + "'")
-                .actualValue("'" + constraint.first() + "' at position " + 
-                           (firstPos + 1) + ", '" + constraint.second() + 
-                           "' at position " + (secondPos + 1))
-                .expectedValue("'" + constraint.first() + "' before '" + 
-                             constraint.second() + "'")
-                .build());
+            messages.add(ValidationMessage.builder().severity(constraint.severity()).ruleId(ORDER_BEFORE)
+                    .location(createSectionLocation(context))
+                    .message("Block '" + constraint.first() + "' must appear before '" + constraint.second() + "'")
+                    .actualValue("'" + constraint.first() + "' at position " + (firstPos + 1) + ", '"
+                            + constraint.second() + "' at position " + (secondPos + 1))
+                    .expectedValue("'" + constraint.first() + "' before '" + constraint.second() + "'").build());
         }
     }
-    
+
     /**
      * Validates after constraints (blockA must come after blockB).
      */
     private void validateAfterConstraints(List<BlockValidationContext.BlockPosition> actualOrder,
-                                        OrderConfig orderConfig,
-                                        BlockValidationContext context,
-                                        List<ValidationMessage> messages) {
-        
+            OrderConfig orderConfig, BlockValidationContext context, List<ValidationMessage> messages) {
+
         for (OrderConfig.OrderConstraint constraint : orderConfig.after()) {
             validateAfterConstraint(actualOrder, constraint, context, messages);
         }
     }
-    
+
     private void validateAfterConstraint(List<BlockValidationContext.BlockPosition> actualOrder,
-                                       OrderConfig.OrderConstraint constraint,
-                                       BlockValidationContext context,
-                                       List<ValidationMessage> messages) {
-        
+            OrderConfig.OrderConstraint constraint, BlockValidationContext context, List<ValidationMessage> messages) {
+
         Integer firstPos = null;
         Integer secondPos = null;
-        
+
         // Find positions of both blocks
         for (BlockValidationContext.BlockPosition position : actualOrder) {
             String identifier = getBlockIdentifier(position.getConfig());
-            
+
             if (identifier.equals(constraint.first())) {
                 firstPos = position.getIndex();
             }
@@ -165,24 +147,18 @@ public final class BlockOrderValidator {
                 secondPos = position.getIndex();
             }
         }
-        
+
         // Validate constraint if both blocks exist
         if (firstPos != null && secondPos != null && firstPos < secondPos) {
-            messages.add(ValidationMessage.builder()
-                .severity(constraint.severity())
-                .ruleId(ORDER_AFTER)
-                .location(createSectionLocation(context))
-                .message("Block '" + constraint.first() + "' must appear after '" + 
-                        constraint.second() + "'")
-                .actualValue("'" + constraint.first() + "' at position " + 
-                           (firstPos + 1) + ", '" + constraint.second() + 
-                           "' at position " + (secondPos + 1))
-                .expectedValue("'" + constraint.first() + "' after '" + 
-                             constraint.second() + "'")
-                .build());
+            messages.add(ValidationMessage.builder().severity(constraint.severity()).ruleId(ORDER_AFTER)
+                    .location(createSectionLocation(context))
+                    .message("Block '" + constraint.first() + "' must appear after '" + constraint.second() + "'")
+                    .actualValue("'" + constraint.first() + "' at position " + (firstPos + 1) + ", '"
+                            + constraint.second() + "' at position " + (secondPos + 1))
+                    .expectedValue("'" + constraint.first() + "' after '" + constraint.second() + "'").build());
         }
     }
-    
+
     /**
      * Gets the identifier for a block (name or type).
      */
@@ -192,24 +168,22 @@ public final class BlockOrderValidator {
         }
         return block.getType().toString().toLowerCase();
     }
-    
+
     /**
      * Creates a location for the section.
      */
     private com.dataliquid.asciidoc.linter.validator.SourceLocation createSectionLocation(
             BlockValidationContext context) {
-        
+
         int lineNumber = -1; // Default if no source location (should not happen)
-        
+
         // Get the actual line number from the container (Section or Document)
         org.asciidoctor.ast.StructuralNode container = context.getContainer();
         if (container != null && container.getSourceLocation() != null) {
             lineNumber = container.getSourceLocation().getLineNumber();
         }
-        
-        return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder()
-            .filename(context.getFilename())
-            .startLine(lineNumber)
-            .build();
+
+        return com.dataliquid.asciidoc.linter.validator.SourceLocation.builder().filename(context.getFilename())
+                .startLine(lineNumber).build();
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetector.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetector.java
@@ -10,87 +10,88 @@ import static com.dataliquid.asciidoc.linter.validator.block.BlockAttributes.*;
  * Detects the type of AsciidoctorJ blocks and maps them to our BlockType enum.
  */
 public final class BlockTypeDetector {
-    
+
     /**
      * Detects the block type from an AsciidoctorJ StructuralNode.
-     * 
-     * @param node the node to analyze
+     *
+     * @param node
+     *            the node to analyze
      * @return the detected block type, or null if type cannot be determined
      */
     public BlockType detectType(StructuralNode node) {
         if (node == null) {
             return null;
         }
-        
+
         try {
             // Check node context
             String context = node.getContext();
             if (context == null) {
                 return null;
             }
-        
-        // Map AsciidoctorJ contexts to our BlockTypes
-        switch (context) {
-            case "paragraph":
-                return BlockType.PARAGRAPH;
-                
-            case "listing":
-                return BlockType.LISTING;
-                
-            case "literal":
-                return BlockType.LITERAL;
-                
-            case "table":
-                return BlockType.TABLE;
-                
-            case "image":
-                return BlockType.IMAGE;
-                
-            case "verse":
-            case "quote":
-                return detectVerseOrQuote(node);
-                
-            case "admonition":
-                return BlockType.ADMONITION;
-                
-            case "pass":
-                return BlockType.PASS;
-                
-            case "sidebar":
-                return BlockType.SIDEBAR;
-                
-            case "audio":
-                return BlockType.AUDIO;
-                
-            case "video":
-                return BlockType.VIDEO;
-                
-            case "example":
-                return BlockType.EXAMPLE;
-                
-            case "open":
-                // These could contain other blocks, check content
-                return detectFromContent(node);
-                
-            case "preamble":
-                // Preamble is a container, not a block itself
-                return null;
-                
-            case "ulist":
-                return BlockType.ULIST;
-                
-            case "dlist":
-                return BlockType.DLIST;
-                
-            default:
-                return null;
-        }
+
+            // Map AsciidoctorJ contexts to our BlockTypes
+            switch (context) {
+                case "paragraph" :
+                    return BlockType.PARAGRAPH;
+
+                case "listing" :
+                    return BlockType.LISTING;
+
+                case "literal" :
+                    return BlockType.LITERAL;
+
+                case "table" :
+                    return BlockType.TABLE;
+
+                case "image" :
+                    return BlockType.IMAGE;
+
+                case "verse" :
+                case "quote" :
+                    return detectVerseOrQuote(node);
+
+                case "admonition" :
+                    return BlockType.ADMONITION;
+
+                case "pass" :
+                    return BlockType.PASS;
+
+                case "sidebar" :
+                    return BlockType.SIDEBAR;
+
+                case "audio" :
+                    return BlockType.AUDIO;
+
+                case "video" :
+                    return BlockType.VIDEO;
+
+                case "example" :
+                    return BlockType.EXAMPLE;
+
+                case "open" :
+                    // These could contain other blocks, check content
+                    return detectFromContent(node);
+
+                case "preamble" :
+                    // Preamble is a container, not a block itself
+                    return null;
+
+                case "ulist" :
+                    return BlockType.ULIST;
+
+                case "dlist" :
+                    return BlockType.DLIST;
+
+                default :
+                    return null;
+            }
         } catch (Exception e) {
             // Handle any exceptions gracefully
             return null;
         }
     }
-    
+
     /**
      * Determines if a quote/verse block is actually a verse block or quote block.
      */
@@ -99,29 +100,27 @@ public final class BlockTypeDetector {
         if ("verse".equals(node.getStyle())) {
             return BlockType.VERSE;
         }
-        
+
         // If context is "verse", it's definitely a verse block
         if ("verse".equals(node.getContext())) {
             return BlockType.VERSE;
         }
-        
+
         // If context is "quote", it's a quote block
         if ("quote".equals(node.getContext())) {
             return BlockType.QUOTE;
         }
-        
+
         // Default: if it has attribution or citetitle, treat as quote
-        if (node.getAttribute(ATTRIBUTION) != null || 
-            node.getAttribute(CITETITLE) != null ||
-            node.getAttribute(AUTHOR) != null ||
-            node.getAttribute(SOURCE) != null) {
+        if (node.getAttribute(ATTRIBUTION) != null || node.getAttribute(CITETITLE) != null
+                || node.getAttribute(AUTHOR) != null || node.getAttribute(SOURCE) != null) {
             return BlockType.QUOTE;
         }
-        
+
         // Could be a quote block containing other content
         return null;
     }
-    
+
     /**
      * Attempts to detect block type from content for container blocks.
      */
@@ -130,28 +129,28 @@ public final class BlockTypeDetector {
         String style = node.getStyle();
         if (style != null) {
             switch (style) {
-                case "source":
-                case "listing":
+                case "source" :
+                case "listing" :
                     return BlockType.LISTING;
-                case "verse":
+                case "verse" :
                     return BlockType.VERSE;
             }
         }
-        
+
         // Check if it's an image block by role
         if (node.hasRole("image") || "image".equals(node.getNodeName())) {
             return BlockType.IMAGE;
         }
-        
+
         // Check if it's a video block by role
         if (node.hasRole("video") || "video".equals(node.getNodeName())) {
             return BlockType.VIDEO;
         }
-        
+
         // Default to null for unknown container blocks
         return null;
     }
-    
+
     /**
      * Checks if a node is a specific block type.
      */

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeValidator.java
@@ -9,39 +9,43 @@ import com.dataliquid.asciidoc.linter.config.blocks.Block;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
- * Interface for block type specific validators.
- * Each block type (paragraph, table, image, etc.) has its own implementation.
- * 
- * <p>Validators work based on the YAML schema structure for block configurations.
- * The YAML configuration defines validation rules that are mapped to corresponding
- * block configuration classes (e.g., {@link com.dataliquid.asciidoc.linter.config.blocks.ListingBlock},
- * {@link com.dataliquid.asciidoc.linter.config.blocks.TableBlock}, etc.).</p>
- * 
- * <p>The YAML schema is defined in {@code src/main/resources/schemas/blocks/} and
- * provides the structure for block-specific validation rules including severity levels,
- * patterns, constraints, and nested rule configurations.</p>
- * 
+ * Interface for block type specific validators. Each block type (paragraph, table, image, etc.) has its own
+ * implementation.
+ *
+ * <p>
+ * Validators work based on the YAML schema structure for block configurations. The YAML configuration defines
+ * validation rules that are mapped to corresponding block configuration classes (e.g.,
+ * {@link com.dataliquid.asciidoc.linter.config.blocks.ListingBlock},
+ * {@link com.dataliquid.asciidoc.linter.config.blocks.TableBlock}, etc.).
+ * </p>
+ *
+ * <p>
+ * The YAML schema is defined in {@code src/main/resources/schemas/blocks/} and provides the structure for
+ * block-specific validation rules including severity levels, patterns, constraints, and nested rule configurations.
+ * </p>
+ *
  * @see com.dataliquid.asciidoc.linter.config.blocks.Block
  * @see com.dataliquid.asciidoc.linter.config.loader.ConfigurationLoader
  */
 public interface BlockTypeValidator {
-    
+
     /**
      * Returns the block type that this validator supports.
-     * 
+     *
      * @return the supported block type
      */
     BlockType getSupportedType();
-    
+
     /**
      * Validates a block against its configuration.
-     * 
-     * @param block the AsciidoctorJ block to validate
-     * @param config the block configuration containing validation rules
-     * @param context the validation context containing section information
+     *
+     * @param block
+     *            the AsciidoctorJ block to validate
+     * @param config
+     *            the block configuration containing validation rules
+     * @param context
+     *            the validation context containing section information
      * @return list of validation messages (errors, warnings, info)
      */
-    List<ValidationMessage> validate(StructuralNode block, 
-                                   Block config,
-                                   BlockValidationContext context);
+    List<ValidationMessage> validate(StructuralNode block, Block config, BlockValidationContext context);
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidationContext.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidationContext.java
@@ -22,7 +22,7 @@ public final class BlockValidationContext {
     private final String filename;
     private final Map<String, List<BlockOccurrence>> occurrences;
     private final List<BlockPosition> blockOrder;
-    
+
     /**
      * Constructor for section validation.
      */
@@ -32,7 +32,7 @@ public final class BlockValidationContext {
         this.occurrences = new HashMap<>();
         this.blockOrder = new ArrayList<>();
     }
-    
+
     /**
      * Constructor for document validation.
      */
@@ -42,19 +42,19 @@ public final class BlockValidationContext {
         this.occurrences = new HashMap<>();
         this.blockOrder = new ArrayList<>();
     }
-    
+
     public Section getSection() {
         return container instanceof Section ? (Section) container : null;
     }
-    
+
     public StructuralNode getContainer() {
         return container;
     }
-    
+
     public String getFilename() {
         return filename;
     }
-    
+
     /**
      * Creates a source location for the given block.
      */
@@ -63,13 +63,10 @@ public final class BlockValidationContext {
         if (block.getSourceLocation() != null) {
             line = block.getSourceLocation().getLineNumber();
         }
-        
-        return SourceLocation.builder()
-            .filename(filename)
-            .startLine(line)
-            .build();
+
+        return SourceLocation.builder().filename(filename).startLine(line).build();
     }
-    
+
     /**
      * Creates a source location for the given block with column information.
      */
@@ -78,28 +75,23 @@ public final class BlockValidationContext {
         if (block.getSourceLocation() != null) {
             line = block.getSourceLocation().getLineNumber();
         }
-        
-        return SourceLocation.builder()
-            .filename(filename)
-            .startLine(line)
-            .endLine(line)
-            .startColumn(startColumn)
-            .endColumn(endColumn)
-            .build();
+
+        return SourceLocation.builder().filename(filename).startLine(line).endLine(line).startColumn(startColumn)
+                .endColumn(endColumn).build();
     }
-    
+
     /**
      * Tracks a block occurrence for validation.
      */
     public void trackBlock(Block config, StructuralNode block) {
         String key = createOccurrenceKey(config);
-        
+
         BlockOccurrence occurrence = new BlockOccurrence(config, block, blockOrder.size());
         occurrences.computeIfAbsent(key, k -> new ArrayList<>()).add(occurrence);
-        
+
         blockOrder.add(new BlockPosition(config, block, blockOrder.size()));
     }
-    
+
     /**
      * Gets all occurrences for a specific block configuration.
      */
@@ -107,21 +99,21 @@ public final class BlockValidationContext {
         String key = createOccurrenceKey(config);
         return occurrences.getOrDefault(key, Collections.emptyList());
     }
-    
+
     /**
      * Gets the count of occurrences for a specific block configuration.
      */
     public int getOccurrenceCount(Block config) {
         return getOccurrences(config).size();
     }
-    
+
     /**
      * Gets all tracked blocks in order.
      */
     public List<BlockPosition> getBlockOrder() {
         return new ArrayList<>(blockOrder);
     }
-    
+
     /**
      * Gets a human-readable name for the block.
      */
@@ -131,14 +123,14 @@ public final class BlockValidationContext {
         }
         return config.getType().toString().toLowerCase() + " block";
     }
-    
+
     private String createOccurrenceKey(Block config) {
         if (config.getName() != null) {
             return config.getType() + ":" + config.getName();
         }
         return config.getType().toString();
     }
-    
+
     /**
      * Represents a block occurrence with its configuration and position.
      */
@@ -146,18 +138,26 @@ public final class BlockValidationContext {
         private final Block config;
         private final StructuralNode block;
         private final int position;
-        
+
         BlockOccurrence(Block config, StructuralNode block, int position) {
             this.config = config;
             this.block = block;
             this.position = position;
         }
-        
-        public Block getConfig() { return config; }
-        public StructuralNode getBlock() { return block; }
-        public int getPosition() { return position; }
+
+        public Block getConfig() {
+            return config;
+        }
+
+        public StructuralNode getBlock() {
+            return block;
+        }
+
+        public int getPosition() {
+            return position;
+        }
     }
-    
+
     /**
      * Represents a block's position in the document.
      */
@@ -165,15 +165,23 @@ public final class BlockValidationContext {
         private final Block config;
         private final StructuralNode block;
         private final int index;
-        
+
         BlockPosition(Block config, StructuralNode block, int index) {
             this.config = config;
             this.block = block;
             this.index = index;
         }
-        
-        public Block getConfig() { return config; }
-        public StructuralNode getBlock() { return block; }
-        public int getIndex() { return index; }
+
+        public Block getConfig() {
+            return config;
+        }
+
+        public StructuralNode getBlock() {
+            return block;
+        }
+
+        public int getIndex() {
+            return index;
+        }
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidatorFactory.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidatorFactory.java
@@ -10,39 +10,41 @@ import com.dataliquid.asciidoc.linter.config.blocks.BlockType;
  * Factory for creating block type validators.
  */
 public final class BlockValidatorFactory {
-    
+
     private final Map<BlockType, BlockTypeValidator> validators;
-    
+
     public BlockValidatorFactory() {
         this.validators = createValidators();
     }
-    
+
     /**
      * Gets a validator for the specified block type.
-     * 
-     * @param type the block type
+     *
+     * @param type
+     *            the block type
      * @return the validator, or null if no validator exists for the type
      */
     public BlockTypeValidator getValidator(BlockType type) {
         return validators.get(type);
     }
-    
+
     /**
      * Checks if a validator exists for the specified block type.
-     * 
-     * @param type the block type
+     *
+     * @param type
+     *            the block type
      * @return true if a validator exists, false otherwise
      */
     public boolean hasValidator(BlockType type) {
         return validators.containsKey(type);
     }
-    
+
     /**
      * Creates and registers all available validators.
      */
     private Map<BlockType, BlockTypeValidator> createValidators() {
         Map<BlockType, BlockTypeValidator> map = new HashMap<>();
-        
+
         // Register all validators
         registerValidator(map, new ParagraphBlockValidator());
         registerValidator(map, new TableBlockValidator());
@@ -59,31 +61,27 @@ public final class BlockValidatorFactory {
         registerValidator(map, new VideoBlockValidator());
         registerValidator(map, new UlistBlockValidator());
         registerValidator(map, new DlistBlockValidator());
-        
+
         return map;
     }
-    
+
     /**
      * Registers a validator in the map.
      */
-    private void registerValidator(Map<BlockType, BlockTypeValidator> map, 
-                                  BlockTypeValidator validator) {
+    private void registerValidator(Map<BlockType, BlockTypeValidator> map, BlockTypeValidator validator) {
         Objects.requireNonNull(validator, "[" + getClass().getName() + "] validator must not be null");
         BlockType type = validator.getSupportedType();
-        
+
         if (type == null) {
             throw new IllegalStateException(
-                "Validator " + validator.getClass().getName() + 
-                " returned null from getSupportedType()");
+                    "Validator " + validator.getClass().getName() + " returned null from getSupportedType()");
         }
-        
+
         if (map.containsKey(type)) {
-            throw new IllegalStateException(
-                "Duplicate validator for type " + type + ": " +
-                map.get(type).getClass().getName() + " and " +
-                validator.getClass().getName());
+            throw new IllegalStateException("Duplicate validator for type " + type + ": "
+                    + map.get(type).getClass().getName() + " and " + validator.getClass().getName());
         }
-        
+
         map.put(type, validator);
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/DlistBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/DlistBlockValidator.java
@@ -23,132 +23,115 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for definition list (dlist) blocks in AsciiDoc documents.
- * 
- * <p>This validator validates definition list blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/dlist-block.yaml}.
- * The YAML configuration is parsed into {@link DlistBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * This validator validates definition list blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/dlist-block.yaml}. The YAML configuration is parsed into {@link DlistBlock}
+ * objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>terms</b>: Validates term count, pattern, and length</li>
- *   <li><b>descriptions</b>: Validates description presence, count, and pattern</li>
- *   <li><b>nestingLevel</b>: Validates maximum nesting depth</li>
- *   <li><b>delimiterStyle</b>: Validates delimiter consistency and allowed styles</li>
+ * <li><b>terms</b>: Validates term count, pattern, and length</li>
+ * <li><b>descriptions</b>: Validates description presence, count, and pattern</li>
+ * <li><b>nestingLevel</b>: Validates maximum nesting depth</li>
+ * <li><b>delimiterStyle</b>: Validates delimiter consistency and allowed styles</li>
  * </ul>
- * 
- * <p>Each nested configuration can optionally define its own severity level.
- * If not specified, the block-level severity is used as fallback.</p>
- * 
+ *
+ * <p>
+ * Each nested configuration can optionally define its own severity level. If not specified, the block-level severity is
+ * used as fallback.
+ * </p>
+ *
  * @see DlistBlock
  * @see BlockTypeValidator
  */
-public final class DlistBlockValidator extends AbstractBlockValidator<DlistBlock> {    
+public final class DlistBlockValidator extends AbstractBlockValidator<DlistBlock> {
     @Override
     public BlockType getSupportedType() {
         return BlockType.DLIST;
     }
-    
+
     @Override
     protected Class<DlistBlock> getBlockConfigClass() {
         return DlistBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               DlistBlock dlistConfig,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, DlistBlock dlistConfig,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Validate only if block is a DescriptionList
         if (!(block instanceof DescriptionList)) {
             return messages;
         }
-        
+
         DescriptionList dlist = (DescriptionList) block;
         List<DescriptionListEntry> entries = dlist.getItems();
-        
+
         // Validate terms
         if (dlistConfig.getTerms() != null) {
             validateTerms(entries, dlistConfig.getTerms(), dlistConfig, context, block, messages);
         }
-        
+
         // Validate descriptions
         if (dlistConfig.getDescriptions() != null) {
             validateDescriptions(entries, dlistConfig.getDescriptions(), dlistConfig, context, block, messages);
         }
-        
+
         // Note: Nesting level and delimiter style validation are not implemented
         // because AsciiDoctor's AST doesn't provide this information reliably.
         // - Delimiter style (::, :::, etc.) is not preserved in the AST
         // - Nesting requires specific syntax that's not commonly used
-        
+
         return messages;
     }
-    
-    private void validateTerms(List<DescriptionListEntry> entries,
-                             DlistBlock.TermsConfig config,
-                             DlistBlock blockConfig,
-                             BlockValidationContext context,
-                             StructuralNode block,
-                             List<ValidationMessage> messages) {
-        
+
+    private void validateTerms(List<DescriptionListEntry> entries, DlistBlock.TermsConfig config,
+            DlistBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         int termCount = entries.size();
-        
+
         // Validate min terms
         if (config.getMin() != null && termCount < config.getMin()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TERMS_MIN)
-                .location(context.createLocation(block))
-                .message("Definition list has too few terms")
-                .actualValue(String.valueOf(termCount))
-                .expectedValue("At least " + config.getMin() + " terms")
-                .addSuggestion(Suggestion.builder()
-                    .description("Add term with description")
-                    .addExample("Term1::")
-                    .addExample("  Description for Term1")
-                    .addExample("")
-                    .addExample("Term2::")
-                    .addExample("  Description for Term2")
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add simple definition")
-                    .addExample("API:: Application Programming Interface")
-                    .addExample("URL:: Uniform Resource Locator")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TERMS_MIN)
+                    .location(context.createLocation(block)).message("Definition list has too few terms")
+                    .actualValue(String.valueOf(termCount)).expectedValue("At least " + config.getMin() + " terms")
+                    .addSuggestion(Suggestion.builder().description("Add term with description").addExample("Term1::")
+                            .addExample("  Description for Term1").addExample("").addExample("Term2::")
+                            .addExample("  Description for Term2").build())
+                    .addSuggestion(Suggestion.builder().description("Add simple definition")
+                            .addExample("API:: Application Programming Interface")
+                            .addExample("URL:: Uniform Resource Locator").build())
+                    .build());
         }
-        
+
         // Validate max terms
         if (config.getMax() != null && termCount > config.getMax()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TERMS_MAX)
-                .location(context.createLocation(block))
-                .message("Definition list has too many terms")
-                .actualValue(String.valueOf(termCount))
-                .expectedValue("At most " + config.getMax() + " terms")
-                .addSuggestion(Suggestion.builder()
-                    .description("Split into multiple definition lists")
-                    .addExample("Group related terms into separate lists with headings")
-                    .explanation("Consider organizing " + (termCount - config.getMax()) + " excess terms")
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Remove less important terms")
-                    .addExample("Keep only the most relevant definitions")
-                    .explanation("Focus on the most essential terms")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TERMS_MAX)
+                    .location(context.createLocation(block)).message("Definition list has too many terms")
+                    .actualValue(String.valueOf(termCount)).expectedValue("At most " + config.getMax() + " terms")
+                    .addSuggestion(Suggestion.builder().description("Split into multiple definition lists")
+                            .addExample("Group related terms into separate lists with headings")
+                            .explanation("Consider organizing " + (termCount - config.getMax()) + " excess terms")
+                            .build())
+                    .addSuggestion(Suggestion.builder().description("Remove less important terms")
+                            .addExample("Keep only the most relevant definitions")
+                            .explanation("Focus on the most essential terms").build())
+                    .build());
         }
-        
+
         // Validate each term
         if (config.getPattern() != null || config.getMinLength() != null || config.getMaxLength() != null) {
             Pattern pattern = config.getPattern() != null ? Pattern.compile(config.getPattern()) : null;
-            
+
             for (DescriptionListEntry entry : entries) {
                 List<ListItem> termItems = entry.getTerms();
                 for (ListItem termItem : termItems) {
@@ -160,181 +143,131 @@ public final class DlistBlockValidator extends AbstractBlockValidator<DlistBlock
             }
         }
     }
-    
-    private void validateTermContent(String term,
-                                   DlistBlock.TermsConfig config,
-                                   Pattern pattern,
-                                   Severity severity,
-                                   BlockValidationContext context,
-                                   StructuralNode block,
-                                   ListItem termItem,
-                                   List<ValidationMessage> messages) {
-        
+
+    private void validateTermContent(String term, DlistBlock.TermsConfig config, Pattern pattern, Severity severity,
+            BlockValidationContext context, StructuralNode block, ListItem termItem, List<ValidationMessage> messages) {
+
         SourcePosition pos = findSourcePosition(block, termItem, context, term);
-        
+
         // Validate pattern
         if (pattern != null && !pattern.matcher(term).matches()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TERMS_PATTERN)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Definition list term does not match required pattern")
-                .actualValue(term)
-                .expectedValue("Pattern: " + config.getPattern())
-                .addSuggestion(Suggestion.builder()
-                    .description("Follow pattern format")
-                    .addExample("Use consistent term format")
-                    .addExample("Example: ACRONYM, Full Name, CamelCase")
-                    .explanation("Term must match pattern: " + config.getPattern())
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TERMS_PATTERN)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Definition list term does not match required pattern").actualValue(term)
+                    .expectedValue("Pattern: " + config.getPattern())
+                    .addSuggestion(Suggestion.builder().description("Follow pattern format")
+                            .addExample("Use consistent term format")
+                            .addExample("Example: ACRONYM, Full Name, CamelCase")
+                            .explanation("Term must match pattern: " + config.getPattern()).build())
+                    .build());
         }
-        
+
         // Validate min length
         if (config.getMinLength() != null && term.length() < config.getMinLength()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TERMS_MIN_LENGTH)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Definition list term is too short")
-                .actualValue(term + " (length: " + term.length() + ")")
-                .expectedValue("Minimum length: " + config.getMinLength())
-                .addSuggestion(Suggestion.builder()
-                    .description("Use more descriptive term")
-                    .addExample("Expand abbreviation: API → Application Programming Interface")
-                    .addExample("Add context: User → User Account")
-                    .explanation("Term needs at least " + config.getMinLength() + " characters")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TERMS_MIN_LENGTH)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Definition list term is too short").actualValue(term + " (length: " + term.length() + ")")
+                    .expectedValue("Minimum length: " + config.getMinLength())
+                    .addSuggestion(Suggestion.builder().description("Use more descriptive term")
+                            .addExample("Expand abbreviation: API → Application Programming Interface")
+                            .addExample("Add context: User → User Account")
+                            .explanation("Term needs at least " + config.getMinLength() + " characters").build())
+                    .build());
         }
-        
+
         // Validate max length
         if (config.getMaxLength() != null && term.length() > config.getMaxLength()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TERMS_MAX_LENGTH)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Definition list term is too long")
-                .actualValue(term + " (length: " + term.length() + ")")
-                .expectedValue("Maximum length: " + config.getMaxLength())
-                .addSuggestion(Suggestion.builder()
-                    .description("Shorten term")
-                    .addExample("Use abbreviation or acronym")
-                    .addExample("Remove unnecessary words")
-                    .explanation("Term must be at most " + config.getMaxLength() + " characters")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TERMS_MAX_LENGTH)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Definition list term is too long").actualValue(term + " (length: " + term.length() + ")")
+                    .expectedValue("Maximum length: " + config.getMaxLength())
+                    .addSuggestion(Suggestion.builder().description("Shorten term")
+                            .addExample("Use abbreviation or acronym").addExample("Remove unnecessary words")
+                            .explanation("Term must be at most " + config.getMaxLength() + " characters").build())
+                    .build());
         }
     }
-    
-    private void validateDescriptions(List<DescriptionListEntry> entries,
-                                    DlistBlock.DescriptionsConfig config,
-                                    DlistBlock blockConfig,
-                                    BlockValidationContext context,
-                                    StructuralNode block,
-                                    List<ValidationMessage> messages) {
-        
+
+    private void validateDescriptions(List<DescriptionListEntry> entries, DlistBlock.DescriptionsConfig config,
+            DlistBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         Pattern pattern = config.getPattern() != null ? Pattern.compile(config.getPattern()) : null;
-        
+
         for (DescriptionListEntry entry : entries) {
             ListItem description = entry.getDescription();
-            
+
             // Check if description is required
-            if (config.getRequired() != null && config.getRequired() && 
-                (description == null || description.getText() == null || description.getText().trim().isEmpty())) {
+            if (config.getRequired() != null && config.getRequired() && (description == null
+                    || description.getText() == null || description.getText().trim().isEmpty())) {
                 // Get the first term for error location
                 List<ListItem> terms = entry.getTerms();
                 if (!terms.isEmpty()) {
                     ListItem firstTerm = terms.get(0);
                     String termText = firstTerm.getText();
                     SourcePosition pos = findSourcePosition(block, firstTerm, context, termText);
-                    
-                    messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(DESCRIPTIONS_REQUIRED)
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .message("Definition list term missing required description")
-                        .actualValue("No description")
-                        .expectedValue("Description required")
-                        .errorType(ErrorType.MISSING_VALUE)
-                        .missingValueHint("Description")
-                        .placeholderContext(PlaceholderContext.builder()
-                            .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                            .build())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Add simple description")
-                            .fixedValue("Description text")
-                            .addExample(termText + "::")
-                            .addExample("  Brief explanation of " + termText)
-                            .build())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Add detailed description")
-                            .addExample(termText + "::")
-                            .addExample("  Detailed explanation of what " + termText + " means")
-                            .addExample("  and how it is used in this context.")
-                            .build())
-                        .build());
+
+                    messages.add(ValidationMessage.builder().severity(severity).ruleId(DESCRIPTIONS_REQUIRED)
+                            .location(
+                                    SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                            .message("Definition list term missing required description").actualValue("No description")
+                            .expectedValue("Description required").errorType(ErrorType.MISSING_VALUE)
+                            .missingValueHint("Description")
+                            .placeholderContext(PlaceholderContext.builder()
+                                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                            .addSuggestion(Suggestion.builder().description("Add simple description")
+                                    .fixedValue("Description text").addExample(termText + "::")
+                                    .addExample("  Brief explanation of " + termText).build())
+                            .addSuggestion(Suggestion.builder().description("Add detailed description")
+                                    .addExample(termText + "::")
+                                    .addExample("  Detailed explanation of what " + termText + " means")
+                                    .addExample("  and how it is used in this context.").build())
+                            .build());
                 }
             }
-            
+
             // Validate description content if present
             if (description != null && description.getText() != null && pattern != null) {
                 String descText = description.getText();
                 if (!pattern.matcher(descText).find()) {
-                    messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(DESCRIPTIONS_PATTERN)
-                        .location(context.createLocation(block))
-                        .message("Definition list description does not match required pattern")
-                        .actualValue(descText.length() > 50 ? descText.substring(0, 50) + "..." : descText)
-                        .expectedValue("Pattern: " + config.getPattern())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Follow description pattern")
-                            .addExample("Ensure description format matches requirements")
-                            .addExample("Start with capital letter and end with period")
-                            .addExample("Use complete sentences")
-                            .explanation("Description must match pattern: " + config.getPattern())
-                            .build())
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(severity).ruleId(DESCRIPTIONS_PATTERN)
+                            .location(context.createLocation(block))
+                            .message("Definition list description does not match required pattern")
+                            .actualValue(descText.length() > 50 ? descText.substring(0, 50) + "..." : descText)
+                            .expectedValue("Pattern: " + config.getPattern())
+                            .addSuggestion(Suggestion.builder().description("Follow description pattern")
+                                    .addExample("Ensure description format matches requirements")
+                                    .addExample("Start with capital letter and end with period")
+                                    .addExample("Use complete sentences")
+                                    .explanation("Description must match pattern: " + config.getPattern()).build())
+                            .build());
                 }
             }
         }
     }
-    
+
     /**
      * Finds the column position of a term in definition list.
      */
-    private SourcePosition findSourcePosition(StructuralNode block, ListItem termItem, 
-                                        BlockValidationContext context, String term) {
+    private SourcePosition findSourcePosition(StructuralNode block, ListItem termItem, BlockValidationContext context,
+            String term) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
-        
+
         // Try to get line number from termItem's source location
         int lineNum = block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1;
         if (termItem.getSourceLocation() != null) {
             lineNum = termItem.getSourceLocation().getLineNumber();
         }
-        
+
         if (fileLines.isEmpty() || lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for the term in the source line
         // Definition list terms are usually in format "term::" or "term:::"
         int termStart = sourceLine.indexOf(term);
@@ -345,7 +278,7 @@ public final class DlistBlockValidator extends AbstractBlockValidator<DlistBlock
                 return new SourcePosition(termStart + 1, termStart + term.length(), lineNum);
             }
         }
-        
+
         // If not found on expected line, search nearby lines
         // Terms might be on different lines than the block start
         for (int offset = -2; offset <= 2; offset++) {
@@ -361,8 +294,8 @@ public final class DlistBlockValidator extends AbstractBlockValidator<DlistBlock
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidator.java
@@ -18,187 +18,154 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for EXAMPLE blocks.
- * 
- * Validates example blocks according to the YAML schema definition,
- * including caption format and collapsible attribute.
+ *
+ * Validates example blocks according to the YAML schema definition, including caption format and collapsible attribute.
  */
 public final class ExampleBlockValidator extends AbstractBlockValidator<ExampleBlock> {
-    
+
     @Override
     public BlockType getSupportedType() {
         return BlockType.EXAMPLE;
     }
-    
+
     @Override
     protected Class<ExampleBlock> getBlockConfigClass() {
         return ExampleBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode node, 
-                                                               ExampleBlock exampleBlock,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode node, ExampleBlock exampleBlock,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Validate caption
         if (exampleBlock.getCaption() != null) {
             messages.addAll(validateCaption(node, exampleBlock, context));
         }
-        
+
         // Validate collapsible
         if (exampleBlock.getCollapsible() != null) {
             messages.addAll(validateCollapsible(node, exampleBlock, context));
         }
-        
+
         return messages;
     }
-    
-    private List<ValidationMessage> validateCaption(StructuralNode node, ExampleBlock block, BlockValidationContext context) {
+
+    private List<ValidationMessage> validateCaption(StructuralNode node, ExampleBlock block,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
         ExampleBlock.CaptionConfig config = block.getCaption();
-        
+
         String caption = node.getTitle();
-        
+
         // Check if caption is required
         if (config.isRequired() && (caption == null || caption.trim().isEmpty())) {
             // Find position for caption placeholder
             int lineNumber = node.getSourceLocation() != null ? node.getSourceLocation().getLineNumber() : 1;
-            messages.add(ValidationMessage.builder()
-                .message("Example block requires a caption")
-                .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .startLine(lineNumber)
-                    .endLine(lineNumber)
-                    .startColumn(1)
-                    .endColumn(1)
-                    .build())
-                .ruleId(CAPTION_REQUIRED)
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(".Example Title")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add caption to example block")
-                    .fixedValue(".Example Title")
-                    .addExample(".Sample Configuration")
-                    .addExample(".Code Example")
-                    .addExample(".Usage Demonstration")
-                    .explanation("Example blocks should have descriptive captions to explain their purpose")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().message("Example block requires a caption")
+                    .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
+                    .location(SourceLocation.builder().filename(context.getFilename()).startLine(lineNumber)
+                            .endLine(lineNumber).startColumn(1).endColumn(1).build())
+                    .ruleId(CAPTION_REQUIRED).errorType(ErrorType.MISSING_VALUE).missingValueHint(".Example Title")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add caption to example block")
+                            .fixedValue(".Example Title").addExample(".Sample Configuration")
+                            .addExample(".Code Example").addExample(".Usage Demonstration")
+                            .explanation("Example blocks should have descriptive captions to explain their purpose")
+                            .build())
+                    .build());
             return messages;
         }
-        
+
         // If caption is not present and not required, skip further validation
         if (caption == null || caption.trim().isEmpty()) {
             return messages;
         }
-        
+
         // Validate caption length
         if (config.getMinLength() != null && caption.length() < config.getMinLength()) {
             messages.add(ValidationMessage.builder()
-                .message(String.format("Example caption length %d is less than required minimum %d",
-                    caption.length(), config.getMinLength()))
-                .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
-                .location(context.createLocation(node))
-                .ruleId(CAPTION_MIN_LENGTH)
-                .addSuggestion(Suggestion.builder()
-                    .description("Use a longer, more descriptive caption")
-                    .addExample("Sample Configuration File")
-                    .addExample("Complete Code Example")
-                    .addExample("Step-by-Step Demonstration")
-                    .explanation("Example captions should be descriptive enough to meet minimum length requirements")
-                    .build())
-                .build());
+                    .message(String.format("Example caption length %d is less than required minimum %d",
+                            caption.length(), config.getMinLength()))
+                    .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
+                    .location(context.createLocation(node)).ruleId(CAPTION_MIN_LENGTH)
+                    .addSuggestion(Suggestion.builder().description("Use a longer, more descriptive caption")
+                            .addExample("Sample Configuration File").addExample("Complete Code Example")
+                            .addExample("Step-by-Step Demonstration")
+                            .explanation(
+                                    "Example captions should be descriptive enough to meet minimum length requirements")
+                            .build())
+                    .build());
         }
-        
+
         if (config.getMaxLength() != null && caption.length() > config.getMaxLength()) {
             messages.add(ValidationMessage.builder()
-                .message(String.format("Example caption length %d exceeds maximum %d",
-                    caption.length(), config.getMaxLength()))
-                .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
-                .location(context.createLocation(node))
-                .ruleId(CAPTION_MAX_LENGTH)
-                .addSuggestion(Suggestion.builder()
-                    .description("Shorten the caption")
-                    .addExample("Config Example")
-                    .addExample("Code Sample")
-                    .addExample("Usage Demo")
-                    .explanation("Example captions should be concise and not exceed maximum length limits")
-                    .build())
-                .build());
+                    .message(String.format("Example caption length %d exceeds maximum %d", caption.length(),
+                            config.getMaxLength()))
+                    .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
+                    .location(context.createLocation(node)).ruleId(CAPTION_MAX_LENGTH)
+                    .addSuggestion(Suggestion.builder().description("Shorten the caption").addExample("Config Example")
+                            .addExample("Code Sample").addExample("Usage Demo")
+                            .explanation("Example captions should be concise and not exceed maximum length limits")
+                            .build())
+                    .build());
         }
-        
+
         // Validate caption pattern
         if (config.getPattern() != null && !config.getPattern().matcher(caption).matches()) {
             messages.add(ValidationMessage.builder()
-                .message(String.format("Example caption '%s' does not match required pattern '%s'",
-                    caption, config.getPattern().pattern()))
-                .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
-                .location(context.createLocation(node))
-                .ruleId(CAPTION_PATTERN)
-                .addSuggestion(Suggestion.builder()
-                    .description("Format caption to match required pattern")
-                    .addExample("Example 1: Basic Setup")
-                    .addExample("Example 2: Advanced Configuration")
-                    .addExample("Example 3: Common Use Case")
-                    .explanation("Example captions must follow the specified format pattern")
-                    .build())
-                .build());
+                    .message(String.format("Example caption '%s' does not match required pattern '%s'", caption,
+                            config.getPattern().pattern()))
+                    .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
+                    .location(context.createLocation(node)).ruleId(CAPTION_PATTERN)
+                    .addSuggestion(Suggestion.builder().description("Format caption to match required pattern")
+                            .addExample("Example 1: Basic Setup").addExample("Example 2: Advanced Configuration")
+                            .addExample("Example 3: Common Use Case")
+                            .explanation("Example captions must follow the specified format pattern").build())
+                    .build());
         }
-        
+
         return messages;
     }
-    
-    private List<ValidationMessage> validateCollapsible(StructuralNode node, ExampleBlock block, BlockValidationContext context) {
+
+    private List<ValidationMessage> validateCollapsible(StructuralNode node, ExampleBlock block,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
         ExampleBlock.CollapsibleConfig config = block.getCollapsible();
-        
+
         // Check for collapsible attribute
         Object collapsibleAttr = node.getAttribute(COLLAPSIBLE_OPTION);
         if (collapsibleAttr == null) {
             collapsibleAttr = node.getAttribute(COLLAPSIBLE);
         }
-        
+
         // Check if collapsible is required
         if (config.isRequired() && collapsibleAttr == null) {
             // Find position for collapsible placeholder
             int lineNumber = node.getSourceLocation() != null ? node.getSourceLocation().getLineNumber() : 1;
-            messages.add(ValidationMessage.builder()
-                .message("Example block requires a collapsible attribute")
-                .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .startLine(lineNumber)
-                    .endLine(lineNumber)
-                    .startColumn(1)
-                    .endColumn(1)
-                    .build())
-                .ruleId(COLLAPSIBLE_REQUIRED)
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("[%collapsible]")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add collapsible attribute to example block")
-                    .fixedValue("[%collapsible]")
-                    .addExample("[%collapsible]")
-                    .addExample("[example,%collapsible]")
-                    .addExample("[%collapsible%open]")
-                    .explanation("Collapsible examples can be collapsed/expanded by readers for better content organization")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().message("Example block requires a collapsible attribute")
+                    .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
+                    .location(SourceLocation.builder().filename(context.getFilename()).startLine(lineNumber)
+                            .endLine(lineNumber).startColumn(1).endColumn(1).build())
+                    .ruleId(COLLAPSIBLE_REQUIRED).errorType(ErrorType.MISSING_VALUE).missingValueHint("[%collapsible]")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add collapsible attribute to example block")
+                            .fixedValue("[%collapsible]").addExample("[%collapsible]")
+                            .addExample("[example,%collapsible]").addExample("[%collapsible%open]")
+                            .explanation(
+                                    "Collapsible examples can be collapsed/expanded by readers for better content organization")
+                            .build())
+                    .build());
             return messages;
         }
-        
+
         // If collapsible is not present and not required, skip further validation
         if (collapsibleAttr == null) {
             return messages;
         }
-        
+
         // Parse boolean value
         Boolean collapsibleValue = null;
         if (collapsibleAttr instanceof Boolean) {
@@ -211,28 +178,26 @@ public final class ExampleBlockValidator extends AbstractBlockValidator<ExampleB
                 collapsibleValue = false;
             }
         }
-        
+
         // Validate allowed values
         if (config.getAllowed() != null && !config.getAllowed().isEmpty()) {
             if (collapsibleValue == null || !config.getAllowed().contains(collapsibleValue)) {
                 messages.add(ValidationMessage.builder()
-                    .message(String.format("Example collapsible value '%s' is not in allowed values %s",
-                        collapsibleAttr, config.getAllowed()))
-                    .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
-                    .location(context.createLocation(node))
-                    .ruleId(COLLAPSIBLE_ALLOWED)
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use a valid collapsible value")
-                        .fixedValue(config.getAllowed().contains(true) ? "[%collapsible]" : "[%collapsible=false]")
-                        .addExample("[%collapsible] for collapsible")
-                        .addExample("[%collapsible%open] for initially open")
-                        .addExample("Remove attribute for non-collapsible")
-                        .explanation("Collapsible attribute must be one of the allowed values")
-                        .build())
-                    .build());
+                        .message(String.format("Example collapsible value '%s' is not in allowed values %s",
+                                collapsibleAttr, config.getAllowed()))
+                        .severity(resolveSeverity(config.getSeverity(), block.getSeverity()))
+                        .location(context.createLocation(node)).ruleId(COLLAPSIBLE_ALLOWED)
+                        .addSuggestion(Suggestion.builder().description("Use a valid collapsible value")
+                                .fixedValue(
+                                        config.getAllowed().contains(true) ? "[%collapsible]" : "[%collapsible=false]")
+                                .addExample("[%collapsible] for collapsible")
+                                .addExample("[%collapsible%open] for initially open")
+                                .addExample("Remove attribute for non-collapsible")
+                                .explanation("Collapsible attribute must be one of the allowed values").build())
+                        .build());
             }
         }
-        
+
         return messages;
     }
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidator.java
@@ -22,86 +22,91 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Validator for image blocks in AsciiDoc documents.
- * 
- * <p>This validator validates image blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/image-block.yaml}.
- * The YAML configuration is parsed into {@link ImageBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * This validator validates image blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/image-block.yaml}. The YAML configuration is parsed into {@link ImageBlock}
+ * objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>url</b>: Validates image URL/path (required, pattern matching)</li>
- *   <li><b>width</b>: Validates image width constraints (required, min/max values)</li>
- *   <li><b>height</b>: Validates image height constraints (required, min/max values)</li>
- *   <li><b>alt</b>: Validates alternative text (required, length constraints)</li>
+ * <li><b>url</b>: Validates image URL/path (required, pattern matching)</li>
+ * <li><b>width</b>: Validates image width constraints (required, min/max values)</li>
+ * <li><b>height</b>: Validates image height constraints (required, min/max values)</li>
+ * <li><b>alt</b>: Validates alternative text (required, length constraints)</li>
  * </ul>
- * 
- * <p>Note: Image block nested configurations do not support individual severity levels.
- * All validations use the block-level severity.</p>
- * 
+ *
+ * <p>
+ * Note: Image block nested configurations do not support individual severity levels. All validations use the
+ * block-level severity.
+ * </p>
+ *
  * @see ImageBlock
  * @see BlockTypeValidator
  */
 public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock> {
-    private static final Logger logger = LogManager.getLogger(ImageBlockValidator.class);    
+    private static final Logger logger = LogManager.getLogger(ImageBlockValidator.class);
+
     @Override
     public BlockType getSupportedType() {
         return BlockType.IMAGE;
     }
-    
+
     @Override
     protected Class<ImageBlock> getBlockConfigClass() {
         return ImageBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               ImageBlock imageConfig,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, ImageBlock imageConfig,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Get image attributes
         String imageUrl = getImageUrl(block);
         String altText = getAltText(block);
-        
+
         // Validate URL
         if (imageConfig.getUrl() != null) {
             validateUrl(imageUrl, imageConfig.getUrl(), context, block, messages, imageConfig);
         }
-        
+
         // Validate width
         if (imageConfig.getWidth() != null) {
             validateDimension(block, WIDTH, imageConfig.getWidth(), context, messages, imageConfig);
         }
-        
+
         // Validate height
         if (imageConfig.getHeight() != null) {
             validateDimension(block, HEIGHT, imageConfig.getHeight(), context, messages, imageConfig);
         }
-        
+
         // Validate alt text
         if (imageConfig.getAlt() != null) {
             validateAltText(altText, imageConfig.getAlt(), context, block, messages, imageConfig);
         }
-        
+
         return messages;
     }
-    
+
     private String getImageUrl(StructuralNode block) {
         // Try different ways to get image URL
         Object target = block.getAttribute(TARGET);
         if (target != null) {
             return target.toString();
         }
-        
+
         // For image blocks, the content might contain the path
         if (block.getContent() != null) {
             return block.getContent().toString();
         }
-        
+
         return null;
     }
-    
+
     private String getAltText(StructuralNode block) {
         Object alt = block.getAttribute(ALT);
         if (alt != null) {
@@ -112,11 +117,10 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
             if (target != null) {
                 String targetStr = target.toString();
                 // Remove file extension and convert to expected alt text format
-                String generatedAlt = targetStr
-                    .replaceFirst("\\.[^.]+$", "")  // Remove extension
-                    .replace("-", " ")              // Replace hyphens with spaces
-                    .replace("_", " ");             // Replace underscores with spaces
-                
+                String generatedAlt = targetStr.replaceFirst("\\.[^.]+$", "") // Remove extension
+                        .replace("-", " ") // Replace hyphens with spaces
+                        .replace("_", " "); // Replace underscores with spaces
+
                 if (altStr.equals(generatedAlt)) {
                     // Alt text was auto-generated from filename - treat as missing
                     logger.debug("Detected auto-generated alt text '{}' from target '{}'", altStr, targetStr);
@@ -127,152 +131,110 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
         }
         return null;
     }
-    
-    private void validateUrl(String url, ImageBlock.UrlConfig urlConfig,
-                           BlockValidationContext context,
-                           StructuralNode block,
-                           List<ValidationMessage> messages,
-                           ImageBlock imageConfig) {
-        
+
+    private void validateUrl(String url, ImageBlock.UrlConfig urlConfig, BlockValidationContext context,
+            StructuralNode block, List<ValidationMessage> messages, ImageBlock imageConfig) {
+
         SourcePosition pos = findSourcePosition(block, context, url);
-        
+
         // Check if URL is required
         if (urlConfig.isRequired() && (url == null || url.trim().isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(imageConfig.getSeverity())
-                .ruleId(URL_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Image must have a URL")
-                .actualValue("No URL")
-                .expectedValue("URL required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("filename.png")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add an image path or URL")
-                    .addExample("image::images/diagram.png[]")
-                    .addExample("image::https://example.com/logo.png[]")
-                    .addExample("image::{imagesdir}/screenshot.jpg[]")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity()).ruleId(URL_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Image must have a URL").actualValue("No URL").expectedValue("URL required")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("filename.png")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add an image path or URL")
+                            .addExample("image::images/diagram.png[]")
+                            .addExample("image::https://example.com/logo.png[]")
+                            .addExample("image::{imagesdir}/screenshot.jpg[]").build())
+                    .build());
             return;
         }
-        
+
         if (url != null && !url.trim().isEmpty() && urlConfig.getPattern() != null) {
             // Validate URL pattern
             if (!urlConfig.getPattern().matcher(url).matches()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(imageConfig.getSeverity())
-                    .ruleId(URL_PATTERN)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Image URL does not match required pattern")
-                    .actualValue(url)
-                    .expectedValue("Pattern: " + urlConfig.getPattern().pattern())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use a path matching the required pattern")
-                        .addExample("Common image formats: .png, .jpg, .jpeg, .svg, .gif")
-                        .addExample("Relative path: images/filename.png")
-                        .addExample("Absolute URL: https://example.com/image.png")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity()).ruleId(URL_PATTERN)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Image URL does not match required pattern").actualValue(url)
+                        .expectedValue("Pattern: " + urlConfig.getPattern().pattern())
+                        .addSuggestion(Suggestion.builder().description("Use a path matching the required pattern")
+                                .addExample("Common image formats: .png, .jpg, .jpeg, .svg, .gif")
+                                .addExample("Relative path: images/filename.png")
+                                .addExample("Absolute URL: https://example.com/image.png").build())
+                        .build());
             }
         }
     }
-    
-    private void validateDimension(StructuralNode block, String dimensionName,
-                                 ImageBlock.DimensionConfig dimConfig,
-                                 BlockValidationContext context,
-                                 List<ValidationMessage> messages,
-                                 ImageBlock imageConfig) {
-        
+
+    private void validateDimension(StructuralNode block, String dimensionName, ImageBlock.DimensionConfig dimConfig,
+            BlockValidationContext context, List<ValidationMessage> messages, ImageBlock imageConfig) {
+
         Object value = block.getAttribute(dimensionName);
         String valueStr = value != null ? value.toString() : null;
         SourcePosition pos = findSourcePosition(block, context, dimensionName, valueStr);
-        
+
         if (dimConfig.isRequired() && (valueStr == null || valueStr.trim().isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(imageConfig.getSeverity())
-                .ruleId(dimensionName.equals(WIDTH) ? WIDTH_REQUIRED : HEIGHT_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Image must have " + dimensionName + " specified")
-                .actualValue("No " + dimensionName)
-                .expectedValue(dimensionName + " required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(dimensionName.equals(WIDTH) ? "640" : "480")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST)
-                    .attributeName(dimensionName)
-                    .hasExistingAttributes(true)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description(String.format("Add %s attribute to the image", dimensionName))
-                    .addExample(String.format("image::image.png[%s=640]", dimensionName))
-                    .addExample("Common sizes: 320x240, 640x480, 800x600, 1024x768")
-                    .addExample("Responsive: width=100%, height=auto")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity())
+                    .ruleId(dimensionName.equals(WIDTH) ? WIDTH_REQUIRED : HEIGHT_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Image must have " + dimensionName + " specified").actualValue("No " + dimensionName)
+                    .expectedValue(dimensionName + " required").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint(dimensionName.equals(WIDTH) ? "640" : "480")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST)
+                                    .attributeName(dimensionName).hasExistingAttributes(true).build())
+                    .addSuggestion(Suggestion.builder()
+                            .description(String.format("Add %s attribute to the image", dimensionName))
+                            .addExample(String.format("image::image.png[%s=640]", dimensionName))
+                            .addExample("Common sizes: 320x240, 640x480, 800x600, 1024x768")
+                            .addExample("Responsive: width=100%, height=auto").build())
+                    .build());
             return;
         }
-        
+
         if (valueStr != null) {
             Integer numericValue = parseNumericValue(valueStr);
             if (numericValue != null) {
                 // Validate min/max
                 if (dimConfig.getMinValue() != null && numericValue < dimConfig.getMinValue()) {
-                    messages.add(ValidationMessage.builder()
-                        .severity(imageConfig.getSeverity())
-                        .ruleId(dimensionName.equals(WIDTH) ? WIDTH_MIN : HEIGHT_MIN)
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .message("Image " + dimensionName + " is too small")
-                        .actualValue(numericValue + "px")
-                        .expectedValue("At least " + dimConfig.getMinValue() + "px")
-                        .addSuggestion(Suggestion.builder()
-                            .description(String.format("Increase %s to meet minimum requirement", dimensionName))
-                            .fixedValue(String.valueOf(dimConfig.getMinValue()))
-                            .addExample(String.format("%s=%d", dimensionName, dimConfig.getMinValue()))
-                            .build())
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity())
+                            .ruleId(dimensionName.equals(WIDTH) ? WIDTH_MIN : HEIGHT_MIN)
+                            .location(
+                                    SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                            .message("Image " + dimensionName + " is too small").actualValue(numericValue + "px")
+                            .expectedValue("At least " + dimConfig.getMinValue() + "px")
+                            .addSuggestion(Suggestion.builder()
+                                    .description(
+                                            String.format("Increase %s to meet minimum requirement", dimensionName))
+                                    .fixedValue(String.valueOf(dimConfig.getMinValue()))
+                                    .addExample(String.format("%s=%d", dimensionName, dimConfig.getMinValue())).build())
+                            .build());
                 }
-                
+
                 if (dimConfig.getMaxValue() != null && numericValue > dimConfig.getMaxValue()) {
-                    messages.add(ValidationMessage.builder()
-                        .severity(imageConfig.getSeverity())
-                        .ruleId(dimensionName.equals(WIDTH) ? WIDTH_MAX : HEIGHT_MAX)
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .message("Image " + dimensionName + " is too large")
-                        .actualValue(numericValue + "px")
-                        .expectedValue("At most " + dimConfig.getMaxValue() + "px")
-                        .addSuggestion(Suggestion.builder()
-                            .description(String.format("Reduce %s to meet maximum limit", dimensionName))
-                            .fixedValue(String.valueOf(dimConfig.getMaxValue()))
-                            .addExample(String.format("%s=%d", dimensionName, dimConfig.getMaxValue()))
-                            .build())
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity())
+                            .ruleId(dimensionName.equals(WIDTH) ? WIDTH_MAX : HEIGHT_MAX)
+                            .location(
+                                    SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                            .message("Image " + dimensionName + " is too large").actualValue(numericValue + "px")
+                            .expectedValue("At most " + dimConfig.getMaxValue() + "px")
+                            .addSuggestion(Suggestion.builder()
+                                    .description(String.format("Reduce %s to meet maximum limit", dimensionName))
+                                    .fixedValue(String.valueOf(dimConfig.getMaxValue()))
+                                    .addExample(String.format("%s=%d", dimensionName, dimConfig.getMaxValue())).build())
+                            .build());
                 }
             }
         }
     }
-    
+
     private Integer parseNumericValue(String value) {
-        if (value == null) return null;
-        
+        if (value == null)
+            return null;
+
         // Remove units (px, %, etc) and parse
         String numeric = value.replaceAll("[^0-9]", "");
         if (!numeric.isEmpty()) {
@@ -284,101 +246,75 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
         }
         return null;
     }
-    
-    private void validateAltText(String altText, ImageBlock.AltTextConfig altConfig,
-                               BlockValidationContext context,
-                               StructuralNode block,
-                               List<ValidationMessage> messages,
-                               ImageBlock imageConfig) {
-        
+
+    private void validateAltText(String altText, ImageBlock.AltTextConfig altConfig, BlockValidationContext context,
+            StructuralNode block, List<ValidationMessage> messages, ImageBlock imageConfig) {
+
         SourcePosition pos = findAltTextPosition(block, context, altText);
-        
+
         if (altConfig.isRequired() && (altText == null || altText.trim().isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(imageConfig.getSeverity())
-                .ruleId(ALT_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Image must have alt text")
-                .actualValue("No alt text")
-                .expectedValue("Alt text required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("Description of image")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add descriptive alt text for accessibility")
-                    .addExample("image::diagram.png[Architecture diagram showing system components]")
-                    .addExample("image::logo.png[Company logo]")
-                    .explanation("Alt text improves accessibility for screen readers and SEO")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity()).ruleId(ALT_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Image must have alt text").actualValue("No alt text").expectedValue("Alt text required")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("Description of image")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add descriptive alt text for accessibility")
+                            .addExample("image::diagram.png[Architecture diagram showing system components]")
+                            .addExample("image::logo.png[Company logo]")
+                            .explanation("Alt text improves accessibility for screen readers and SEO").build())
+                    .build());
             return;
         }
-        
+
         if (altText != null && !altText.trim().isEmpty()) {
             // Validate min length
             if (altConfig.getMinLength() != null && altText.length() < altConfig.getMinLength()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(imageConfig.getSeverity())
-                    .ruleId(ALT_MIN_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Image alt text is too short")
-                    .actualValue(altText.length() + " characters")
-                    .expectedValue("At least " + altConfig.getMinLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Provide more descriptive alt text")
-                        .addExample("Instead of 'logo', use 'Company XYZ corporate logo'")
-                        .addExample("Instead of 'diagram', use 'System architecture diagram showing microservices'")
-                        .explanation("Descriptive alt text improves accessibility and understanding")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity()).ruleId(ALT_MIN_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Image alt text is too short").actualValue(altText.length() + " characters")
+                        .expectedValue("At least " + altConfig.getMinLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Provide more descriptive alt text")
+                                .addExample("Instead of 'logo', use 'Company XYZ corporate logo'")
+                                .addExample(
+                                        "Instead of 'diagram', use 'System architecture diagram showing microservices'")
+                                .explanation("Descriptive alt text improves accessibility and understanding").build())
+                        .build());
             }
-            
+
             // Validate max length
             if (altConfig.getMaxLength() != null && altText.length() > altConfig.getMaxLength()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(imageConfig.getSeverity())
-                    .ruleId(ALT_MAX_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Image alt text is too long")
-                    .actualValue(altText.length() + " characters")
-                    .expectedValue("At most " + altConfig.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten the alt text while keeping it descriptive")
-                        .addExample(String.format("Keep alt text under %d characters", altConfig.getMaxLength()))
-                        .explanation("Concise alt text is easier to process for screen readers")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(imageConfig.getSeverity()).ruleId(ALT_MAX_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Image alt text is too long").actualValue(altText.length() + " characters")
+                        .expectedValue("At most " + altConfig.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder()
+                                .description("Shorten the alt text while keeping it descriptive")
+                                .addExample(
+                                        String.format("Keep alt text under %d characters", altConfig.getMaxLength()))
+                                .explanation("Concise alt text is easier to process for screen readers").build())
+                        .build());
             }
         }
     }
-    
+
     /**
      * Finds the column position of alt text in image macro.
      */
     private SourcePosition findAltTextPosition(StructuralNode block, BlockValidationContext context, String altText) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for image:: macro pattern
         int imageStart = sourceLine.indexOf("image::");
         if (imageStart >= 0) {
@@ -406,27 +342,27 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
-    
+
     /**
      * Finds the column position of URL in image macro.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context, String url) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for image:: macro pattern
         int imageStart = sourceLine.indexOf("image::");
         if (imageStart >= 0) {
@@ -434,7 +370,7 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
             if (urlEnd == -1) {
                 urlEnd = sourceLine.length();
             }
-            
+
             if (url != null && !url.isEmpty()) {
                 // Find the specific URL position
                 int urlStart = sourceLine.indexOf(url, imageStart + 7);
@@ -446,35 +382,35 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
                 return new SourcePosition(imageStart + 8, imageStart + 8, lineNum);
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
-    
+
     /**
      * Finds the column position of a dimension attribute (width/height) in image macro.
      */
-    private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context, 
-                                                   String dimensionName, String value) {
+    private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context,
+            String dimensionName, String value) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for the dimension attribute pattern
         String pattern = dimensionName + "=";
         int attrStart = sourceLine.indexOf(pattern);
-        
+
         if (attrStart >= 0) {
             int valueStart = attrStart + pattern.length();
-            
+
             if (value != null && !value.isEmpty()) {
                 // Find where the value ends
                 int valueEnd = valueStart + value.length();
@@ -492,8 +428,8 @@ public final class ImageBlockValidator extends AbstractBlockValidator<ImageBlock
                 return new SourcePosition(bracketEnd + 1, bracketEnd + 1, lineNum);
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/LiteralBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/LiteralBlockValidator.java
@@ -18,16 +18,22 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for literal blocks in AsciiDoc documents.
- * 
- * <p>This validator validates literal blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/literal-block.yaml}.
- * The YAML configuration is parsed into {@link LiteralBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Literal blocks use .... delimiters and display preformatted text without syntax highlighting.
- * They are commonly used for configuration files, console output, or other plain text content.</p>
- * 
- * <p>Example usage in AsciiDoc:</p>
+ *
+ * <p>
+ * This validator validates literal blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/literal-block.yaml}. The YAML configuration is parsed into
+ * {@link LiteralBlock} objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Literal blocks use .... delimiters and display preformatted text without syntax highlighting. They are commonly used
+ * for configuration files, console output, or other plain text content.
+ * </p>
+ *
+ * <p>
+ * Example usage in AsciiDoc:
+ * </p>
+ *
  * <pre>
  * .Example Configuration
  * ....
@@ -37,255 +43,221 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
  *   timeout: 30s
  * ....
  * </pre>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>title</b>: Validates optional title (required, minLength, maxLength)</li>
- *   <li><b>lines</b>: Validates line count (min, max)</li>
- *   <li><b>indentation</b>: Validates indentation consistency and constraints (required, consistent, minSpaces, maxSpaces)</li>
+ * <li><b>title</b>: Validates optional title (required, minLength, maxLength)</li>
+ * <li><b>lines</b>: Validates line count (min, max)</li>
+ * <li><b>indentation</b>: Validates indentation consistency and constraints (required, consistent, minSpaces,
+ * maxSpaces)</li>
  * </ul>
- * 
- * <p>Each nested configuration can optionally define its own severity level.
- * If not specified, the block-level severity is used as fallback.</p>
- * 
+ *
+ * <p>
+ * Each nested configuration can optionally define its own severity level. If not specified, the block-level severity is
+ * used as fallback.
+ * </p>
+ *
  * @see LiteralBlock
  * @see BlockTypeValidator
  */
 public final class LiteralBlockValidator extends AbstractBlockValidator<LiteralBlock> {
-    
+
     @Override
     public BlockType getSupportedType() {
         return BlockType.LITERAL;
     }
-    
+
     @Override
     protected Class<LiteralBlock> getBlockConfigClass() {
         return LiteralBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               LiteralBlock config,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, LiteralBlock config,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Get literal block attributes and content
         String title = getTitle(block);
         List<String> lines = getContentLines(block);
-        
+
         // Validate title
         if (config.getTitle() != null) {
             validateTitle(title, config.getTitle(), config, context, block, messages);
         }
-        
+
         // Validate lines
         if (config.getLines() != null) {
             validateLines(lines, config.getLines(), config, context, block, messages);
         }
-        
+
         // Validate indentation
         if (config.getIndentation() != null) {
             validateIndentation(lines, config.getIndentation(), config, context, block, messages);
         }
-        
+
         return messages;
     }
-    
+
     private String getTitle(StructuralNode block) {
         Object titleObj = block.getTitle();
         return titleObj != null ? titleObj.toString() : null;
     }
-    
+
     private List<String> getContentLines(StructuralNode block) {
         List<String> lines = new ArrayList<>();
         String content = getBlockContent(block);
-        
+
         if (!content.isEmpty()) {
             String[] contentLines = content.split("\n");
             for (String line : contentLines) {
                 lines.add(line);
             }
         }
-        
+
         return lines;
     }
-    
-    private void validateTitle(String title, LiteralBlock.TitleConfig config,
-                             LiteralBlock blockConfig,
-                             BlockValidationContext context,
-                             StructuralNode block,
-                             List<ValidationMessage> messages) {
-        
+
+    private void validateTitle(String title, LiteralBlock.TitleConfig config, LiteralBlock blockConfig,
+            BlockValidationContext context, StructuralNode block, List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         // Check if title is required
         if (config.isRequired() && (title == null || title.trim().isEmpty())) {
             SourcePosition pos = findTitlePosition(block, context);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TITLE_REQUIRED)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Literal block requires a title")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(".Title")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add title to literal block")
-                    .fixedValue(".Configuration Example")
-                    .addExample(".Sample Output")
-                    .addExample(".Code Listing")
-                    .addExample(".Log Example")
-                    .explanation("Literal blocks should have descriptive titles to explain their content")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_REQUIRED)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Literal block requires a title").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint(".Title")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add title to literal block")
+                            .fixedValue(".Configuration Example").addExample(".Sample Output")
+                            .addExample(".Code Listing").addExample(".Log Example")
+                            .explanation("Literal blocks should have descriptive titles to explain their content")
+                            .build())
+                    .build());
             return;
         }
-        
+
         if (title != null && !title.trim().isEmpty()) {
             String trimmedTitle = title.trim();
-            
+
             // Validate length constraints
-            ValidationMessage lengthMessage = validateLength(trimmedTitle, 
-                                                           config.getMinLength(), 
-                                                           config.getMaxLength(),
-                                                           "title", severity, context, block);
+            ValidationMessage lengthMessage = validateLength(trimmedTitle, config.getMinLength(), config.getMaxLength(),
+                    "title", severity, context, block);
             addIfNotNull(messages, lengthMessage);
         }
     }
-    
-    private void validateLines(List<String> lines, LiteralBlock.LinesConfig config,
-                             LiteralBlock blockConfig,
-                             BlockValidationContext context,
-                             StructuralNode block,
-                             List<ValidationMessage> messages) {
-        
+
+    private void validateLines(List<String> lines, LiteralBlock.LinesConfig config, LiteralBlock blockConfig,
+            BlockValidationContext context, StructuralNode block, List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         int lineCount = lines.size();
-        
+
         // Validate line count constraints
-        ValidationMessage countMessage = validateMinMax(lineCount, 
-                                                      config.getMin(), 
-                                                      config.getMax(),
-                                                      "Line count", severity, context, block);
+        ValidationMessage countMessage = validateMinMax(lineCount, config.getMin(), config.getMax(), "Line count",
+                severity, context, block);
         addIfNotNull(messages, countMessage);
     }
-    
+
     private void validateIndentation(List<String> lines, LiteralBlock.IndentationConfig config,
-                                   LiteralBlock blockConfig,
-                                   BlockValidationContext context,
-                                   StructuralNode block,
-                                   List<ValidationMessage> messages) {
-        
+            LiteralBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         // Skip if indentation checking is not required
         if (!config.isRequired()) {
             return;
         }
-        
+
         Integer firstIndentation = null;
         int lineNumber = 0;
-        
+
         for (String line : lines) {
             lineNumber++;
-            
+
             // Skip empty lines for indentation checking
             if (line.isEmpty() || line.trim().isEmpty()) {
                 continue;
             }
-            
+
             int indentSpaces = countLeadingSpaces(line);
-            
+
             // Check minimum spaces
             if (config.getMinSpaces() != null && indentSpaces < config.getMinSpaces()) {
                 String indentPlaceholder = " ".repeat(config.getMinSpaces());
-                int currentLineNum = block.getSourceLocation() != null ? 
-                    block.getSourceLocation().getLineNumber() + lineNumber : lineNumber;
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(INDENTATION_MIN_SPACES)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .startLine(currentLineNum)
-                        .endLine(currentLineNum)
-                        .startColumn(1)
-                        .endColumn(1)
-                        .build())
-                    .message("Literal block requires minimum indentation of " + config.getMinSpaces() + " spaces")
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .actualValue(indentSpaces + " spaces")
-                    .expectedValue("At least " + config.getMinSpaces() + " spaces")
-                    .missingValueHint(indentPlaceholder)
-                    .placeholderContext(PlaceholderContext.builder()
-                        .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Add proper indentation to literal block content")
-                        .fixedValue(" ".repeat(config.getMinSpaces()))
-                        .addExample("    // 4 spaces indentation")
-                        .addExample("  // 2 spaces indentation")
-                        .addExample("        // 8 spaces indentation")
-                        .explanation("Literal blocks should maintain consistent indentation for readability")
-                        .build())
-                    .build());
+                int currentLineNum = block.getSourceLocation() != null
+                        ? block.getSourceLocation().getLineNumber() + lineNumber
+                        : lineNumber;
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(INDENTATION_MIN_SPACES)
+                        .location(SourceLocation.builder().filename(context.getFilename()).startLine(currentLineNum)
+                                .endLine(currentLineNum).startColumn(1).endColumn(1).build())
+                        .message("Literal block requires minimum indentation of " + config.getMinSpaces() + " spaces")
+                        .errorType(ErrorType.MISSING_VALUE).actualValue(indentSpaces + " spaces")
+                        .expectedValue("At least " + config.getMinSpaces() + " spaces")
+                        .missingValueHint(indentPlaceholder)
+                        .placeholderContext(PlaceholderContext.builder()
+                                .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                        .addSuggestion(Suggestion.builder()
+                                .description("Add proper indentation to literal block content")
+                                .fixedValue(" ".repeat(config.getMinSpaces())).addExample("    // 4 spaces indentation")
+                                .addExample("  // 2 spaces indentation").addExample("        // 8 spaces indentation")
+                                .explanation("Literal blocks should maintain consistent indentation for readability")
+                                .build())
+                        .build());
                 break; // Only report the first line with insufficient indentation
             }
-            
+
             // Check maximum spaces
             if (config.getMaxSpaces() != null && indentSpaces > config.getMaxSpaces()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(INDENTATION_MAX_SPACES)
-                    .location(context.createLocation(block))
-                    .message("Line " + lineNumber + " has excessive indentation")
-                    .actualValue(indentSpaces + " spaces")
-                    .expectedValue("At most " + config.getMaxSpaces() + " spaces")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Reduce indentation to maximum allowed")
-                        .fixedValue(" ".repeat(config.getMaxSpaces()))
-                        .addExample("Remove extra spaces")
-                        .addExample("Use consistent indentation")
-                        .addExample("Align with other lines")
-                        .explanation("Literal block indentation should not exceed the maximum allowed spaces")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(INDENTATION_MAX_SPACES)
+                        .location(context.createLocation(block))
+                        .message("Line " + lineNumber + " has excessive indentation")
+                        .actualValue(indentSpaces + " spaces")
+                        .expectedValue("At most " + config.getMaxSpaces() + " spaces")
+                        .addSuggestion(Suggestion.builder().description("Reduce indentation to maximum allowed")
+                                .fixedValue(" ".repeat(config.getMaxSpaces())).addExample("Remove extra spaces")
+                                .addExample("Use consistent indentation").addExample("Align with other lines")
+                                .explanation("Literal block indentation should not exceed the maximum allowed spaces")
+                                .build())
+                        .build());
             }
-            
+
             // Check consistency
             if (config.isConsistent()) {
                 if (firstIndentation == null) {
                     firstIndentation = indentSpaces;
                 } else if (indentSpaces != firstIndentation) {
-                    messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(INDENTATION_CONSISTENT)
-                        .location(context.createLocation(block))
-                        .message("Line " + lineNumber + " has inconsistent indentation")
-                        .actualValue(indentSpaces + " spaces")
-                        .expectedValue(firstIndentation + " spaces (consistent with first non-empty line)")
-                        .addSuggestion(Suggestion.builder()
-                            .description("Make indentation consistent across all lines")
-                            .fixedValue(" ".repeat(firstIndentation))
-                            .addExample("Align with first line indentation")
-                            .addExample("Use same number of spaces as other lines")
-                            .addExample("Check for mixed tabs and spaces")
-                            .explanation("Literal blocks should have consistent indentation throughout")
-                            .build())
-                        .build());
+                    messages.add(
+                            ValidationMessage.builder().severity(severity).ruleId(INDENTATION_CONSISTENT)
+                                    .location(context.createLocation(block))
+                                    .message("Line " + lineNumber + " has inconsistent indentation")
+                                    .actualValue(indentSpaces + " spaces")
+                                    .expectedValue(firstIndentation + " spaces (consistent with first non-empty line)")
+                                    .addSuggestion(Suggestion.builder()
+                                            .description("Make indentation consistent across all lines")
+                                            .fixedValue(" ".repeat(firstIndentation))
+                                            .addExample("Align with first line indentation")
+                                            .addExample("Use same number of spaces as other lines")
+                                            .addExample("Check for mixed tabs and spaces")
+                                            .explanation("Literal blocks should have consistent indentation throughout")
+                                            .build())
+                                    .build());
                 }
             }
         }
     }
-    
+
     private int countLeadingSpaces(String line) {
         int count = 0;
         for (char c : line.toCharArray()) {
@@ -300,7 +272,7 @@ public final class LiteralBlockValidator extends AbstractBlockValidator<LiteralB
         }
         return count;
     }
-    
+
     /**
      * Finds the position where title should be inserted.
      */
@@ -308,7 +280,7 @@ public final class LiteralBlockValidator extends AbstractBlockValidator<LiteralB
         if (block.getSourceLocation() == null) {
             return new SourcePosition(1, 1, 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         return new SourcePosition(1, 1, lineNum);
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidator.java
@@ -20,70 +20,74 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for paragraph blocks in AsciiDoc documents.
- * 
- * <p>This validator validates paragraph blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/paragraph-block.yaml}.
- * The YAML configuration is parsed into {@link ParagraphBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * This validator validates paragraph blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/paragraph-block.yaml}. The YAML configuration is parsed into
+ * {@link ParagraphBlock} objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>lines</b>: Validates line count constraints (min/max number of lines)</li>
- *   <li><b>sentence</b>: Validates sentence-level constraints:
- *     <ul>
- *       <li><b>occurrence</b>: Min/max number of sentences per paragraph</li>
- *       <li><b>words</b>: Min/max number of words per sentence</li>
- *     </ul>
- *   </li>
+ * <li><b>lines</b>: Validates line count constraints (min/max number of lines)</li>
+ * <li><b>sentence</b>: Validates sentence-level constraints:
+ * <ul>
+ * <li><b>occurrence</b>: Min/max number of sentences per paragraph</li>
+ * <li><b>words</b>: Min/max number of words per sentence</li>
  * </ul>
- * 
- * <p>The lines and sentence configurations can optionally define their own severity levels.
- * If not specified, the block-level severity is used as fallback.</p>
- * 
+ * </li>
+ * </ul>
+ *
+ * <p>
+ * The lines and sentence configurations can optionally define their own severity levels. If not specified, the
+ * block-level severity is used as fallback.
+ * </p>
+ *
  * @see ParagraphBlock
  * @see BlockTypeValidator
  */
-public final class ParagraphBlockValidator extends AbstractBlockValidator<ParagraphBlock> {    
+public final class ParagraphBlockValidator extends AbstractBlockValidator<ParagraphBlock> {
     @Override
     public BlockType getSupportedType() {
         return BlockType.PARAGRAPH;
     }
-    
+
     @Override
     protected Class<ParagraphBlock> getBlockConfigClass() {
         return ParagraphBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               ParagraphBlock paragraphConfig,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, ParagraphBlock paragraphConfig,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Get paragraph content
         String content = getBlockContent(block);
-        
+
         // Validate line count if configured
         if (paragraphConfig.getLines() != null) {
             int lineCount = countLinesNonEmpty(content);
             validateLineCount(lineCount, paragraphConfig.getLines(), paragraphConfig, context, block, messages);
         }
-        
+
         // Validate sentence count and structure if configured
         if (paragraphConfig.getSentence() != null) {
             validateSentences(content, paragraphConfig.getSentence(), paragraphConfig, context, block, messages);
         }
-        
+
         return messages;
     }
-    
+
     // getBlockContent is now inherited from AbstractBlockValidator
-    
+
     private int countLinesNonEmpty(String content) {
         if (content == null || content.isEmpty()) {
             return 0;
         }
-        
+
         // Split by newlines and count non-empty lines
         String[] lines = content.split("\n");
         int count = 0;
@@ -92,272 +96,207 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
                 count++;
             }
         }
-        
+
         return count;
     }
-    
-    private void validateLineCount(int actualLines, 
-                                 com.dataliquid.asciidoc.linter.config.rule.LineConfig lineConfig,
-                                 ParagraphBlock blockConfig,
-                                 BlockValidationContext context,
-                                 StructuralNode block,
-                                 List<ValidationMessage> messages) {
-        
+
+    private void validateLineCount(int actualLines, com.dataliquid.asciidoc.linter.config.rule.LineConfig lineConfig,
+            ParagraphBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(lineConfig.severity(), blockConfig.getSeverity());
-        
+
         if (lineConfig.min() != null && actualLines < lineConfig.min()) {
             SourcePosition pos = findSourcePosition(block, context, actualLines);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(LINES_MIN)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Paragraph has too few lines")
-                .actualValue(String.valueOf(actualLines))
-                .expectedValue("At least " + lineConfig.min() + " lines")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("Add more content here...")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add more lines to paragraph")
-                    .addExample("This is the first line of content.")
-                    .addExample("This is additional content on a new line.")
-                    .addExample("Add more descriptive text here.")
-                    .explanation("Paragraph needs at least " + lineConfig.min() + " lines")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(LINES_MIN)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Paragraph has too few lines").actualValue(String.valueOf(actualLines))
+                    .expectedValue("At least " + lineConfig.min() + " lines").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("Add more content here...")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add more lines to paragraph")
+                            .addExample("This is the first line of content.")
+                            .addExample("This is additional content on a new line.")
+                            .addExample("Add more descriptive text here.")
+                            .explanation("Paragraph needs at least " + lineConfig.min() + " lines").build())
+                    .build());
         }
-        
+
         if (lineConfig.max() != null && actualLines > lineConfig.max()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(LINES_MAX)
-                .location(context.createLocation(block))
-                .message("Paragraph has too many lines")
-                .actualValue(String.valueOf(actualLines))
-                .expectedValue("At most " + lineConfig.max() + " lines")
-                .addSuggestion(Suggestion.builder()
-                    .description("Split paragraph into smaller parts")
-                    .addExample("Break into multiple paragraphs")
-                    .addExample("Use bullet points for lists")
-                    .addExample("Remove unnecessary details")
-                    .explanation("Consider splitting content to stay under " + lineConfig.max() + " lines")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(LINES_MAX)
+                    .location(context.createLocation(block)).message("Paragraph has too many lines")
+                    .actualValue(String.valueOf(actualLines)).expectedValue("At most " + lineConfig.max() + " lines")
+                    .addSuggestion(Suggestion.builder().description("Split paragraph into smaller parts")
+                            .addExample("Break into multiple paragraphs").addExample("Use bullet points for lists")
+                            .addExample("Remove unnecessary details")
+                            .explanation("Consider splitting content to stay under " + lineConfig.max() + " lines")
+                            .build())
+                    .build());
         }
     }
-    
-    private void validateSentences(String content,
-                                  ParagraphBlock.SentenceConfig sentenceConfig,
-                                  ParagraphBlock blockConfig,
-                                  BlockValidationContext context,
-                                  StructuralNode block,
-                                  List<ValidationMessage> messages) {
-        
+
+    private void validateSentences(String content, ParagraphBlock.SentenceConfig sentenceConfig,
+            ParagraphBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         if (content == null || content.isEmpty()) {
             // If content is empty and sentences are required, check occurrence min
-            if (sentenceConfig.getOccurrence() != null && 
-                sentenceConfig.getOccurrence().min() > 0) {
-                Severity severity = resolveSeverity(sentenceConfig.getOccurrence().severity(), blockConfig.getSeverity());
-                    
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(SENTENCE_OCCURRENCE_MIN)
-                    .location(context.createLocation(block))
-                    .message("Paragraph has too few sentences")
-                    .actualValue("0")
-                    .expectedValue("At least " + sentenceConfig.getOccurrence().min() + " sentences")
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint("Add sentence content.")
-                    .placeholderContext(PlaceholderContext.builder()
-                        .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Add sentences to paragraph")
-                        .addExample("This is the first sentence.")
-                        .addExample("This is the second sentence with more detail.")
-                        .addExample("This concludes the paragraph.")
-                        .explanation("Paragraph needs at least " + sentenceConfig.getOccurrence().min() + " sentences")
-                        .build())
-                    .build());
+            if (sentenceConfig.getOccurrence() != null && sentenceConfig.getOccurrence().min() > 0) {
+                Severity severity = resolveSeverity(sentenceConfig.getOccurrence().severity(),
+                        blockConfig.getSeverity());
+
+                messages.add(
+                        ValidationMessage.builder().severity(severity).ruleId(SENTENCE_OCCURRENCE_MIN)
+                                .location(context.createLocation(block)).message("Paragraph has too few sentences")
+                                .actualValue("0")
+                                .expectedValue("At least " + sentenceConfig.getOccurrence().min() + " sentences")
+                                .errorType(ErrorType.MISSING_VALUE).missingValueHint("Add sentence content.")
+                                .placeholderContext(PlaceholderContext.builder()
+                                        .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                                .addSuggestion(
+                                        Suggestion.builder().description("Add sentences to paragraph")
+                                                .addExample("This is the first sentence.")
+                                                .addExample("This is the second sentence with more detail.")
+                                                .addExample("This concludes the paragraph.")
+                                                .explanation("Paragraph needs at least "
+                                                        + sentenceConfig.getOccurrence().min() + " sentences")
+                                                .build())
+                                .build());
             }
             return;
         }
-        
+
         // Split content into sentences
         List<String> sentences = splitIntoSentences(content);
-        
+
         // Validate sentence occurrence
         if (sentenceConfig.getOccurrence() != null) {
-            validateSentenceOccurrence(sentences.size(), sentenceConfig.getOccurrence(), 
-                                     blockConfig, context, block, messages);
+            validateSentenceOccurrence(sentences.size(), sentenceConfig.getOccurrence(), blockConfig, context, block,
+                    messages);
         }
-        
+
         // Validate words per sentence
         if (sentenceConfig.getWords() != null) {
-            validateWordsPerSentence(sentences, sentenceConfig.getWords(), 
-                                   blockConfig, context, block, messages);
+            validateWordsPerSentence(sentences, sentenceConfig.getWords(), blockConfig, context, block, messages);
         }
     }
-    
+
     private List<String> splitIntoSentences(String content) {
         List<String> sentences = new ArrayList<>();
-        
+
         // First, replace newlines with spaces to handle multi-line sentences
         String normalizedContent = content.replaceAll("\\n+", " ").trim();
-        
+
         // Simple approach: split by sentence-ending punctuation
         // This is a simplified version that works for most cases
         String[] parts = normalizedContent.split("(?<=[.!?])\\s+");
-        
+
         for (String part : parts) {
             String trimmed = part.trim();
             if (!trimmed.isEmpty()) {
                 sentences.add(trimmed);
             }
         }
-        
+
         // If no sentences found but content exists, treat the whole content as one sentence
         if (sentences.isEmpty() && !normalizedContent.trim().isEmpty()) {
             sentences.add(normalizedContent.trim());
         }
-        
+
         return sentences;
     }
-    
-    private void validateSentenceOccurrence(int sentenceCount,
-                                          OccurrenceConfig occurrenceConfig,
-                                          ParagraphBlock blockConfig,
-                                          BlockValidationContext context,
-                                          StructuralNode block,
-                                          List<ValidationMessage> messages) {
-        
+
+    private void validateSentenceOccurrence(int sentenceCount, OccurrenceConfig occurrenceConfig,
+            ParagraphBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         Severity severity = resolveSeverity(occurrenceConfig.severity(), blockConfig.getSeverity());
-        
+
         if (sentenceCount < occurrenceConfig.min()) {
             SourcePosition pos = findSourcePositionAtEndOfContent(block, context);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(SENTENCE_OCCURRENCE_MIN)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Paragraph has too few sentences")
-                .actualValue(String.valueOf(sentenceCount))
-                .expectedValue("At least " + occurrenceConfig.min() + " sentences")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("Add more sentences.")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add more sentences")
-                    .addExample("Expand with additional details.")
-                    .addExample("Provide supporting information.")
-                    .addExample("Include relevant examples.")
-                    .explanation("Need " + (occurrenceConfig.min() - sentenceCount) + " more sentences")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(SENTENCE_OCCURRENCE_MIN)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Paragraph has too few sentences").actualValue(String.valueOf(sentenceCount))
+                    .expectedValue("At least " + occurrenceConfig.min() + " sentences")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("Add more sentences.")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add more sentences")
+                            .addExample("Expand with additional details.").addExample("Provide supporting information.")
+                            .addExample("Include relevant examples.")
+                            .explanation("Need " + (occurrenceConfig.min() - sentenceCount) + " more sentences")
+                            .build())
+                    .build());
         }
-        
+
         if (sentenceCount > occurrenceConfig.max()) {
             SourceLocation location = createParagraphLocation(block, context);
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(SENTENCE_OCCURRENCE_MAX)
-                .location(location)
-                .message("Paragraph has too many sentences")
-                .actualValue(String.valueOf(sentenceCount))
-                .expectedValue("At most " + occurrenceConfig.max() + " sentences")
-                .addSuggestion(Suggestion.builder()
-                    .description("Reduce sentence count")
-                    .addExample("Split into multiple paragraphs")
-                    .addExample("Combine related sentences")
-                    .addExample("Remove redundant information")
-                    .explanation("Remove " + (sentenceCount - occurrenceConfig.max()) + " sentences")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(SENTENCE_OCCURRENCE_MAX)
+                    .location(location).message("Paragraph has too many sentences")
+                    .actualValue(String.valueOf(sentenceCount))
+                    .expectedValue("At most " + occurrenceConfig.max() + " sentences")
+                    .addSuggestion(Suggestion.builder().description("Reduce sentence count")
+                            .addExample("Split into multiple paragraphs").addExample("Combine related sentences")
+                            .addExample("Remove redundant information")
+                            .explanation("Remove " + (sentenceCount - occurrenceConfig.max()) + " sentences").build())
+                    .build());
         }
     }
-    
-    private void validateWordsPerSentence(List<String> sentences,
-                                        ParagraphBlock.WordsConfig wordsConfig,
-                                        ParagraphBlock blockConfig,
-                                        BlockValidationContext context,
-                                        StructuralNode block,
-                                        List<ValidationMessage> messages) {
-        
+
+    private void validateWordsPerSentence(List<String> sentences, ParagraphBlock.WordsConfig wordsConfig,
+            ParagraphBlock blockConfig, BlockValidationContext context, StructuralNode block,
+            List<ValidationMessage> messages) {
+
         Severity severity = resolveSeverity(wordsConfig.getSeverity(), blockConfig.getSeverity());
         String fullContent = getBlockContent(block);
-        
+
         for (int i = 0; i < sentences.size(); i++) {
             String sentence = sentences.get(i);
             int wordCount = countWords(sentence);
-            
+
             if (wordsConfig.getMin() != null && wordCount < wordsConfig.getMin()) {
                 SourcePosition pos = findSentenceEndPosition(block, context, sentence, i);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(SENTENCE_WORDS_MIN)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Sentence " + (i + 1) + " has too few words")
-                    .actualValue(wordCount + " words")
-                    .expectedValue("At least " + wordsConfig.getMin() + " words")
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint("add more words")
-                    .placeholderContext(PlaceholderContext.builder()
-                        .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Expand sentence with more detail")
-                        .addExample("Add descriptive adjectives")
-                        .addExample("Include supporting details")
-                        .addExample("Provide specific examples")
-                        .explanation("Sentence needs " + (wordsConfig.getMin() - wordCount) + " more words")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(SENTENCE_WORDS_MIN)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Sentence " + (i + 1) + " has too few words").actualValue(wordCount + " words")
+                        .expectedValue("At least " + wordsConfig.getMin() + " words").errorType(ErrorType.MISSING_VALUE)
+                        .missingValueHint("add more words")
+                        .placeholderContext(PlaceholderContext.builder()
+                                .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                        .addSuggestion(Suggestion.builder().description("Expand sentence with more detail")
+                                .addExample("Add descriptive adjectives").addExample("Include supporting details")
+                                .addExample("Provide specific examples")
+                                .explanation("Sentence needs " + (wordsConfig.getMin() - wordCount) + " more words")
+                                .build())
+                        .build());
             }
-            
+
             if (wordsConfig.getMax() != null && wordCount > wordsConfig.getMax()) {
                 SourceLocation location = createSentenceLocation(block, context, fullContent, sentence, i);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(SENTENCE_WORDS_MAX)
-                    .location(location)
-                    .message("Sentence " + (i + 1) + " has too many words")
-                    .actualValue(wordCount + " words")
-                    .expectedValue("At most " + wordsConfig.getMax() + " words")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Simplify sentence")
-                        .addExample("Remove unnecessary words")
-                        .addExample("Split into two sentences")
-                        .addExample("Use more concise language")
-                        .explanation("Remove " + (wordCount - wordsConfig.getMax()) + " words")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(SENTENCE_WORDS_MAX)
+                        .location(location).message("Sentence " + (i + 1) + " has too many words")
+                        .actualValue(wordCount + " words").expectedValue("At most " + wordsConfig.getMax() + " words")
+                        .addSuggestion(Suggestion.builder().description("Simplify sentence")
+                                .addExample("Remove unnecessary words").addExample("Split into two sentences")
+                                .addExample("Use more concise language")
+                                .explanation("Remove " + (wordCount - wordsConfig.getMax()) + " words").build())
+                        .build());
             }
         }
     }
-    
+
     private int countWords(String text) {
         if (text == null || text.trim().isEmpty()) {
             return 0;
         }
-        
+
         // Split by whitespace and count non-empty parts
         String[] words = text.trim().split("\\s+");
         return words.length;
     }
-    
+
     /**
      * Creates a source location for the entire paragraph block with proper column positions.
      */
@@ -366,99 +305,92 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
             return context.createLocation(block);
         }
-        
+
         int startLine = block.getSourceLocation().getLineNumber();
         if (startLine <= 0 || startLine > fileLines.size()) {
             return context.createLocation(block);
         }
-        
+
         // Get the paragraph content
         String content = getBlockContent(block);
         if (content == null || content.isEmpty()) {
             return context.createLocation(block);
         }
-        
+
         // For paragraphs, find the actual text position
         String firstLine = fileLines.get(startLine - 1);
-        
+
         // Create location with full line span
-        return SourceLocation.builder()
-            .filename(context.getFilename())
-            .startLine(startLine)
-            .endLine(startLine)
-            .startColumn(1)
-            .endColumn(firstLine.length())
-            .build();
+        return SourceLocation.builder().filename(context.getFilename()).startLine(startLine).endLine(startLine)
+                .startColumn(1).endColumn(firstLine.length()).build();
     }
-    
+
     /**
      * Creates a source location for a specific sentence within a paragraph.
      */
-    private SourceLocation createSentenceLocation(StructuralNode block, BlockValidationContext context, 
-                                                  String fullContent, String sentence, int sentenceIndex) {
+    private SourceLocation createSentenceLocation(StructuralNode block, BlockValidationContext context,
+            String fullContent, String sentence, int sentenceIndex) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
             return context.createLocation(block);
         }
-        
+
         int startLine = block.getSourceLocation().getLineNumber();
         if (startLine <= 0 || startLine > fileLines.size()) {
             return context.createLocation(block);
         }
-        
+
         // For simplicity, if it's a single-line paragraph, highlight the whole line
         // In real scenarios, we could find the exact position of the sentence
         String paragraphLine = fileLines.get(startLine - 1);
-        
+
         // Try to find the sentence in the paragraph
         int sentenceStart = paragraphLine.indexOf(sentence.trim());
         if (sentenceStart == -1) {
             // If not found, return the whole paragraph location
             return createParagraphLocation(block, context);
         }
-        
+
         // Create location for the specific sentence
-        return SourceLocation.builder()
-            .filename(context.getFilename())
-            .startLine(startLine)
-            .endLine(startLine)
-            .startColumn(sentenceStart + 1)  // 1-based indexing
-            .endColumn(sentenceStart + sentence.trim().length())  // Exclusive end position
-            .build();
+        return SourceLocation.builder().filename(context.getFilename()).startLine(startLine).endLine(startLine)
+                .startColumn(sentenceStart + 1) // 1-based indexing
+                .endColumn(sentenceStart + sentence.trim().length()) // Exclusive end position
+                .build();
     }
-    
+
     /**
      * Finds the position before the punctuation mark at the end of a sentence.
      */
-    private SourcePosition findSentenceEndPosition(StructuralNode block, BlockValidationContext context, 
-                                                   String sentence, int sentenceIndex) {
+    private SourcePosition findSentenceEndPosition(StructuralNode block, BlockValidationContext context,
+            String sentence, int sentenceIndex) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int startLine = block.getSourceLocation().getLineNumber();
         if (startLine <= 0 || startLine > fileLines.size()) {
             return new SourcePosition(1, 1, startLine);
         }
-        
+
         // Get the paragraph line
         String paragraphLine = fileLines.get(startLine - 1);
-        
+
         // Find the sentence in the paragraph
         String trimmedSentence = sentence.trim();
         int sentenceStart = paragraphLine.indexOf(trimmedSentence);
-        
+
         if (sentenceStart == -1) {
             // If not found, try to find without the punctuation
             String sentenceWithoutPunctuation = trimmedSentence.replaceAll("[.!?]+$", "");
             sentenceStart = paragraphLine.indexOf(sentenceWithoutPunctuation);
         }
-        
+
         if (sentenceStart != -1) {
             // Find position before punctuation
             int endPos = sentenceStart + trimmedSentence.length();
-            
+
             // Check if there's punctuation at the end
             if (trimmedSentence.matches(".*[.!?]+$")) {
                 // Find where the punctuation starts
@@ -467,7 +399,7 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
                     punctuationStart--;
                 }
                 punctuationStart++; // Move to first punctuation character
-                
+
                 // Position should be before the punctuation
                 endPos = sentenceStart + punctuationStart + 1; // +1 for 1-based column
                 return new SourcePosition(endPos, endPos, startLine);
@@ -477,25 +409,26 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
                 return new SourcePosition(endPos, endPos, startLine);
             }
         }
-        
+
         // Fallback: position at end of line
         return new SourcePosition(paragraphLine.length() + 1, paragraphLine.length() + 1, startLine);
     }
-    
+
     /**
      * Finds the position at the end of the paragraph content for appending.
      */
     private SourcePosition findSourcePositionAtEndOfContent(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int startLine = block.getSourceLocation().getLineNumber();
         if (startLine <= 0 || startLine > fileLines.size()) {
             return new SourcePosition(1, 1, startLine);
         }
-        
+
         // For paragraphs, we want to position at the end of the content
         String content = getBlockContent(block);
         if (content != null && !content.isEmpty()) {
@@ -504,45 +437,46 @@ public final class ParagraphBlockValidator extends AbstractBlockValidator<Paragr
             int endColumn = paragraphLine.length() + 1;
             return new SourcePosition(endColumn, endColumn, startLine);
         }
-        
+
         return new SourcePosition(1, 1, startLine);
     }
-    
+
     /**
      * Finds the position where additional lines should be added.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context, int currentLines) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int startLine = block.getSourceLocation().getLineNumber();
         if (startLine <= 0 || startLine > fileLines.size()) {
             return new SourcePosition(1, 1, startLine);
         }
-        
+
         // For paragraphs, we want to position at the end of the current content
         String content = getBlockContent(block);
         if (content != null && !content.isEmpty()) {
             String[] lines = content.split("\n");
             int lastNonEmptyLine = startLine;
-            
+
             // Find the last line of the paragraph
             for (int i = 0; i < lines.length && startLine + i <= fileLines.size(); i++) {
                 if (!lines[i].trim().isEmpty()) {
                     lastNonEmptyLine = startLine + i;
                 }
             }
-            
+
             // Position at the end of the last line
             if (lastNonEmptyLine > 0 && lastNonEmptyLine <= fileLines.size()) {
                 String lastLine = fileLines.get(lastNonEmptyLine - 1);
                 return new SourcePosition(lastLine.length() + 1, lastLine.length() + 1, lastNonEmptyLine);
             }
         }
-        
+
         return new SourcePosition(1, 1, startLine);
     }
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidator.java
@@ -21,20 +21,26 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for pass (passthrough) blocks in AsciiDoc documents.
- * 
- * <p>This validator validates pass blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/pass-block.yaml}.
- * The YAML configuration is parsed into {@link PassBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Pass blocks use ++++ delimiters and pass content through without processing.
- * This validator uses custom attributes that are not native to AsciiDoc:</p>
+ *
+ * <p>
+ * This validator validates pass blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/pass-block.yaml}. The YAML configuration is parsed into {@link PassBlock}
+ * objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Pass blocks use ++++ delimiters and pass content through without processing. This validator uses custom attributes
+ * that are not native to AsciiDoc:
+ * </p>
  * <ul>
- *   <li><b>pass-type</b>: Custom attribute specifying content type (html, xml, svg)</li>
- *   <li><b>pass-reason</b>: Custom attribute providing reason for using raw passthrough</li>
+ * <li><b>pass-type</b>: Custom attribute specifying content type (html, xml, svg)</li>
+ * <li><b>pass-reason</b>: Custom attribute providing reason for using raw passthrough</li>
  * </ul>
- * 
- * <p>Example usage in AsciiDoc:</p>
+ *
+ * <p>
+ * Example usage in AsciiDoc:
+ * </p>
+ *
  * <pre>
  * [pass,pass-type=html,pass-reason="Custom widget for product gallery"]
  * ++++
@@ -43,312 +49,241 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
  * &lt;/div&gt;
  * ++++
  * </pre>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>type</b>: Validates content type specification (required, allowed values)</li>
- *   <li><b>content</b>: Validates content (required, maxLength, pattern)</li>
- *   <li><b>reason</b>: Validates reason (required, minLength, maxLength)</li>
+ * <li><b>type</b>: Validates content type specification (required, allowed values)</li>
+ * <li><b>content</b>: Validates content (required, maxLength, pattern)</li>
+ * <li><b>reason</b>: Validates reason (required, minLength, maxLength)</li>
  * </ul>
- * 
- * <p>Each nested configuration can optionally define its own severity level.
- * If not specified, the block-level severity is used as fallback.</p>
- * 
+ *
+ * <p>
+ * Each nested configuration can optionally define its own severity level. If not specified, the block-level severity is
+ * used as fallback.
+ * </p>
+ *
  * @see PassBlock
  * @see BlockTypeValidator
  */
-public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> {    
+public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> {
     @Override
     public BlockType getSupportedType() {
         return BlockType.PASS;
     }
-    
+
     @Override
     protected Class<PassBlock> getBlockConfigClass() {
         return PassBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               PassBlock passConfig,
-                                                               BlockValidationContext context) {
-        
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, PassBlock passConfig,
+            BlockValidationContext context) {
+
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Get pass block attributes
         String passType = getAttributeAsString(block, TYPE);
         String passReason = getAttributeAsString(block, REASON);
         String content = getBlockContent(block);
-        
+
         // Validate type
         if (passConfig.getTypeConfig() != null) {
             validateType(passType, passConfig.getTypeConfig(), passConfig, context, block, messages);
         }
-        
+
         // Validate content
         if (passConfig.getContent() != null) {
             validateContent(content, passConfig.getContent(), passConfig, context, block, messages);
         }
-        
+
         // Validate reason
         if (passConfig.getReason() != null) {
             validateReason(passReason, passConfig.getReason(), passConfig, context, block, messages);
         }
-        
+
         return messages;
     }
-    
+
     private String getAttributeAsString(StructuralNode block, String attributeName) {
         Object value = block.getAttribute(attributeName);
         return value != null ? value.toString() : null;
     }
-    
-    
-    private void validateType(String passType, PassBlock.TypeConfig config,
-                            PassBlock blockConfig,
-                            BlockValidationContext context,
-                            StructuralNode block,
-                            List<ValidationMessage> messages) {
-        
+
+    private void validateType(String passType, PassBlock.TypeConfig config, PassBlock blockConfig,
+            BlockValidationContext context, StructuralNode block, List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         // Check if type is required
         if (config.isRequired() && (passType == null || passType.trim().isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TYPE_REQUIRED)
-                .location(context.createLocation(block, 1, 1))
-                .message("Pass block requires a type")
-                .actualValue("No type specified")
-                .expectedValue("Type required (type attribute)")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("[pass,type=html]")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add type attribute to pass block")
-                    .fixedValue("[pass,type=html]")
-                    .addExample("[pass,type=html]")
-                    .addExample("[pass,type=xml]")
-                    .addExample("[pass,type=svg]")
-                    .explanation("Pass blocks should specify the content type for proper processing")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TYPE_REQUIRED)
+                    .location(context.createLocation(block, 1, 1)).message("Pass block requires a type")
+                    .actualValue("No type specified").expectedValue("Type required (type attribute)")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("[pass,type=html]")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add type attribute to pass block")
+                            .fixedValue("[pass,type=html]").addExample("[pass,type=html]").addExample("[pass,type=xml]")
+                            .addExample("[pass,type=svg]")
+                            .explanation("Pass blocks should specify the content type for proper processing").build())
+                    .build());
         }
-        
+
         // Validate allowed types if specified
         if (passType != null && config.getAllowed() != null && !config.getAllowed().isEmpty()) {
             if (!config.getAllowed().contains(passType)) {
                 SourcePosition pos = findPassTypePosition(block, context, passType);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(TYPE_ALLOWED)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Pass block type '" + passType + "' is not allowed")
-                    .actualValue(passType)
-                    .expectedValue("One of: " + String.join(", ", config.getAllowed()))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use a valid pass block type")
-                        .fixedValue("[pass,type=" + config.getAllowed().get(0) + "]")
-                        .addExample("[pass,type=html] for HTML content")
-                        .addExample("[pass,type=xml] for XML content")
-                        .addExample("[pass,type=svg] for SVG graphics")
-                        .explanation("Pass block type must be one of the allowed content types")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(TYPE_ALLOWED)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Pass block type '" + passType + "' is not allowed").actualValue(passType)
+                        .expectedValue("One of: " + String.join(", ", config.getAllowed()))
+                        .addSuggestion(Suggestion.builder().description("Use a valid pass block type")
+                                .fixedValue("[pass,type=" + config.getAllowed().get(0) + "]")
+                                .addExample("[pass,type=html] for HTML content")
+                                .addExample("[pass,type=xml] for XML content")
+                                .addExample("[pass,type=svg] for SVG graphics")
+                                .explanation("Pass block type must be one of the allowed content types").build())
+                        .build());
             }
         }
     }
-    
-    private void validateContent(String content, PassBlock.ContentConfig config,
-                               PassBlock blockConfig,
-                               BlockValidationContext context,
-                               StructuralNode block,
-                               List<ValidationMessage> messages) {
-        
+
+    private void validateContent(String content, PassBlock.ContentConfig config, PassBlock blockConfig,
+            BlockValidationContext context, StructuralNode block, List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         // Check if content is required
         if (config.isRequired() && (content == null || content.trim().isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(CONTENT_REQUIRED)
-                .location(context.createLocation(block, 1, 1))
-                .message("Pass block requires content")
-                .actualValue("No content")
-                .expectedValue("Content required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("Content")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add content to pass block")
-                    .addExample("<div>HTML content</div>")
-                    .addExample("<?xml version=\"1.0\"?>")
-                    .addExample("<svg>SVG content</svg>")
-                    .explanation("Pass blocks must contain the raw content to be passed through")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(CONTENT_REQUIRED)
+                    .location(context.createLocation(block, 1, 1)).message("Pass block requires content")
+                    .actualValue("No content").expectedValue("Content required").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("Content")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add content to pass block")
+                            .addExample("<div>HTML content</div>").addExample("<?xml version=\"1.0\"?>")
+                            .addExample("<svg>SVG content</svg>")
+                            .explanation("Pass blocks must contain the raw content to be passed through").build())
+                    .build());
             return;
         }
-        
+
         // Validate max length
         if (content != null && config.getMaxLength() != null) {
             int contentLength = content.length();
             if (contentLength > config.getMaxLength()) {
                 SourcePosition pos = findSourcePosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(CONTENT_MAX_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Pass block content is too long")
-                    .actualValue(contentLength + " characters")
-                    .expectedValue("Maximum " + config.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten pass block content")
-                        .addExample("Remove non-essential markup")
-                        .addExample("Split into multiple pass blocks")
-                        .addExample("Use external files for large content")
-                        .explanation("Pass block content should not exceed the maximum length limit")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(CONTENT_MAX_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Pass block content is too long").actualValue(contentLength + " characters")
+                        .expectedValue("Maximum " + config.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Shorten pass block content")
+                                .addExample("Remove non-essential markup").addExample("Split into multiple pass blocks")
+                                .addExample("Use external files for large content")
+                                .explanation("Pass block content should not exceed the maximum length limit").build())
+                        .build());
             }
         }
-        
+
         // Validate pattern
         if (content != null && config.getPattern() != null) {
             if (!config.getPattern().matcher(content).matches()) {
                 SourcePosition pos = findSourcePosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(CONTENT_PATTERN)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Pass block content does not match required pattern")
-                    .actualValue("Content does not match pattern")
-                    .expectedValue("Pattern: " + config.getPattern().pattern())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Format pass block content to match pattern")
-                        .addExample("Ensure proper markup syntax")
-                        .addExample("Check for valid HTML/XML structure")
-                        .addExample("Validate content format")
-                        .explanation("Pass block content must follow the specified format pattern")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(CONTENT_PATTERN)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Pass block content does not match required pattern")
+                        .actualValue("Content does not match pattern")
+                        .expectedValue("Pattern: " + config.getPattern().pattern())
+                        .addSuggestion(Suggestion.builder().description("Format pass block content to match pattern")
+                                .addExample("Ensure proper markup syntax")
+                                .addExample("Check for valid HTML/XML structure").addExample("Validate content format")
+                                .explanation("Pass block content must follow the specified format pattern").build())
+                        .build());
             }
         }
     }
-    
-    private void validateReason(String passReason, PassBlock.ReasonConfig config,
-                                     PassBlock blockConfig,
-                                     BlockValidationContext context,
-                                     StructuralNode block,
-                                     List<ValidationMessage> messages) {
-        
+
+    private void validateReason(String passReason, PassBlock.ReasonConfig config, PassBlock blockConfig,
+            BlockValidationContext context, StructuralNode block, List<ValidationMessage> messages) {
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(config.getSeverity(), blockConfig.getSeverity());
-        
+
         // Check if reason is required
         if (config.isRequired() && (passReason == null || passReason.trim().isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(REASON_REQUIRED)
-                .location(context.createLocation(block, 1, 1))
-                .message("Pass block requires a reason")
-                .actualValue("No reason provided")
-                .expectedValue("Reason required (reason attribute)")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("[pass,reason=\"explanation\"]")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add reason for using pass block")
-                    .fixedValue("[pass,reason=\"Custom HTML widget\"]")
-                    .addExample("[pass,reason=\"Custom HTML widget\"]")
-                    .addExample("[pass,reason=\"Third-party integration\"]")
-                    .addExample("[pass,reason=\"Legacy markup support\"]")
-                    .explanation("Pass blocks should explain why raw passthrough is necessary")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(REASON_REQUIRED)
+                    .location(context.createLocation(block, 1, 1)).message("Pass block requires a reason")
+                    .actualValue("No reason provided").expectedValue("Reason required (reason attribute)")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("[pass,reason=\"explanation\"]")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add reason for using pass block")
+                            .fixedValue("[pass,reason=\"Custom HTML widget\"]")
+                            .addExample("[pass,reason=\"Custom HTML widget\"]")
+                            .addExample("[pass,reason=\"Third-party integration\"]")
+                            .addExample("[pass,reason=\"Legacy markup support\"]")
+                            .explanation("Pass blocks should explain why raw passthrough is necessary").build())
+                    .build());
             return;
         }
-        
+
         if (passReason != null) {
             int reasonLength = passReason.length();
-            
+
             // Validate min length
             if (config.getMinLength() != null && reasonLength < config.getMinLength()) {
                 SourcePosition pos = findReasonPosition(block, context, passReason);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(REASON_MIN_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Pass block reason is too short")
-                    .actualValue(reasonLength + " characters")
-                    .expectedValue("At least " + config.getMinLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Provide a more detailed reason")
-                        .addExample("Custom HTML widget for interactive content")
-                        .addExample("Third-party JavaScript integration required")
-                        .addExample("Legacy markup that cannot be converted")
-                        .explanation("Pass block reasons should be detailed enough to meet minimum length requirements")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(REASON_MIN_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Pass block reason is too short").actualValue(reasonLength + " characters")
+                        .expectedValue("At least " + config.getMinLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Provide a more detailed reason")
+                                .addExample("Custom HTML widget for interactive content")
+                                .addExample("Third-party JavaScript integration required")
+                                .addExample("Legacy markup that cannot be converted")
+                                .explanation(
+                                        "Pass block reasons should be detailed enough to meet minimum length requirements")
+                                .build())
+                        .build());
             }
-            
+
             // Validate max length
             if (config.getMaxLength() != null && reasonLength > config.getMaxLength()) {
                 SourcePosition pos = findReasonPosition(block, context, passReason);
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(REASON_MAX_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Pass block reason is too long")
-                    .actualValue(reasonLength + " characters")
-                    .expectedValue("At most " + config.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten the reason description")
-                        .addExample("Custom widget")
-                        .addExample("Third-party integration")
-                        .addExample("Legacy markup")
-                        .explanation("Pass block reasons should be concise and not exceed maximum length limits")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(REASON_MAX_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Pass block reason is too long").actualValue(reasonLength + " characters")
+                        .expectedValue("At most " + config.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Shorten the reason description")
+                                .addExample("Custom widget").addExample("Third-party integration")
+                                .addExample("Legacy markup")
+                                .explanation(
+                                        "Pass block reasons should be concise and not exceed maximum length limits")
+                                .build())
+                        .build());
             }
         }
     }
-    
+
     /**
      * Finds the position of pass block content.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int blockLineNum = block.getSourceLocation().getLineNumber();
         String content = getBlockContent(block);
-        
+
         if (content != null && !content.isEmpty()) {
             // Content is between the ++++ delimiters
             // Find the first line of actual content
@@ -360,22 +295,23 @@ public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> 
                 }
             }
         }
-        
+
         // Default to block line
         return new SourcePosition(1, 1, blockLineNum);
     }
-    
+
     /**
      * Finds the position of type attribute or entire [pass] line.
      */
     private SourcePosition findPassTypePosition(StructuralNode block, BlockValidationContext context, String passType) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int blockLineNum = block.getSourceLocation().getLineNumber();
-        
+
         // [pass] line is typically one or two lines before the block delimiter ++++
         for (int offset = -2; offset <= 0; offset++) {
             int checkLine = blockLineNum + offset;
@@ -408,21 +344,22 @@ public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> 
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, blockLineNum);
     }
-    
+
     /**
      * Finds the position of reason attribute in [pass] line.
      */
     private SourcePosition findReasonPosition(StructuralNode block, BlockValidationContext context, String reason) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int blockLineNum = block.getSourceLocation().getLineNumber();
-        
+
         // [pass] line is typically one or two lines before the block delimiter ++++
         for (int offset = -2; offset <= 0; offset++) {
             int checkLine = blockLineNum + offset;
@@ -457,10 +394,8 @@ public final class PassBlockValidator extends AbstractBlockValidator<PassBlock> 
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, blockLineNum);
     }
-    
-    
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidator.java
@@ -20,388 +20,309 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
- * Validator for quote blocks.
- * Based on the YAML schema structure for validating AsciiDoc quote blocks.
+ * Validator for quote blocks. Based on the YAML schema structure for validating AsciiDoc quote blocks.
  */
-public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock> {    
+public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock> {
     @Override
     public BlockType getSupportedType() {
         return BlockType.QUOTE;
     }
-    
+
     @Override
     protected Class<QuoteBlock> getBlockConfigClass() {
         return QuoteBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode node, 
-                                                               QuoteBlock quoteBlock,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode node, QuoteBlock quoteBlock,
+            BlockValidationContext context) {
         List<ValidationMessage> results = new ArrayList<>();
-        
+
         // Validate attribution
         if (quoteBlock.getAttribution() != null) {
             validateAttribution(node, quoteBlock.getAttribution(), quoteBlock.getSeverity(), results, context);
         }
-        
+
         // Validate citation
         if (quoteBlock.getCitation() != null) {
             validateCitation(node, quoteBlock.getCitation(), quoteBlock.getSeverity(), results, context);
         }
-        
+
         // Validate content
         if (quoteBlock.getContent() != null) {
             validateContent(node, quoteBlock.getContent(), quoteBlock.getSeverity(), results, context);
         }
-        
+
         return results;
     }
-    
-    private void validateAttribution(StructuralNode node, QuoteBlock.AttributionConfig config, 
-                               Severity blockSeverity, List<ValidationMessage> results,
-                               BlockValidationContext context) {
+
+    private void validateAttribution(StructuralNode node, QuoteBlock.AttributionConfig config, Severity blockSeverity,
+            List<ValidationMessage> results, BlockValidationContext context) {
         String attribution = extractAttribution(node);
         Severity severity = resolveSeverity(config.getSeverity(), blockSeverity);
-        
+
         if (config.isRequired() && (attribution == null || attribution.trim().isEmpty())) {
             SourcePosition pos = findSourcePosition(node, context);
-            results.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(ATTRIBUTION_REQUIRED)
-                .message("Quote attribution is required but not provided")
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("attribution")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.LIST_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add quote attribution")
-                    .addExample("[quote, Einstein]")
-                    .addExample("[quote, \"Albert Einstein\", \"Relativity Theory\"]")
-                    .addExample("[quote, Author Name]")
-                    .build())
-                .build());
+            results.add(ValidationMessage.builder().severity(severity).ruleId(ATTRIBUTION_REQUIRED)
+                    .message("Quote attribution is required but not provided")
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("attribution")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.LIST_VALUE).build())
+                    .addSuggestion(
+                            Suggestion.builder().description("Add quote attribution").addExample("[quote, Einstein]")
+                                    .addExample("[quote, \"Albert Einstein\", \"Relativity Theory\"]")
+                                    .addExample("[quote, Author Name]").build())
+                    .build());
             return;
         }
-        
+
         if (attribution != null && !attribution.trim().isEmpty()) {
             // Validate minLength
             if (config.getMinLength() != null && attribution.length() < config.getMinLength()) {
-                results.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(ATTRIBUTION_MIN_LENGTH)
-                    .message(String.format("Quote attribution is too short (minimum %d characters, found %d)",
-                                  config.getMinLength(), attribution.length()))
-                    .location(context.createLocation(node))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use longer attribution")
-                        .addExample("Use full name: Albert Einstein")
-                        .addExample("Include title: Dr. John Smith")
-                        .explanation("Attribution needs at least " + config.getMinLength() + " characters")
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(severity).ruleId(ATTRIBUTION_MIN_LENGTH)
+                        .message(String.format("Quote attribution is too short (minimum %d characters, found %d)",
+                                config.getMinLength(), attribution.length()))
+                        .location(context.createLocation(node))
+                        .addSuggestion(Suggestion.builder().description("Use longer attribution")
+                                .addExample("Use full name: Albert Einstein")
+                                .addExample("Include title: Dr. John Smith")
+                                .explanation("Attribution needs at least " + config.getMinLength() + " characters")
+                                .build())
+                        .build());
             }
-            
+
             // Validate maxLength
             if (config.getMaxLength() != null && attribution.length() > config.getMaxLength()) {
-                results.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(ATTRIBUTION_MAX_LENGTH)
-                    .message(String.format("Quote attribution is too long (maximum %d characters, found %d)",
-                                  config.getMaxLength(), attribution.length()))
-                    .location(context.createLocation(node))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten attribution")
-                        .addExample("Use initials: A. Einstein")
-                        .addExample("Use last name only")
-                        .explanation("Attribution must be at most " + config.getMaxLength() + " characters")
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(severity).ruleId(ATTRIBUTION_MAX_LENGTH)
+                        .message(String.format("Quote attribution is too long (maximum %d characters, found %d)",
+                                config.getMaxLength(), attribution.length()))
+                        .location(context.createLocation(node))
+                        .addSuggestion(Suggestion.builder().description("Shorten attribution")
+                                .addExample("Use initials: A. Einstein").addExample("Use last name only")
+                                .explanation("Attribution must be at most " + config.getMaxLength() + " characters")
+                                .build())
+                        .build());
             }
-            
+
             // Validate pattern
             if (config.getPattern() != null && !config.getPattern().matcher(attribution).matches()) {
                 SourcePosition pos = findSourcePosition(node, context);
-                results.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(ATTRIBUTION_PATTERN)
-                    .message("Quote attribution does not match required pattern")
-                    .actualValue(attribution)
-                    .expectedValue("Pattern: " + config.getPattern().pattern())
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Follow attribution pattern")
-                        .addExample("Match the required format")
-                        .addExample("Example: Last Name, First Name")
-                        .explanation("Attribution must match pattern: " + config.getPattern().pattern())
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(severity).ruleId(ATTRIBUTION_PATTERN)
+                        .message("Quote attribution does not match required pattern").actualValue(attribution)
+                        .expectedValue("Pattern: " + config.getPattern().pattern())
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .addSuggestion(Suggestion.builder().description("Follow attribution pattern")
+                                .addExample("Match the required format").addExample("Example: Last Name, First Name")
+                                .explanation("Attribution must match pattern: " + config.getPattern().pattern())
+                                .build())
+                        .build());
             }
         }
     }
-    
-    private void validateCitation(StructuralNode node, QuoteBlock.CitationConfig config,
-                               Severity blockSeverity, List<ValidationMessage> results,
-                               BlockValidationContext context) {
+
+    private void validateCitation(StructuralNode node, QuoteBlock.CitationConfig config, Severity blockSeverity,
+            List<ValidationMessage> results, BlockValidationContext context) {
         String citation = extractCitation(node);
         Severity severity = resolveSeverity(config.getSeverity(), blockSeverity);
-        
+
         if (config.isRequired() && (citation == null || citation.trim().isEmpty())) {
             SourcePosition pos = findCitationPosition(node, context);
-            results.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(CITATION_REQUIRED)
-                .message("Quote citation is required but not provided")
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("citation")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.LIST_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add quote citation")
-                    .addExample("[quote, Einstein, \"Special Relativity\"]")
-                    .addExample("[quote, Author, \"Book Title\"]")
-                    .addExample("[quote, Speaker, \"Speech Title\"]")
-                    .build())
-                .build());
+            results.add(ValidationMessage.builder().severity(severity).ruleId(CITATION_REQUIRED)
+                    .message("Quote citation is required but not provided")
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("citation")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.LIST_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add quote citation")
+                            .addExample("[quote, Einstein, \"Special Relativity\"]")
+                            .addExample("[quote, Author, \"Book Title\"]")
+                            .addExample("[quote, Speaker, \"Speech Title\"]").build())
+                    .build());
             return;
         }
-        
+
         if (citation != null && !citation.trim().isEmpty()) {
             // Validate minLength
             if (config.getMinLength() != null && citation.length() < config.getMinLength()) {
-                results.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(CITATION_MIN_LENGTH)
-                    .message(String.format("Quote citation is too short (minimum %d characters, found %d)",
-                                  config.getMinLength(), citation.length()))
-                    .location(context.createLocation(node))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use longer citation")
-                        .addExample("Include full book/article title")
-                        .addExample("Add publication year")
-                        .explanation("Citation needs at least " + config.getMinLength() + " characters")
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(severity).ruleId(CITATION_MIN_LENGTH)
+                        .message(String.format("Quote citation is too short (minimum %d characters, found %d)",
+                                config.getMinLength(), citation.length()))
+                        .location(context.createLocation(node))
+                        .addSuggestion(Suggestion.builder().description("Use longer citation")
+                                .addExample("Include full book/article title").addExample("Add publication year")
+                                .explanation("Citation needs at least " + config.getMinLength() + " characters")
+                                .build())
+                        .build());
             }
-            
+
             // Validate maxLength
             if (config.getMaxLength() != null && citation.length() > config.getMaxLength()) {
-                results.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(CITATION_MAX_LENGTH)
-                    .message(String.format("Quote citation is too long (maximum %d characters, found %d)",
-                                  config.getMaxLength(), citation.length()))
-                    .location(context.createLocation(node))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten citation")
-                        .addExample("Use abbreviated title")
-                        .addExample("Remove unnecessary details")
-                        .explanation("Citation must be at most " + config.getMaxLength() + " characters")
-                        .build())
-                    .build());
+                results.add(
+                        ValidationMessage.builder().severity(severity).ruleId(CITATION_MAX_LENGTH)
+                                .message(String.format("Quote citation is too long (maximum %d characters, found %d)",
+                                        config.getMaxLength(), citation.length()))
+                                .location(context.createLocation(node))
+                                .addSuggestion(Suggestion.builder().description("Shorten citation")
+                                        .addExample("Use abbreviated title").addExample("Remove unnecessary details")
+                                        .explanation(
+                                                "Citation must be at most " + config.getMaxLength() + " characters")
+                                        .build())
+                                .build());
             }
-            
+
             // Validate pattern
             if (config.getPattern() != null && !config.getPattern().matcher(citation).matches()) {
                 SourcePosition pos = findCitationPosition(node, context);
-                results.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(CITATION_PATTERN)
-                    .message("Quote citation does not match required pattern")
-                    .actualValue(citation)
-                    .expectedValue("Pattern: " + config.getPattern().pattern())
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Follow citation pattern")
-                        .addExample("Use proper citation format")
-                        .addExample("Example: Title, Year")
-                        .explanation("Citation must match pattern: " + config.getPattern().pattern())
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(severity).ruleId(CITATION_PATTERN)
+                        .message("Quote citation does not match required pattern").actualValue(citation)
+                        .expectedValue("Pattern: " + config.getPattern().pattern())
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .addSuggestion(Suggestion.builder().description("Follow citation pattern")
+                                .addExample("Use proper citation format").addExample("Example: Title, Year")
+                                .explanation("Citation must match pattern: " + config.getPattern().pattern()).build())
+                        .build());
             }
         }
     }
-    
-    private void validateContent(StructuralNode node, QuoteBlock.ContentConfig config,
-                                Severity blockSeverity, List<ValidationMessage> results,
-                                BlockValidationContext context) {
+
+    private void validateContent(StructuralNode node, QuoteBlock.ContentConfig config, Severity blockSeverity,
+            List<ValidationMessage> results, BlockValidationContext context) {
         String content = extractContent(node);
-        
+
         if (config.isRequired() && (content == null || content.trim().isEmpty())) {
-            results.add(ValidationMessage.builder()
-                .severity(blockSeverity)
-                .ruleId(CONTENT_REQUIRED)
-                .message("Quote block requires content")
-                .location(context.createLocation(node))
-                .addSuggestion(Suggestion.builder()
-                    .description("Add quote content")
-                    .addExample("[quote]")
-                    .addExample("____")
-                    .addExample("Your meaningful quote content goes here.")
-                    .addExample("____")
-                    .build())
-                .build());
+            results.add(ValidationMessage.builder().severity(blockSeverity).ruleId(CONTENT_REQUIRED)
+                    .message("Quote block requires content").location(context.createLocation(node))
+                    .addSuggestion(Suggestion.builder().description("Add quote content").addExample("[quote]")
+                            .addExample("____").addExample("Your meaningful quote content goes here.")
+                            .addExample("____").build())
+                    .build());
             return;
         }
-        
+
         if (content != null && !content.trim().isEmpty()) {
             // Validate minLength
             if (config.getMinLength() != null && content.length() < config.getMinLength()) {
-                results.add(ValidationMessage.builder()
-                    .severity(blockSeverity)
-                    .ruleId(CONTENT_MIN_LENGTH)
-                    .message(String.format("Quote content is too short (minimum %d characters, found %d)",
-                                  config.getMinLength(), content.length()))
-                    .location(context.createLocation(node))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Expand quote content")
-                        .addExample("Add more context to the quote")
-                        .addExample("Include complete thoughts")
-                        .explanation("Content needs at least " + config.getMinLength() + " characters")
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(blockSeverity).ruleId(CONTENT_MIN_LENGTH)
+                        .message(String.format("Quote content is too short (minimum %d characters, found %d)",
+                                config.getMinLength(), content.length()))
+                        .location(context.createLocation(node))
+                        .addSuggestion(Suggestion.builder().description("Expand quote content")
+                                .addExample("Add more context to the quote").addExample("Include complete thoughts")
+                                .explanation("Content needs at least " + config.getMinLength() + " characters").build())
+                        .build());
             }
-            
+
             // Validate maxLength
             if (config.getMaxLength() != null && content.length() > config.getMaxLength()) {
-                results.add(ValidationMessage.builder()
-                    .severity(blockSeverity)
-                    .ruleId(CONTENT_MAX_LENGTH)
-                    .message(String.format("Quote content is too long (maximum %d characters, found %d)",
-                                  config.getMaxLength(), content.length()))
-                    .location(context.createLocation(node))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten quote content")
-                        .addExample("Use ellipsis for shortened quotes")
-                        .addExample("Focus on key message")
-                        .explanation("Content must be at most " + config.getMaxLength() + " characters")
-                        .build())
-                    .build());
+                results.add(ValidationMessage.builder().severity(blockSeverity).ruleId(CONTENT_MAX_LENGTH)
+                        .message(String.format("Quote content is too long (maximum %d characters, found %d)",
+                                config.getMaxLength(), content.length()))
+                        .location(context.createLocation(node))
+                        .addSuggestion(Suggestion.builder().description("Shorten quote content")
+                                .addExample("Use ellipsis for shortened quotes").addExample("Focus on key message")
+                                .explanation("Content must be at most " + config.getMaxLength() + " characters")
+                                .build())
+                        .build());
             }
-            
+
             // Validate lines
             if (config.getLines() != null) {
                 validateLines(node, content, config.getLines(), blockSeverity, results, context);
             }
         }
     }
-    
+
     private void validateLines(StructuralNode node, String content, QuoteBlock.LinesConfig config,
-                              Severity blockSeverity, List<ValidationMessage> results,
-                              BlockValidationContext context) {
+            Severity blockSeverity, List<ValidationMessage> results, BlockValidationContext context) {
         String[] lines = content.split("\n");
         int lineCount = lines.length;
         Severity severity = resolveSeverity(config.getSeverity(), blockSeverity);
-        
+
         if (config.getMin() != null && lineCount < config.getMin()) {
-            results.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(CONTENT_LINES_MIN)
-                .message(String.format("Quote content has too few lines (minimum %d, found %d)",
-                              config.getMin(), lineCount))
-                .location(context.createLocation(node))
-                .addSuggestion(Suggestion.builder()
-                    .description("Add more lines to quote")
-                    .addExample("Break long sentences across lines")
-                    .addExample("Add context or explanation")
-                    .explanation("Quote needs at least " + config.getMin() + " lines")
-                    .build())
-                .build());
+            results.add(ValidationMessage.builder().severity(severity).ruleId(CONTENT_LINES_MIN)
+                    .message(String.format("Quote content has too few lines (minimum %d, found %d)", config.getMin(),
+                            lineCount))
+                    .location(context.createLocation(node))
+                    .addSuggestion(Suggestion.builder().description("Add more lines to quote")
+                            .addExample("Break long sentences across lines").addExample("Add context or explanation")
+                            .explanation("Quote needs at least " + config.getMin() + " lines").build())
+                    .build());
         }
-        
+
         if (config.getMax() != null && lineCount > config.getMax()) {
-            results.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(CONTENT_LINES_MAX)
-                .message(String.format("Quote content has too many lines (maximum %d, found %d)",
-                              config.getMax(), lineCount))
-                .location(context.createLocation(node))
-                .addSuggestion(Suggestion.builder()
-                    .description("Reduce quote lines")
-                    .addExample("Combine related sentences")
-                    .addExample("Remove less essential parts")
-                    .explanation("Quote should have at most " + config.getMax() + " lines")
-                    .build())
-                .build());
+            results.add(ValidationMessage.builder().severity(severity).ruleId(CONTENT_LINES_MAX)
+                    .message(String.format("Quote content has too many lines (maximum %d, found %d)", config.getMax(),
+                            lineCount))
+                    .location(context.createLocation(node))
+                    .addSuggestion(Suggestion.builder().description("Reduce quote lines")
+                            .addExample("Combine related sentences").addExample("Remove less essential parts")
+                            .explanation("Quote should have at most " + config.getMax() + " lines").build())
+                    .build());
         }
     }
-    
+
     private String extractAttribution(StructuralNode node) {
         // Check for attribution attribute (standard way)
         Object attribution = node.getAttribute(ATTRIBUTION);
         if (attribution != null) {
             return attribution.toString();
         }
-        
+
         // Check for author attribute (alternative way)
         Object author = node.getAttribute(AUTHOR);
         if (author != null) {
             return author.toString();
         }
-        
+
         // Check for positional attribute [quote, Author, Source]
         Object attr1 = node.getAttribute(ATTR_1);
         if (attr1 != null) {
             return attr1.toString();
         }
-        
+
         return null;
     }
-    
+
     private String extractCitation(StructuralNode node) {
         // Check for citetitle attribute (standard way for citation)
         Object citetitle = node.getAttribute(CITETITLE);
         if (citetitle != null) {
             return citetitle.toString();
         }
-        
+
         // Check for source attribute (alternative way)
         Object source = node.getAttribute(SOURCE);
         if (source != null) {
             return source.toString();
         }
-        
+
         // Check for positional attribute [quote, Author, Source]
         Object attr2 = node.getAttribute(ATTR_2);
         if (attr2 != null) {
             return attr2.toString();
         }
-        
+
         return null;
     }
-    
+
     private String extractContent(StructuralNode node) {
         // Use inherited getBlockContent method from AbstractBlockValidator
         return getBlockContent(node);
     }
-    
+
     /**
      * Finds the position for quote attribution.
      */
     private SourcePosition findSourcePosition(StructuralNode node, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || node.getSourceLocation() == null) {
-            return new SourcePosition(7, 7, node.getSourceLocation() != null ? node.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(7, 7,
+                    node.getSourceLocation() != null ? node.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = node.getSourceLocation().getLineNumber();
-        
+
         // Quote blocks typically start one line before the reported line
         // Search backward for [quote]
         for (int i = lineNum - 1; i >= 0 && i >= lineNum - 5; i--) {
@@ -427,21 +348,22 @@ public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock
                 }
             }
         }
-        
+
         return new SourcePosition(7, 7, lineNum);
     }
-    
+
     /**
      * Finds the position for quote citation.
      */
     private SourcePosition findCitationPosition(StructuralNode node, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || node.getSourceLocation() == null) {
-            return new SourcePosition(16, 16, node.getSourceLocation() != null ? node.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(16, 16,
+                    node.getSourceLocation() != null ? node.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = node.getSourceLocation().getLineNumber();
-        
+
         // Quote blocks typically start one line before the reported line
         // Search backward for [quote]
         for (int i = lineNum - 1; i >= 0 && i >= lineNum - 5; i--) {
@@ -469,9 +391,8 @@ public final class QuoteBlockValidator extends AbstractBlockValidator<QuoteBlock
                 }
             }
         }
-        
+
         return new SourcePosition(16, 16, lineNum);
     }
-    
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidator.java
@@ -19,342 +19,272 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for sidebar blocks based on YAML schema configuration.
- * 
- * <p>Sidebar blocks in AsciiDoc are delimited by **** and contain supplementary information.
- * This validator checks:
+ *
+ * <p>
+ * Sidebar blocks in AsciiDoc are delimited by **** and contain supplementary information. This validator checks:
  * <ul>
- *   <li>Title requirements (optional with pattern, minLength, maxLength)</li>
- *   <li>Content requirements (required with minLength, maxLength, nested lines)</li>
- *   <li>Position requirements (optional with allowed values)</li>
+ * <li>Title requirements (optional with pattern, minLength, maxLength)</li>
+ * <li>Content requirements (required with minLength, maxLength, nested lines)</li>
+ * <li>Position requirements (optional with allowed values)</li>
  * </ul>
- * 
- * <p>Each nested configuration can optionally define its own severity level.
- * If not specified, the block-level severity is used as fallback.</p>
- * 
+ *
+ * <p>
+ * Each nested configuration can optionally define its own severity level. If not specified, the block-level severity is
+ * used as fallback.
+ * </p>
+ *
  * @see SidebarBlock
  * @see BlockTypeValidator
  */
 public final class SidebarBlockValidator extends AbstractBlockValidator<SidebarBlock> {
-    
+
     @Override
     public BlockType getSupportedType() {
         return BlockType.SIDEBAR;
     }
-    
+
     @Override
     protected Class<SidebarBlock> getBlockConfigClass() {
         return SidebarBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               SidebarBlock sidebarConfig,
-                                                               BlockValidationContext context) {
-        
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, SidebarBlock sidebarConfig,
+            BlockValidationContext context) {
+
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Validate title
         if (sidebarConfig.getTitle() != null) {
             validateTitle(block, sidebarConfig, context, messages);
         }
-        
+
         // Validate content
         if (sidebarConfig.getContent() != null) {
             validateContent(block, sidebarConfig, context, messages);
         }
-        
+
         // Validate position
         if (sidebarConfig.getPosition() != null) {
             validatePosition(block, sidebarConfig, context, messages);
         }
-        
+
         return messages;
     }
-    
-    private void validateTitle(StructuralNode block, SidebarBlock config,
-                             BlockValidationContext context, List<ValidationMessage> messages) {
+
+    private void validateTitle(StructuralNode block, SidebarBlock config, BlockValidationContext context,
+            List<ValidationMessage> messages) {
         SidebarBlock.TitleConfig titleConfig = config.getTitle();
-        
+
         String title = block.getTitle();
         boolean hasTitle = title != null && !title.trim().isEmpty();
-        
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(titleConfig.getSeverity(), config.getSeverity());
-        
+
         // Check if title is required
         if (titleConfig.isRequired() && !hasTitle) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TITLE_REQUIRED)
-                .location(context.createLocation(block))
-                .message("Sidebar block requires a title")
-                .actualValue("No title")
-                .expectedValue("Title required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(".Sidebar Title")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add title to sidebar block")
-                    .addExample(".Important Information")
-                    .addExample(".Additional Notes")
-                    .addExample(".Side Note")
-                    .explanation("Sidebar blocks should have descriptive titles to indicate their purpose")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_REQUIRED)
+                    .location(context.createLocation(block)).message("Sidebar block requires a title")
+                    .actualValue("No title").expectedValue("Title required").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint(".Sidebar Title")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add title to sidebar block")
+                            .addExample(".Important Information").addExample(".Additional Notes")
+                            .addExample(".Side Note")
+                            .explanation("Sidebar blocks should have descriptive titles to indicate their purpose")
+                            .build())
+                    .build());
             return;
         }
-        
+
         if (!hasTitle) {
             return;
         }
-        
+
         // Validate title length
         if (titleConfig.getMinLength() != null && title.length() < titleConfig.getMinLength()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TITLE_MIN_LENGTH)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar title too short")
-                .actualValue(title.length() + " characters")
-                .expectedValue("At least " + titleConfig.getMinLength() + " characters")
-                .addSuggestion(Suggestion.builder()
-                    .description("Use a longer, more descriptive title")
-                    .addExample("Additional Information")
-                    .addExample("Important Notes")
-                    .addExample("Related Topics")
-                    .explanation("Sidebar titles should be descriptive enough to meet minimum length requirements")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_MIN_LENGTH)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar title too short")
+                    .actualValue(title.length() + " characters")
+                    .expectedValue("At least " + titleConfig.getMinLength() + " characters")
+                    .addSuggestion(Suggestion.builder().description("Use a longer, more descriptive title")
+                            .addExample("Additional Information").addExample("Important Notes")
+                            .addExample("Related Topics")
+                            .explanation(
+                                    "Sidebar titles should be descriptive enough to meet minimum length requirements")
+                            .build())
+                    .build());
         }
-        
+
         if (titleConfig.getMaxLength() != null && title.length() > titleConfig.getMaxLength()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(TITLE_MAX_LENGTH)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar title too long")
-                .actualValue(title.length() + " characters")
-                .expectedValue("At most " + titleConfig.getMaxLength() + " characters")
-                .addSuggestion(Suggestion.builder()
-                    .description("Shorten the title")
-                    .addExample("Info")
-                    .addExample("Notes")
-                    .addExample("Tip")
-                    .explanation("Sidebar titles should be concise and not exceed maximum length limits")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_MAX_LENGTH)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar title too long")
+                    .actualValue(title.length() + " characters")
+                    .expectedValue("At most " + titleConfig.getMaxLength() + " characters")
+                    .addSuggestion(Suggestion.builder().description("Shorten the title").addExample("Info")
+                            .addExample("Notes").addExample("Tip")
+                            .explanation("Sidebar titles should be concise and not exceed maximum length limits")
+                            .build())
+                    .build());
         }
-        
+
         // Validate title pattern
         if (titleConfig.getPattern() != null) {
             Pattern pattern = titleConfig.getPattern();
             if (!pattern.matcher(title).matches()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(TITLE_PATTERN)
-                    .location(context.createLocation(block, 1, 1))
-                    .message("Sidebar title does not match required pattern")
-                    .actualValue(title)
-                    .expectedValue("Pattern: " + pattern.pattern())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Format title to match required pattern")
-                        .addExample("Important Note")
-                        .addExample("Quick Reference")
-                        .addExample("Related Information")
-                        .explanation("Sidebar titles must follow the specified format pattern")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(TITLE_PATTERN)
+                        .location(context.createLocation(block, 1, 1))
+                        .message("Sidebar title does not match required pattern").actualValue(title)
+                        .expectedValue("Pattern: " + pattern.pattern())
+                        .addSuggestion(Suggestion.builder().description("Format title to match required pattern")
+                                .addExample("Important Note").addExample("Quick Reference")
+                                .addExample("Related Information")
+                                .explanation("Sidebar titles must follow the specified format pattern").build())
+                        .build());
             }
         }
     }
-    
-    private void validateContent(StructuralNode block, SidebarBlock config,
-                               BlockValidationContext context, List<ValidationMessage> messages) {
+
+    private void validateContent(StructuralNode block, SidebarBlock config, BlockValidationContext context,
+            List<ValidationMessage> messages) {
         SidebarBlock.ContentConfig contentConfig = config.getContent();
-        
+
         String content = getBlockContent(block);
-        
+
         // Check if content is required
         if (contentConfig.isRequired() && content.isEmpty()) {
-            messages.add(ValidationMessage.builder()
-                .severity(config.getSeverity())
-                .ruleId(CONTENT_REQUIRED)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar block requires content")
-                .actualValue("No content")
-                .expectedValue("Content required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("Content")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add content to sidebar block")
-                    .addExample("This is additional information related to the main content.")
-                    .addExample("Key points to remember:")
-                    .addExample("For more details, see Chapter 5.")
-                    .explanation("Sidebar blocks must contain relevant supplementary information")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(CONTENT_REQUIRED)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar block requires content")
+                    .actualValue("No content").expectedValue("Content required").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("Content")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add content to sidebar block")
+                            .addExample("This is additional information related to the main content.")
+                            .addExample("Key points to remember:").addExample("For more details, see Chapter 5.")
+                            .explanation("Sidebar blocks must contain relevant supplementary information").build())
+                    .build());
             return;
         }
-        
+
         if (content.isEmpty()) {
             return;
         }
-        
+
         // Validate content length
         if (contentConfig.getMinLength() != null && content.length() < contentConfig.getMinLength()) {
-            messages.add(ValidationMessage.builder()
-                .severity(config.getSeverity())
-                .ruleId(CONTENT_MIN_LENGTH)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar content too short")
-                .actualValue(content.length() + " characters")
-                .expectedValue("At least " + contentConfig.getMinLength() + " characters")
-                .addSuggestion(Suggestion.builder()
-                    .description("Add more detailed content")
-                    .addExample("Expand with additional details or examples")
-                    .addExample("Include relevant background information")
-                    .addExample("Add context or explanatory notes")
-                    .explanation("Sidebar content should be detailed enough to meet minimum length requirements")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(CONTENT_MIN_LENGTH)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar content too short")
+                    .actualValue(content.length() + " characters")
+                    .expectedValue("At least " + contentConfig.getMinLength() + " characters")
+                    .addSuggestion(Suggestion.builder().description("Add more detailed content")
+                            .addExample("Expand with additional details or examples")
+                            .addExample("Include relevant background information")
+                            .addExample("Add context or explanatory notes")
+                            .explanation(
+                                    "Sidebar content should be detailed enough to meet minimum length requirements")
+                            .build())
+                    .build());
         }
-        
+
         if (contentConfig.getMaxLength() != null && content.length() > contentConfig.getMaxLength()) {
-            messages.add(ValidationMessage.builder()
-                .severity(config.getSeverity())
-                .ruleId(CONTENT_MAX_LENGTH)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar content too long")
-                .actualValue(content.length() + " characters")
-                .expectedValue("At most " + contentConfig.getMaxLength() + " characters")
-                .addSuggestion(Suggestion.builder()
-                    .description("Shorten the content")
-                    .addExample("Use bullet points for conciseness")
-                    .addExample("Remove non-essential details")
-                    .addExample("Split into multiple smaller sidebars")
-                    .explanation("Sidebar content should be concise and not exceed maximum length limits")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(CONTENT_MAX_LENGTH)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar content too long")
+                    .actualValue(content.length() + " characters")
+                    .expectedValue("At most " + contentConfig.getMaxLength() + " characters")
+                    .addSuggestion(Suggestion.builder().description("Shorten the content")
+                            .addExample("Use bullet points for conciseness").addExample("Remove non-essential details")
+                            .addExample("Split into multiple smaller sidebars")
+                            .explanation("Sidebar content should be concise and not exceed maximum length limits")
+                            .build())
+                    .build());
         }
-        
+
         // Validate lines if configured
         if (contentConfig.getLines() != null) {
             validateLines(block, config, contentConfig.getLines(), context, messages);
         }
     }
-    
-    private void validateLines(StructuralNode block, SidebarBlock config, 
-                             SidebarBlock.LinesConfig linesConfig,
-                             BlockValidationContext context, List<ValidationMessage> messages) {
-        
+
+    private void validateLines(StructuralNode block, SidebarBlock config, SidebarBlock.LinesConfig linesConfig,
+            BlockValidationContext context, List<ValidationMessage> messages) {
+
         String content = getBlockContent(block);
         String[] lines = content.split("\n");
         int lineCount = lines.length;
-        
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(linesConfig.getSeverity(), config.getSeverity());
-        
+
         // Validate minimum lines
         if (linesConfig.getMin() != null && lineCount < linesConfig.getMin()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(LINES_MIN)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar has too few lines")
-                .actualValue(lineCount + " lines")
-                .expectedValue("At least " + linesConfig.getMin() + " lines")
-                .addSuggestion(Suggestion.builder()
-                    .description("Add more lines of content")
-                    .addExample("Add additional paragraphs")
-                    .addExample("Include multiple bullet points")
-                    .addExample("Break content across more lines")
-                    .explanation("Sidebar content should meet the minimum line count requirement")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(LINES_MIN)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar has too few lines")
+                    .actualValue(lineCount + " lines").expectedValue("At least " + linesConfig.getMin() + " lines")
+                    .addSuggestion(Suggestion.builder().description("Add more lines of content")
+                            .addExample("Add additional paragraphs").addExample("Include multiple bullet points")
+                            .addExample("Break content across more lines")
+                            .explanation("Sidebar content should meet the minimum line count requirement").build())
+                    .build());
         }
-        
+
         // Validate maximum lines
         if (linesConfig.getMax() != null && lineCount > linesConfig.getMax()) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(LINES_MAX)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar has too many lines")
-                .actualValue(lineCount + " lines")
-                .expectedValue("At most " + linesConfig.getMax() + " lines")
-                .addSuggestion(Suggestion.builder()
-                    .description("Reduce the number of lines")
-                    .addExample("Combine shorter lines")
-                    .addExample("Remove redundant information")
-                    .addExample("Use more concise language")
-                    .explanation("Sidebar content should not exceed the maximum line count limit")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(LINES_MAX)
+                    .location(context.createLocation(block, 1, 1)).message("Sidebar has too many lines")
+                    .actualValue(lineCount + " lines").expectedValue("At most " + linesConfig.getMax() + " lines")
+                    .addSuggestion(Suggestion.builder().description("Reduce the number of lines")
+                            .addExample("Combine shorter lines").addExample("Remove redundant information")
+                            .addExample("Use more concise language")
+                            .explanation("Sidebar content should not exceed the maximum line count limit").build())
+                    .build());
         }
     }
-    
-    private void validatePosition(StructuralNode block, SidebarBlock config,
-                                BlockValidationContext context, List<ValidationMessage> messages) {
+
+    private void validatePosition(StructuralNode block, SidebarBlock config, BlockValidationContext context,
+            List<ValidationMessage> messages) {
         SidebarBlock.PositionConfig positionConfig = config.getPosition();
-        
+
         // Get position attribute
         Object positionAttr = block.getAttribute(POSITION);
         String position = positionAttr != null ? positionAttr.toString() : null;
-        
+
         // Get severity with fallback to block severity
         Severity severity = resolveSeverity(positionConfig.getSeverity(), config.getSeverity());
-        
+
         // Check if position is required
         if (positionConfig.isRequired() && (position == null || position.isEmpty())) {
-            messages.add(ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(POSITION_REQUIRED)
-                .location(context.createLocation(block, 1, 1))
-                .message("Sidebar block requires a position attribute")
-                .actualValue("No position attribute")
-                .expectedValue("Position attribute required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("[position=left]")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add position attribute to sidebar")
-                    .fixedValue("[position=left]")
-                    .addExample("[sidebar,position=left]")
-                    .addExample("[sidebar,position=right]")
-                    .addExample("[sidebar,position=center]")
-                    .explanation("Sidebar blocks should specify their position for proper layout")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(POSITION_REQUIRED)
+                    .location(context.createLocation(block, 1, 1))
+                    .message("Sidebar block requires a position attribute").actualValue("No position attribute")
+                    .expectedValue("Position attribute required").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("[position=left]")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add position attribute to sidebar")
+                            .fixedValue("[position=left]").addExample("[sidebar,position=left]")
+                            .addExample("[sidebar,position=right]").addExample("[sidebar,position=center]")
+                            .explanation("Sidebar blocks should specify their position for proper layout").build())
+                    .build());
             return;
         }
-        
+
         // Validate allowed positions
-        if (position != null && !position.isEmpty() && 
-            positionConfig.getAllowed() != null && !positionConfig.getAllowed().isEmpty()) {
+        if (position != null && !position.isEmpty() && positionConfig.getAllowed() != null
+                && !positionConfig.getAllowed().isEmpty()) {
             if (!positionConfig.getAllowed().contains(position)) {
-                messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(POSITION_ALLOWED)
-                    .location(context.createLocation(block, 1, 1))
-                    .message("Invalid sidebar position")
-                    .actualValue(position)
-                    .expectedValue("One of: " + String.join(", ", positionConfig.getAllowed()))
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use a valid position value")
-                        .fixedValue("[position=" + positionConfig.getAllowed().get(0) + "]")
-                        .addExample("[sidebar,position=left]")
-                        .addExample("[sidebar,position=right]")
-                        .addExample("[sidebar,position=center]")
-                        .explanation("Sidebar position must be one of the allowed values")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(POSITION_ALLOWED)
+                        .location(context.createLocation(block, 1, 1)).message("Invalid sidebar position")
+                        .actualValue(position)
+                        .expectedValue("One of: " + String.join(", ", positionConfig.getAllowed()))
+                        .addSuggestion(Suggestion.builder().description("Use a valid position value")
+                                .fixedValue("[position=" + positionConfig.getAllowed().get(0) + "]")
+                                .addExample("[sidebar,position=left]").addExample("[sidebar,position=right]")
+                                .addExample("[sidebar,position=center]")
+                                .explanation("Sidebar position must be one of the allowed values").build())
+                        .build());
             }
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidator.java
@@ -20,469 +20,359 @@ import com.dataliquid.asciidoc.linter.validator.Suggestion;
 
 /**
  * Validator for verse/quote blocks in AsciiDoc documents.
- * 
- * <p>This validator validates verse blocks based on the YAML schema structure
- * defined in {@code src/main/resources/schemas/blocks/verse-block.yaml}.
- * The YAML configuration is parsed into {@link VerseBlock} objects which
- * define the validation rules.</p>
- * 
- * <p>Supported validation rules from YAML schema:</p>
+ *
+ * <p>
+ * This validator validates verse blocks based on the YAML schema structure defined in
+ * {@code src/main/resources/schemas/blocks/verse-block.yaml}. The YAML configuration is parsed into {@link VerseBlock}
+ * objects which define the validation rules.
+ * </p>
+ *
+ * <p>
+ * Supported validation rules from YAML schema:
+ * </p>
  * <ul>
- *   <li><b>author</b>: Validates verse author (required, pattern, length constraints)</li>
- *   <li><b>attribution</b>: Validates source attribution (required, pattern, length constraints)</li>
- *   <li><b>content</b>: Validates verse content (required, length constraints, pattern)</li>
+ * <li><b>author</b>: Validates verse author (required, pattern, length constraints)</li>
+ * <li><b>attribution</b>: Validates source attribution (required, pattern, length constraints)</li>
+ * <li><b>content</b>: Validates verse content (required, length constraints, pattern)</li>
  * </ul>
- * 
- * <p>Note: Verse block nested configurations do not support individual severity levels.
- * All validations use the block-level severity.</p>
- * 
+ *
+ * <p>
+ * Note: Verse block nested configurations do not support individual severity levels. All validations use the
+ * block-level severity.
+ * </p>
+ *
  * @see VerseBlock
  * @see BlockTypeValidator
  */
-public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock> {    
+public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock> {
     @Override
     public BlockType getSupportedType() {
         return BlockType.VERSE;
     }
-    
+
     @Override
     protected Class<VerseBlock> getBlockConfigClass() {
         return VerseBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, 
-                                                               VerseBlock verseConfig,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode block, VerseBlock verseConfig,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Get verse attributes
         String author = getAuthor(block);
         String attribution = getAttribution(block);
         String content = getBlockContent(block);
-        
+
         // Validate author
         if (verseConfig.getAuthor() != null) {
             validateAuthor(author, verseConfig.getAuthor(), context, block, messages, verseConfig);
         }
-        
+
         // Validate attribution
         if (verseConfig.getAttribution() != null) {
             validateAttribution(attribution, verseConfig.getAttribution(), context, block, messages, verseConfig);
         }
-        
+
         // Validate content
         if (verseConfig.getContent() != null) {
             validateContent(content, verseConfig.getContent(), context, block, messages, verseConfig);
         }
-        
+
         return messages;
     }
-    
+
     private String getAuthor(StructuralNode block) {
         // Author can be in attribution attribute (standard way)
         Object attr = block.getAttribute(ATTRIBUTION);
         if (attr != null) {
             return attr.toString();
         }
-        
+
         // Check for author attribute
         attr = block.getAttribute(AUTHOR);
         if (attr != null) {
             return attr.toString();
         }
-        
+
         // Check for positional attribute [verse, Author, Source]
         // AsciidoctorJ puts "verse" in attribute "1", author in "2"
         Object attr2 = block.getAttribute(ATTR_2);
         if (attr2 != null) {
             return attr2.toString();
         }
-        
+
         return null;
     }
-    
+
     private String getAttribution(StructuralNode block) {
         // Or in citetitle attribute (this is where AsciidoctorJ puts the citation)
         Object attr = block.getAttribute(CITETITLE);
         if (attr != null) {
             return attr.toString();
         }
-        
+
         // Attribution can be in attribution attribute
         attr = block.getAttribute(ATTRIBUTION);
         if (attr != null) {
             return attr.toString();
         }
-        
+
         // Check for positional attribute [verse, Author, Source]
         // AsciidoctorJ puts "verse" in attribute "1", author in "2", source in "3"
         Object attr3 = block.getAttribute(ATTR_3);
         if (attr3 != null) {
             return attr3.toString();
         }
-        
+
         return null;
     }
-    
+
     // getBlockContent is now inherited from AbstractBlockValidator
-    
-    private void validateAuthor(String author, VerseBlock.AuthorConfig config,
-                              BlockValidationContext context,
-                              StructuralNode block,
-                              List<ValidationMessage> messages,
-                              VerseBlock verseConfig) {
-        
+
+    private void validateAuthor(String author, VerseBlock.AuthorConfig config, BlockValidationContext context,
+            StructuralNode block, List<ValidationMessage> messages, VerseBlock verseConfig) {
+
         // Check if author is required
         if (config.isRequired() && (author == null || author.trim().isEmpty())) {
             // Create location pointing to where author should be in [verse] line
             SourceLocation verseLocation = context.createLocation(block);
             // The [verse] line is typically one line before the block delimiter
-            SourceLocation authorLocation = SourceLocation.builder()
-                .filename(verseLocation.getFilename())
-                .startLine(verseLocation.getStartLine() - 1)  // [verse] line is before ____
-                .endLine(verseLocation.getStartLine() - 1)
-                .startColumn(7)  // After "[verse,"
-                .endColumn(7)
-                .build();
-                
-            messages.add(ValidationMessage.builder()
-                .severity(verseConfig.getSeverity())
-                .ruleId(AUTHOR_REQUIRED)
-                .location(authorLocation)
-                .message("Verse author is required but not provided")
-                .actualValue("No author")
-                .expectedValue("Author required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("author")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add author to verse block")
-                    .addExample("[verse, \"William Shakespeare\", \"Hamlet\"]") 
-                    .addExample("[verse, \"Maya Angelou\", \"I Know Why the Caged Bird Sings\"]") 
-                    .addExample("[verse, \"Robert Frost\", \"The Road Not Taken\"]") 
-                    .explanation("Verse blocks should include proper attribution with author name")
-                    .build())
-                .build());
+            SourceLocation authorLocation = SourceLocation.builder().filename(verseLocation.getFilename())
+                    .startLine(verseLocation.getStartLine() - 1) // [verse] line is before ____
+                    .endLine(verseLocation.getStartLine() - 1).startColumn(7) // After "[verse,"
+                    .endColumn(7).build();
+
+            messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(AUTHOR_REQUIRED)
+                    .location(authorLocation).message("Verse author is required but not provided")
+                    .actualValue("No author").expectedValue("Author required").errorType(ErrorType.MISSING_VALUE)
+                    .missingValueHint("author")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add author to verse block")
+                            .addExample("[verse, \"William Shakespeare\", \"Hamlet\"]")
+                            .addExample("[verse, \"Maya Angelou\", \"I Know Why the Caged Bird Sings\"]")
+                            .addExample("[verse, \"Robert Frost\", \"The Road Not Taken\"]")
+                            .explanation("Verse blocks should include proper attribution with author name").build())
+                    .build());
             return;
         }
-        
+
         if (author != null && !author.trim().isEmpty()) {
             // Validate author length
             if (config.getMinLength() != null && author.length() < config.getMinLength()) {
                 SourcePosition pos = findSourcePosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(verseConfig.getSeverity())
-                    .ruleId(AUTHOR_MIN_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Verse author is too short")
-                    .actualValue(author.length() + " characters")
-                    .expectedValue("At least " + config.getMinLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use longer author name")
-                        .addExample("William Shakespeare")
-                        .addExample("Edgar Allan Poe")
-                        .addExample("Emily Dickinson")
-                        .explanation("Author names should meet the minimum length requirement")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(AUTHOR_MIN_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Verse author is too short").actualValue(author.length() + " characters")
+                        .expectedValue("At least " + config.getMinLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Use longer author name")
+                                .addExample("William Shakespeare").addExample("Edgar Allan Poe")
+                                .addExample("Emily Dickinson")
+                                .explanation("Author names should meet the minimum length requirement").build())
+                        .build());
             }
-            
+
             if (config.getMaxLength() != null && author.length() > config.getMaxLength()) {
                 SourcePosition pos = findSourcePosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(verseConfig.getSeverity())
-                    .ruleId(AUTHOR_MAX_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Verse author is too long")
-                    .actualValue(author.length() + " characters")
-                    .expectedValue("At most " + config.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten author name")
-                        .addExample("Use initials: E.A. Poe")
-                        .addExample("Use last name only: Shakespeare")
-                        .addExample("Use common name: Anonymous")
-                        .explanation("Author names should not exceed the maximum length limit")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(AUTHOR_MAX_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Verse author is too long").actualValue(author.length() + " characters")
+                        .expectedValue("At most " + config.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Shorten author name")
+                                .addExample("Use initials: E.A. Poe").addExample("Use last name only: Shakespeare")
+                                .addExample("Use common name: Anonymous")
+                                .explanation("Author names should not exceed the maximum length limit").build())
+                        .build());
             }
-            
+
             // Validate pattern if specified
             if (config.getPattern() != null) {
                 if (!config.getPattern().matcher(author).matches()) {
                     SourcePosition pos = findSourcePosition(block, context);
-                    messages.add(ValidationMessage.builder()
-                        .severity(verseConfig.getSeverity())
-                        .ruleId(AUTHOR_PATTERN)
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .message("Verse author does not match required pattern")
-                        .actualValue(author)
-                        .expectedValue("Pattern: " + config.getPattern().pattern())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Format author name to match pattern")
-                            .addExample("John Smith")
-                            .addExample("Mary Jane Watson")
-                            .addExample("Dr. John Doe")
-                            .explanation("Author names must follow the specified format pattern")
-                            .build())
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(AUTHOR_PATTERN)
+                            .location(
+                                    SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                            .message("Verse author does not match required pattern").actualValue(author)
+                            .expectedValue("Pattern: " + config.getPattern().pattern())
+                            .addSuggestion(Suggestion.builder().description("Format author name to match pattern")
+                                    .addExample("John Smith").addExample("Mary Jane Watson").addExample("Dr. John Doe")
+                                    .explanation("Author names must follow the specified format pattern").build())
+                            .build());
                 }
             }
         }
     }
-    
+
     private void validateAttribution(String attribution, VerseBlock.AttributionConfig config,
-                                   BlockValidationContext context,
-                                   StructuralNode block,
-                                   List<ValidationMessage> messages,
-                                   VerseBlock verseConfig) {
-        
+            BlockValidationContext context, StructuralNode block, List<ValidationMessage> messages,
+            VerseBlock verseConfig) {
+
         // Check if attribution is required
         if (config.isRequired() && (attribution == null || attribution.trim().isEmpty())) {
             // Create location pointing to where attribution should be in [verse] line
             SourceLocation verseLocation = context.createLocation(block);
             // The [verse] line is typically one line before the block delimiter
-            SourceLocation attributionLocation = SourceLocation.builder()
-                .filename(verseLocation.getFilename())
-                .startLine(verseLocation.getStartLine() - 1)  // [verse] line is before ____
-                .endLine(verseLocation.getStartLine() - 1)
-                .startColumn(7)  // After "[verse,"
-                .endColumn(7)
-                .build();
-                
-            messages.add(ValidationMessage.builder()
-                .severity(verseConfig.getSeverity())
-                .ruleId(ATTRIBUTION_REQUIRED)
-                .location(attributionLocation)
-                .message("Verse attribution is required but not provided")
-                .actualValue("No attribution")
-                .expectedValue("Attribution required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("attribution")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add attribution source to verse block")
-                    .addExample("[verse, \"William Shakespeare\", \"Hamlet Act 3, Scene 1\"]") 
-                    .addExample("[verse, \"Maya Angelou\", \"Still I Rise\"]")
-                    .addExample("[verse, \"Robert Frost\", \"The Road Not Taken\"]")
-                    .explanation("Verse blocks should include proper source attribution")
-                    .build())
-                .build());
+            SourceLocation attributionLocation = SourceLocation.builder().filename(verseLocation.getFilename())
+                    .startLine(verseLocation.getStartLine() - 1) // [verse] line is before ____
+                    .endLine(verseLocation.getStartLine() - 1).startColumn(7) // After "[verse,"
+                    .endColumn(7).build();
+
+            messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(ATTRIBUTION_REQUIRED)
+                    .location(attributionLocation).message("Verse attribution is required but not provided")
+                    .actualValue("No attribution").expectedValue("Attribution required")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("attribution")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add attribution source to verse block")
+                            .addExample("[verse, \"William Shakespeare\", \"Hamlet Act 3, Scene 1\"]")
+                            .addExample("[verse, \"Maya Angelou\", \"Still I Rise\"]")
+                            .addExample("[verse, \"Robert Frost\", \"The Road Not Taken\"]")
+                            .explanation("Verse blocks should include proper source attribution").build())
+                    .build());
             return;
         }
-        
+
         if (attribution != null && !attribution.trim().isEmpty()) {
             // Validate attribution length
             if (config.getMinLength() != null && attribution.length() < config.getMinLength()) {
                 SourcePosition pos = findAttributionPosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(verseConfig.getSeverity())
-                    .ruleId(ATTRIBUTION_MIN_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Verse attribution is too short")
-                    .actualValue(attribution.length() + " characters")
-                    .expectedValue("At least " + config.getMinLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Use longer attribution source")
-                        .addExample("Romeo and Juliet Act 2, Scene 2")
-                        .addExample("The Great Gatsby Chapter 9")
-                        .addExample("Paradise Lost Book 1")
-                        .explanation("Attribution sources should meet the minimum length requirement")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity())
+                        .ruleId(ATTRIBUTION_MIN_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Verse attribution is too short").actualValue(attribution.length() + " characters")
+                        .expectedValue("At least " + config.getMinLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Use longer attribution source")
+                                .addExample("Romeo and Juliet Act 2, Scene 2").addExample("The Great Gatsby Chapter 9")
+                                .addExample("Paradise Lost Book 1")
+                                .explanation("Attribution sources should meet the minimum length requirement").build())
+                        .build());
             }
-            
+
             if (config.getMaxLength() != null && attribution.length() > config.getMaxLength()) {
                 SourcePosition pos = findAttributionPosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(verseConfig.getSeverity())
-                    .ruleId(ATTRIBUTION_MAX_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Verse attribution is too long")
-                    .actualValue(attribution.length() + " characters")
-                    .expectedValue("At most " + config.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten attribution source")
-                        .addExample("Use abbreviations: Hamlet Act 3")
-                        .addExample("Use short title: The Raven")
-                        .addExample("Use year only: Poetry 1920")
-                        .explanation("Attribution sources should not exceed the maximum length limit")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity())
+                        .ruleId(ATTRIBUTION_MAX_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Verse attribution is too long").actualValue(attribution.length() + " characters")
+                        .expectedValue("At most " + config.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Shorten attribution source")
+                                .addExample("Use abbreviations: Hamlet Act 3").addExample("Use short title: The Raven")
+                                .addExample("Use year only: Poetry 1920")
+                                .explanation("Attribution sources should not exceed the maximum length limit").build())
+                        .build());
             }
-            
+
             // Validate pattern if specified
             if (config.getPattern() != null) {
                 if (!config.getPattern().matcher(attribution).matches()) {
                     SourcePosition pos = findAttributionPosition(block, context);
-                    messages.add(ValidationMessage.builder()
-                        .severity(verseConfig.getSeverity())
-                        .ruleId(ATTRIBUTION_PATTERN)
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .message("Verse attribution does not match required pattern")
-                        .actualValue(attribution)
-                        .expectedValue("Pattern: " + config.getPattern().pattern())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Format attribution source to match pattern")
-                            .addExample("Hamlet, Act III, Scene I")
-                            .addExample("Romeo and Juliet (1595)")
-                            .addExample("Sonnets, No. 18")
-                            .explanation("Attribution sources must follow the specified format pattern")
-                            .build())
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity())
+                            .ruleId(ATTRIBUTION_PATTERN)
+                            .location(
+                                    SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                            .message("Verse attribution does not match required pattern").actualValue(attribution)
+                            .expectedValue("Pattern: " + config.getPattern().pattern())
+                            .addSuggestion(
+                                    Suggestion.builder().description("Format attribution source to match pattern")
+                                            .addExample("Hamlet, Act III, Scene I")
+                                            .addExample("Romeo and Juliet (1595)").addExample("Sonnets, No. 18")
+                                            .explanation("Attribution sources must follow the specified format pattern")
+                                            .build())
+                            .build());
                 }
             }
         }
     }
-    
-    private void validateContent(String content, VerseBlock.ContentConfig config,
-                               BlockValidationContext context,
-                               StructuralNode block,
-                               List<ValidationMessage> messages,
-                               VerseBlock verseConfig) {
-        
+
+    private void validateContent(String content, VerseBlock.ContentConfig config, BlockValidationContext context,
+            StructuralNode block, List<ValidationMessage> messages, VerseBlock verseConfig) {
+
         // Check if content is required
         if (config.isRequired() && (content == null || content.trim().isEmpty())) {
             // Report error on the [verse] line, not the block delimiter
             SourceLocation verseLocation = context.createLocation(block, 1, 1);
-            SourceLocation contentLocation = SourceLocation.builder()
-                .filename(verseLocation.getFilename())
-                .startLine(verseLocation.getStartLine() - 1)  // [verse] line is before ____
-                .endLine(verseLocation.getStartLine() - 1)
-                .startColumn(1)
-                .endColumn(1)
-                .build();
-                
-            messages.add(ValidationMessage.builder()
-                .severity(verseConfig.getSeverity())
-                .ruleId(CONTENT_REQUIRED)
-                .location(contentLocation)
-                .message("Verse block requires content")
-                .actualValue("No content")
-                .expectedValue("Content required")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint("Content")
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add content to verse block")
-                    .addExample("To be or not to be, that is the question")
-                    .addExample("Roses are red,\nViolets are blue")
-                    .addExample("Two roads diverged in a yellow wood")
-                    .explanation("Verse blocks must contain the actual verse or poem content")
-                    .build())
-                .build());
+            SourceLocation contentLocation = SourceLocation.builder().filename(verseLocation.getFilename())
+                    .startLine(verseLocation.getStartLine() - 1) // [verse] line is before ____
+                    .endLine(verseLocation.getStartLine() - 1).startColumn(1).endColumn(1).build();
+
+            messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(CONTENT_REQUIRED)
+                    .location(contentLocation).message("Verse block requires content").actualValue("No content")
+                    .expectedValue("Content required").errorType(ErrorType.MISSING_VALUE).missingValueHint("Content")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add content to verse block")
+                            .addExample("To be or not to be, that is the question")
+                            .addExample("Roses are red,\nViolets are blue")
+                            .addExample("Two roads diverged in a yellow wood")
+                            .explanation("Verse blocks must contain the actual verse or poem content").build())
+                    .build());
             return;
         }
-        
+
         // Validate content length
         int contentLength = content != null ? content.length() : 0;
         if (config.getMinLength() != null && contentLength < config.getMinLength()) {
             SourcePosition pos = findContentPosition(block, context);
-            messages.add(ValidationMessage.builder()
-                .severity(verseConfig.getSeverity())
-                .ruleId(CONTENT_MIN_LENGTH)
-                .location(SourceLocation.builder()
-                    .filename(context.getFilename())
-                    .fromPosition(pos)
-                    .build())
-                .message("Verse content is too short")
-                .actualValue(contentLength + " characters")
-                .expectedValue("At least " + config.getMinLength() + " characters")
-                .addSuggestion(Suggestion.builder()
-                    .description("Add more content to verse block")
-                    .addExample("Include complete verses or stanzas")
-                    .addExample("Add additional lines of poetry")
-                    .addExample("Include full quotations")
-                    .explanation("Verse content should meet the minimum length requirement")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(CONTENT_MIN_LENGTH)
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .message("Verse content is too short").actualValue(contentLength + " characters")
+                    .expectedValue("At least " + config.getMinLength() + " characters")
+                    .addSuggestion(Suggestion.builder().description("Add more content to verse block")
+                            .addExample("Include complete verses or stanzas")
+                            .addExample("Add additional lines of poetry").addExample("Include full quotations")
+                            .explanation("Verse content should meet the minimum length requirement").build())
+                    .build());
         }
-        
+
         if (content != null) {
             if (config.getMaxLength() != null && content.length() > config.getMaxLength()) {
                 SourcePosition pos = findContentPosition(block, context);
-                messages.add(ValidationMessage.builder()
-                    .severity(verseConfig.getSeverity())
-                    .ruleId(CONTENT_MAX_LENGTH)
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .message("Verse content is too long")
-                    .actualValue(content.length() + " characters")
-                    .expectedValue("At most " + config.getMaxLength() + " characters")
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten verse content")
-                        .addExample("Use selected stanzas only")
-                        .addExample("Quote key lines instead of full text")
-                        .addExample("Split into multiple verse blocks")
-                        .explanation("Verse content should not exceed the maximum length limit")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(CONTENT_MAX_LENGTH)
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .message("Verse content is too long").actualValue(content.length() + " characters")
+                        .expectedValue("At most " + config.getMaxLength() + " characters")
+                        .addSuggestion(Suggestion.builder().description("Shorten verse content")
+                                .addExample("Use selected stanzas only")
+                                .addExample("Quote key lines instead of full text")
+                                .addExample("Split into multiple verse blocks")
+                                .explanation("Verse content should not exceed the maximum length limit").build())
+                        .build());
             }
-            
+
             // Validate pattern if specified
             if (config.getPattern() != null) {
                 if (!config.getPattern().matcher(content).matches()) {
                     SourcePosition pos = findContentPosition(block, context);
-                    messages.add(ValidationMessage.builder()
-                        .severity(verseConfig.getSeverity())
-                        .ruleId(CONTENT_PATTERN)
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .message("Verse content does not match required pattern")
-                        .actualValue(content.substring(0, Math.min(content.length(), 50)) + "...")
-                        .expectedValue("Pattern: " + config.getPattern().pattern())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Format verse content to match pattern")
-                            .addExample("Ensure proper line breaks")
-                            .addExample("Use correct punctuation")
-                            .addExample("Follow required verse structure")
-                            .explanation("Verse content must follow the specified format pattern")
-                            .build())
-                        .build());
+                    messages.add(ValidationMessage.builder().severity(verseConfig.getSeverity()).ruleId(CONTENT_PATTERN)
+                            .location(
+                                    SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                            .message("Verse content does not match required pattern")
+                            .actualValue(content.substring(0, Math.min(content.length(), 50)) + "...")
+                            .expectedValue("Pattern: " + config.getPattern().pattern())
+                            .addSuggestion(Suggestion.builder().description("Format verse content to match pattern")
+                                    .addExample("Ensure proper line breaks").addExample("Use correct punctuation")
+                                    .addExample("Follow required verse structure")
+                                    .explanation("Verse content must follow the specified format pattern").build())
+                            .build());
                 }
             }
         }
     }
-    
+
     /**
      * Finds the position of author in [verse] attribute line.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int blockLineNum = block.getSourceLocation().getLineNumber();
-        
+
         // [verse] line is typically one or two lines before the block delimiter ____
         for (int offset = -2; offset <= 0; offset++) {
             int checkLine = blockLineNum + offset;
@@ -507,21 +397,22 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, blockLineNum);
     }
-    
+
     /**
      * Finds the position of attribution in [verse] attribute line.
      */
     private SourcePosition findAttributionPosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int blockLineNum = block.getSourceLocation().getLineNumber();
-        
+
         // [verse] line is typically one or two lines before the block delimiter ____
         for (int offset = -2; offset <= 0; offset++) {
             int checkLine = blockLineNum + offset;
@@ -535,7 +426,7 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
                     int quoteStart = -1;
                     int quoteEnd = -1;
                     int searchPos = 0;
-                    
+
                     // Find the second quoted string (first is author, second is attribution)
                     while (searchPos < line.length() && quoteCount < 2) {
                         int nextQuoteStart = line.indexOf("\"", searchPos);
@@ -557,34 +448,35 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
                             break; // No more quotes found
                         }
                     }
-                    
+
                     if (quoteStart >= 0 && quoteEnd > quoteStart) {
                         // Return position of the content between quotes, excluding the quotes
                         // Column positions are 1-based
                         return new SourcePosition(quoteStart + 2, quoteEnd, checkLine);
                     }
-                    
+
                     // If we can't find the third parameter, return a default position
                     return new SourcePosition(1, 1, checkLine);
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, blockLineNum);
     }
-    
+
     /**
      * Finds the position of verse content.
      */
     private SourcePosition findContentPosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int blockLineNum = block.getSourceLocation().getLineNumber();
         String content = getBlockContent(block);
-        
+
         if (content != null && !content.isEmpty()) {
             // Content is between the ____ delimiters
             // Find the first line of actual content
@@ -596,11 +488,9 @@ public final class VerseBlockValidator extends AbstractBlockValidator<VerseBlock
                 }
             }
         }
-        
+
         // Default to block line
         return new SourcePosition(1, 1, blockLineNum);
     }
-    
-    
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidator.java
@@ -22,437 +22,357 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
  * Validator for video blocks in AsciiDoc documents.
- * 
- * Validates video blocks based on the YAML schema configuration including:
- * - URL validation (required and pattern matching)
- * - Dimension constraints (width and height)
- * - Poster image validation
- * - Controls requirement
- * - Caption validation
+ *
+ * Validates video blocks based on the YAML schema configuration including: - URL validation (required and pattern
+ * matching) - Dimension constraints (width and height) - Poster image validation - Controls requirement - Caption
+ * validation
  */
-public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock> {    
+public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock> {
     @Override
     public BlockType getSupportedType() {
         return BlockType.VIDEO;
     }
-    
+
     @Override
     protected Class<VideoBlock> getBlockConfigClass() {
         return VideoBlock.class;
     }
-    
+
     @Override
-    protected List<ValidationMessage> performSpecificValidations(StructuralNode node, 
-                                                               VideoBlock videoConfig,
-                                                               BlockValidationContext context) {
+    protected List<ValidationMessage> performSpecificValidations(StructuralNode node, VideoBlock videoConfig,
+            BlockValidationContext context) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         // Validate URL
         if (videoConfig.getUrl() != null) {
             validateUrl(node, videoConfig, messages, context);
         }
-        
+
         // Validate dimensions
         if (videoConfig.getWidth() != null) {
             validateDimension(node, videoConfig, WIDTH, videoConfig.getWidth(), messages, context);
         }
-        
+
         if (videoConfig.getHeight() != null) {
             validateDimension(node, videoConfig, HEIGHT, videoConfig.getHeight(), messages, context);
         }
-        
+
         // Validate poster
         if (videoConfig.getPoster() != null) {
             validatePoster(node, videoConfig, messages, context);
         }
-        
+
         // Validate options (controls)
         if (videoConfig.getOptions() != null && videoConfig.getOptions().getControls() != null) {
             validateControls(node, videoConfig, messages, context);
         }
-        
+
         // Validate caption
         if (videoConfig.getCaption() != null) {
             validateCaption(node, videoConfig, messages, context);
         }
-        
+
         return messages;
     }
-    
-    private void validateUrl(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
+
+    private void validateUrl(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages,
+            BlockValidationContext context) {
         VideoBlock.UrlConfig urlConfig = videoConfig.getUrl();
         String url = (String) node.getAttribute(TARGET);
-        
+
         // Determine severity
         Severity severity = resolveSeverity(urlConfig.getSeverity(), videoConfig.getSeverity());
-        
+
         // Check if required
         if (Boolean.TRUE.equals(urlConfig.getRequired()) && (url == null || url.trim().isEmpty())) {
             SourcePosition pos = findSourcePosition(node, context, url);
-            messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(URL_REQUIRED)
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(URL_REQUIRED)
                     .message("Video URL is required but not provided")
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint("target")
-                    .placeholderContext(PlaceholderContext.builder()
-                        .type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Add a video URL using the target attribute")
-                        .addExample("video::https://www.youtube.com/embed/VIDEO_ID[width=640,height=360]")
-                        .addExample("video::path/to/video.mp4[]")
-                        .build())
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("target")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.SIMPLE_VALUE).build())
+                    .addSuggestion(Suggestion.builder().description("Add a video URL using the target attribute")
+                            .addExample("video::https://www.youtube.com/embed/VIDEO_ID[width=640,height=360]")
+                            .addExample("video::path/to/video.mp4[]").build())
                     .build());
             return;
         }
-        
+
         // Check pattern
         if (url != null && urlConfig.getPattern() != null) {
             Pattern pattern = urlConfig.getPattern();
             if (!pattern.matcher(url).matches()) {
                 SourcePosition pos = findSourcePosition(node, context, url);
-                messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(URL_PATTERN)
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(URL_PATTERN)
                         .message("Video URL does not match required pattern")
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .errorType(ErrorType.INVALID_PATTERN)
-                        .actualValue(url)
-                        .expectedValue(pattern.pattern())
-                        .addSuggestion(Suggestion.builder()
-                            .description("Use a URL matching the required pattern")
-                            .addExample("For YouTube: https://www.youtube.com/embed/VIDEO_ID")
-                            .addExample("For Vimeo: https://player.vimeo.com/video/VIDEO_ID")
-                            .addExample("For local files: path/to/video.mp4")
-                            .build())
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .errorType(ErrorType.INVALID_PATTERN).actualValue(url).expectedValue(pattern.pattern())
+                        .addSuggestion(Suggestion.builder().description("Use a URL matching the required pattern")
+                                .addExample("For YouTube: https://www.youtube.com/embed/VIDEO_ID")
+                                .addExample("For Vimeo: https://player.vimeo.com/video/VIDEO_ID")
+                                .addExample("For local files: path/to/video.mp4").build())
                         .build());
             }
         }
     }
-    
-    private void validateDimension(StructuralNode node, VideoBlock videoConfig, String dimensionType, 
-                                  VideoBlock.DimensionConfig dimensionConfig, List<ValidationMessage> messages, BlockValidationContext context) {
+
+    private void validateDimension(StructuralNode node, VideoBlock videoConfig, String dimensionType,
+            VideoBlock.DimensionConfig dimensionConfig, List<ValidationMessage> messages,
+            BlockValidationContext context) {
         String dimensionStr = (String) node.getAttribute(dimensionType);
-        
+
         // Determine severity
         Severity severity = resolveSeverity(dimensionConfig.getSeverity(), videoConfig.getSeverity());
-        
+
         // Check if required
-        if (Boolean.TRUE.equals(dimensionConfig.getRequired()) && 
-            (dimensionStr == null || dimensionStr.trim().isEmpty())) {
+        if (Boolean.TRUE.equals(dimensionConfig.getRequired())
+                && (dimensionStr == null || dimensionStr.trim().isEmpty())) {
             SourcePosition pos = findSourcePosition(node, context, dimensionType, dimensionStr);
-            
+
             // Check if there are existing attributes
             boolean hasOtherAttributes = false;
             if (dimensionType.equals(WIDTH)) {
-                hasOtherAttributes = node.getAttribute(HEIGHT) != null || 
-                                   node.getAttribute(POSTER) != null || 
-                                   node.getAttribute(OPTIONS) != null;
+                hasOtherAttributes = node.getAttribute(HEIGHT) != null || node.getAttribute(POSTER) != null
+                        || node.getAttribute(OPTIONS) != null;
             } else if (dimensionType.equals(HEIGHT)) {
-                hasOtherAttributes = node.getAttribute(WIDTH) != null || 
-                                   node.getAttribute(POSTER) != null || 
-                                   node.getAttribute(OPTIONS) != null;
+                hasOtherAttributes = node.getAttribute(WIDTH) != null || node.getAttribute(POSTER) != null
+                        || node.getAttribute(OPTIONS) != null;
             }
-            
-            messages.add(ValidationMessage.builder()
-                    .severity(severity)
+
+            messages.add(ValidationMessage.builder().severity(severity)
                     .ruleId(dimensionType.equals(WIDTH) ? WIDTH_REQUIRED : HEIGHT_REQUIRED)
                     .message(String.format("Video %s is required but not provided", dimensionType))
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint(dimensionType.equals(WIDTH) ? "640" : "360")
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint(dimensionType.equals(WIDTH) ? "640" : "360")
                     .placeholderContext(PlaceholderContext.builder()
-                        .type(hasOtherAttributes ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST : 
-                                                  PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
-                        .attributeName(dimensionType)
-                        .hasExistingAttributes(hasOtherAttributes)
-                        .build())
+                            .type(hasOtherAttributes
+                                    ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST
+                                    : PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
+                            .attributeName(dimensionType).hasExistingAttributes(hasOtherAttributes).build())
                     .addSuggestion(Suggestion.builder()
-                        .description(String.format("Add %s attribute to video block", dimensionType))
-                        .addExample(String.format("video::video.mp4[%s=640]", dimensionType))
-                        .addExample("Common 16:9 dimensions: width=640,height=360 or width=1280,height=720")
-                        .build())
+                            .description(String.format("Add %s attribute to video block", dimensionType))
+                            .addExample(String.format("video::video.mp4[%s=640]", dimensionType))
+                            .addExample("Common 16:9 dimensions: width=640,height=360 or width=1280,height=720")
+                            .build())
                     .build());
             return;
         }
-        
+
         // Validate dimension value
         if (dimensionStr != null) {
             try {
                 int value = Integer.parseInt(dimensionStr);
-                
+
                 if (dimensionConfig.getMinValue() != null && value < dimensionConfig.getMinValue()) {
-                    messages.add(ValidationMessage.builder()
-                            .severity(severity)
+                    messages.add(ValidationMessage.builder().severity(severity)
                             .ruleId(dimensionType.equals(WIDTH) ? WIDTH_MIN : HEIGHT_MIN)
                             .message(String.format("Video %s is below minimum value", dimensionType))
-                            .location(context.createLocation(node))
-                            .errorType(ErrorType.OUT_OF_RANGE)
+                            .location(context.createLocation(node)).errorType(ErrorType.OUT_OF_RANGE)
                             .actualValue(String.valueOf(value))
                             .expectedValue(String.format(">= %d", dimensionConfig.getMinValue()))
                             .addSuggestion(Suggestion.builder()
-                                .description(String.format("Increase %s to at least %d pixels", dimensionType, dimensionConfig.getMinValue()))
-                                .addExample(String.format("%s=%d", dimensionType, dimensionConfig.getMinValue()))
-                                .build())
+                                    .description(String.format("Increase %s to at least %d pixels", dimensionType,
+                                            dimensionConfig.getMinValue()))
+                                    .addExample(String.format("%s=%d", dimensionType, dimensionConfig.getMinValue()))
+                                    .build())
                             .build());
                 }
-                
+
                 if (dimensionConfig.getMaxValue() != null && value > dimensionConfig.getMaxValue()) {
-                    messages.add(ValidationMessage.builder()
-                            .severity(severity)
+                    messages.add(ValidationMessage.builder().severity(severity)
                             .ruleId(dimensionType.equals(WIDTH) ? WIDTH_MAX : HEIGHT_MAX)
                             .message(String.format("Video %s exceeds maximum value", dimensionType))
-                            .location(context.createLocation(node))
-                            .errorType(ErrorType.OUT_OF_RANGE)
+                            .location(context.createLocation(node)).errorType(ErrorType.OUT_OF_RANGE)
                             .actualValue(String.valueOf(value))
                             .expectedValue(String.format("<= %d", dimensionConfig.getMaxValue()))
                             .addSuggestion(Suggestion.builder()
-                                .description(String.format("Reduce %s to at most %d pixels", dimensionType, dimensionConfig.getMaxValue()))
-                                .addExample(String.format("%s=%d", dimensionType, dimensionConfig.getMaxValue()))
-                                .build())
+                                    .description(String.format("Reduce %s to at most %d pixels", dimensionType,
+                                            dimensionConfig.getMaxValue()))
+                                    .addExample(String.format("%s=%d", dimensionType, dimensionConfig.getMaxValue()))
+                                    .build())
                             .build());
                 }
             } catch (NumberFormatException e) {
-                messages.add(ValidationMessage.builder()
-                        .severity(severity)
+                messages.add(ValidationMessage.builder().severity(severity)
                         .ruleId(dimensionType.equals(WIDTH) ? WIDTH_INVALID : HEIGHT_INVALID)
                         .message(String.format("Video %s is not a valid number", dimensionType))
-                        .location(context.createLocation(node))
-                        .errorType(ErrorType.INVALID_PATTERN)
-                        .actualValue(dimensionStr)
-                        .expectedValue("numeric value")
+                        .location(context.createLocation(node)).errorType(ErrorType.INVALID_PATTERN)
+                        .actualValue(dimensionStr).expectedValue("numeric value")
                         .addSuggestion(Suggestion.builder()
-                            .description(String.format("Use a numeric value for %s", dimensionType))
-                            .addExample(String.format("%s=640", dimensionType))
-                            .build())
+                                .description(String.format("Use a numeric value for %s", dimensionType))
+                                .addExample(String.format("%s=640", dimensionType)).build())
                         .build());
             }
         }
     }
-    
-    private void validatePoster(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
+
+    private void validatePoster(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages,
+            BlockValidationContext context) {
         VideoBlock.PosterConfig posterConfig = videoConfig.getPoster();
         String poster = (String) node.getAttribute(POSTER);
-        
+
         // Determine severity
         Severity severity = resolveSeverity(posterConfig.getSeverity(), videoConfig.getSeverity());
-        
+
         // Check if required
         if (Boolean.TRUE.equals(posterConfig.getRequired()) && (poster == null || poster.trim().isEmpty())) {
             SourcePosition pos = findPosterPosition(node, context, poster);
-            
+
             // Check if there are existing attributes
-            boolean hasOtherAttributes = node.getAttribute(WIDTH) != null || 
-                                       node.getAttribute(HEIGHT) != null || 
-                                       node.getAttribute(OPTIONS) != null;
-            
-            messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(POSTER_REQUIRED)
+            boolean hasOtherAttributes = node.getAttribute(WIDTH) != null || node.getAttribute(HEIGHT) != null
+                    || node.getAttribute(OPTIONS) != null;
+
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(POSTER_REQUIRED)
                     .message("Video poster image is required but not provided")
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint("thumbnail.jpg")
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint("thumbnail.jpg")
                     .placeholderContext(PlaceholderContext.builder()
-                        .type(hasOtherAttributes ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST : 
-                                                  PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
-                        .attributeName("poster")
-                        .hasExistingAttributes(hasOtherAttributes)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Add a poster image for the video")
-                        .addExample("video::video.mp4[poster=thumbnail.jpg]")
-                        .addExample("poster=images/video-preview.png")
-                        .build())
+                            .type(hasOtherAttributes
+                                    ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST
+                                    : PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
+                            .attributeName("poster").hasExistingAttributes(hasOtherAttributes).build())
+                    .addSuggestion(Suggestion.builder().description("Add a poster image for the video")
+                            .addExample("video::video.mp4[poster=thumbnail.jpg]")
+                            .addExample("poster=images/video-preview.png").build())
                     .build());
             return;
         }
-        
+
         // Check pattern
         if (poster != null && posterConfig.getPattern() != null) {
             Pattern pattern = posterConfig.getPattern();
             if (!pattern.matcher(poster).matches()) {
                 SourcePosition pos = findPosterPosition(node, context, poster);
-                messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(POSTER_PATTERN)
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(POSTER_PATTERN)
                         .message("Video poster does not match required pattern")
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .errorType(ErrorType.INVALID_PATTERN)
-                        .actualValue(poster)
-                        .expectedValue(pattern.pattern())
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .errorType(ErrorType.INVALID_PATTERN).actualValue(poster).expectedValue(pattern.pattern())
                         .addSuggestion(Suggestion.builder()
-                            .description("Use a poster image path matching the required pattern")
-                            .addExample("Common image formats: .jpg, .jpeg, .png, .webp")
-                            .build())
+                                .description("Use a poster image path matching the required pattern")
+                                .addExample("Common image formats: .jpg, .jpeg, .png, .webp").build())
                         .build());
             }
         }
     }
-    
-    private void validateControls(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
+
+    private void validateControls(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages,
+            BlockValidationContext context) {
         VideoBlock.ControlsConfig controlsConfig = videoConfig.getOptions().getControls();
         String controlsAttr = (String) node.getAttribute(OPTIONS);
-        
+
         // Determine severity
         Severity severity = resolveSeverity(controlsConfig.getSeverity(), videoConfig.getSeverity());
-        
+
         // Check if controls are required
         if (Boolean.TRUE.equals(controlsConfig.getRequired())) {
             boolean hasControls = controlsAttr != null && controlsAttr.contains("controls");
-            
+
             if (!hasControls) {
                 SourcePosition pos = findSourcePosition(node, context);
-                
+
                 // Check if there are existing attributes
-                boolean hasOtherAttributes = node.getAttribute(WIDTH) != null || 
-                                           node.getAttribute(HEIGHT) != null || 
-                                           node.getAttribute(POSTER) != null;
-                
-                messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(CONTROLS_REQUIRED)
+                boolean hasOtherAttributes = node.getAttribute(WIDTH) != null || node.getAttribute(HEIGHT) != null
+                        || node.getAttribute(POSTER) != null;
+
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(CONTROLS_REQUIRED)
                         .message("Video controls are required but not enabled")
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .errorType(ErrorType.MISSING_VALUE)
-                        .missingValueHint("controls")
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .errorType(ErrorType.MISSING_VALUE).missingValueHint("controls")
                         .placeholderContext(PlaceholderContext.builder()
-                            .type(hasOtherAttributes ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST : 
-                                                      PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
-                            .attributeName("options")
-                            .hasExistingAttributes(hasOtherAttributes)
-                            .build())
-                        .actualValue(controlsAttr)
-                        .expectedValue("controls")
-                        .addSuggestion(Suggestion.builder()
-                            .description("Enable video player controls")
-                            .addExample("video::video.mp4[options=controls]")
-                            .addExample("video::video.mp4[opts=controls]")
-                            .build())
+                                .type(hasOtherAttributes
+                                        ? PlaceholderContext.PlaceholderType.ATTRIBUTE_IN_LIST
+                                        : PlaceholderContext.PlaceholderType.ATTRIBUTE_VALUE)
+                                .attributeName("options").hasExistingAttributes(hasOtherAttributes).build())
+                        .actualValue(controlsAttr).expectedValue("controls")
+                        .addSuggestion(Suggestion.builder().description("Enable video player controls")
+                                .addExample("video::video.mp4[options=controls]")
+                                .addExample("video::video.mp4[opts=controls]").build())
                         .build());
             }
         }
     }
-    
-    private void validateCaption(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages, BlockValidationContext context) {
+
+    private void validateCaption(StructuralNode node, VideoBlock videoConfig, List<ValidationMessage> messages,
+            BlockValidationContext context) {
         VideoBlock.CaptionConfig captionConfig = videoConfig.getCaption();
         String caption = (String) node.getAttribute(CAPTION);
-        
+
         // If no caption attribute, check for title
         if (caption == null) {
             caption = node.getTitle();
         }
-        
+
         // Determine severity
         Severity severity = resolveSeverity(captionConfig.getSeverity(), videoConfig.getSeverity());
-        
+
         // Check if required
         if (Boolean.TRUE.equals(captionConfig.getRequired()) && (caption == null || caption.trim().isEmpty())) {
             SourcePosition pos = findCaptionPosition(node, context);
-            messages.add(ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(CAPTION_REQUIRED)
+            messages.add(ValidationMessage.builder().severity(severity).ruleId(CAPTION_REQUIRED)
                     .message("Video caption is required but not provided")
-                    .location(SourceLocation.builder()
-                        .filename(context.getFilename())
-                        .fromPosition(pos)
-                        .build())
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint(".Video Title")
-                    .placeholderContext(PlaceholderContext.builder()
-                        .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Add a caption or title to the video")
-                        .addExample(".Video Title\nvideo::video.mp4[]")
-                        .addExample("video::video.mp4[caption=\"My Video\"]")
-                        .build())
+                    .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint(".Video Title")
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add a caption or title to the video")
+                            .addExample(".Video Title\nvideo::video.mp4[]")
+                            .addExample("video::video.mp4[caption=\"My Video\"]").build())
                     .build());
             return;
         }
-        
+
         // Check length constraints
         if (caption != null) {
             int length = caption.length();
-            
+
             if (captionConfig.getMinLength() != null && length < captionConfig.getMinLength()) {
                 SourcePosition pos = findCaptionPosition(node, context);
-                messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(CAPTION_MIN_LENGTH)
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(CAPTION_MIN_LENGTH)
                         .message("Video caption is too short")
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .errorType(ErrorType.OUT_OF_RANGE)
-                        .actualValue(String.format("%d characters", length))
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .errorType(ErrorType.OUT_OF_RANGE).actualValue(String.format("%d characters", length))
                         .expectedValue(String.format(">= %d characters", captionConfig.getMinLength()))
-                        .addSuggestion(Suggestion.builder()
-                            .description("Provide a more descriptive caption")
-                            .addExample(String.format("Caption should be at least %d characters", captionConfig.getMinLength()))
-                            .build())
+                        .addSuggestion(Suggestion.builder().description("Provide a more descriptive caption")
+                                .addExample(String.format("Caption should be at least %d characters",
+                                        captionConfig.getMinLength()))
+                                .build())
                         .build());
             }
-            
+
             if (captionConfig.getMaxLength() != null && length > captionConfig.getMaxLength()) {
                 SourcePosition pos = findCaptionPosition(node, context);
-                messages.add(ValidationMessage.builder()
-                        .severity(severity)
-                        .ruleId(CAPTION_MAX_LENGTH)
+                messages.add(ValidationMessage.builder().severity(severity).ruleId(CAPTION_MAX_LENGTH)
                         .message("Video caption is too long")
-                        .location(SourceLocation.builder()
-                            .filename(context.getFilename())
-                            .fromPosition(pos)
-                            .build())
-                        .errorType(ErrorType.OUT_OF_RANGE)
-                        .actualValue(String.format("%d characters", length))
+                        .location(SourceLocation.builder().filename(context.getFilename()).fromPosition(pos).build())
+                        .errorType(ErrorType.OUT_OF_RANGE).actualValue(String.format("%d characters", length))
                         .expectedValue(String.format("<= %d characters", captionConfig.getMaxLength()))
-                        .addSuggestion(Suggestion.builder()
-                            .description("Shorten the caption to fit the limit")
-                            .addExample(String.format("Caption should be at most %d characters", captionConfig.getMaxLength()))
-                            .build())
+                        .addSuggestion(Suggestion.builder().description("Shorten the caption to fit the limit")
+                                .addExample(String.format("Caption should be at most %d characters",
+                                        captionConfig.getMaxLength()))
+                                .build())
                         .build());
             }
         }
     }
-    
+
     /**
      * Finds the column position of URL in video macro.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context, String url) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for video:: macro pattern
         int videoStart = sourceLine.indexOf("video::");
         if (videoStart >= 0) {
@@ -460,7 +380,7 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
             if (urlEnd == -1) {
                 urlEnd = sourceLine.length();
             }
-            
+
             if (url != null && !url.isEmpty()) {
                 // Find the specific URL position
                 int urlStart = sourceLine.indexOf(url, videoStart + 7);
@@ -472,41 +392,42 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                 return new SourcePosition(videoStart + 8, videoStart + 8, lineNum);
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
     /**
      * Finds the column position of a dimension attribute (width/height) in video macro.
      */
-    private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context, 
-                                                   String dimensionType, String dimensionValue) {
+    private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context,
+            String dimensionType, String dimensionValue) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for attributes bracket
         int bracketStart = sourceLine.indexOf("[");
         if (bracketStart >= 0) {
             int bracketEnd = sourceLine.indexOf("]", bracketStart);
             if (bracketEnd > bracketStart) {
                 String attributes = sourceLine.substring(bracketStart + 1, bracketEnd);
-                
+
                 if (dimensionValue != null && !dimensionValue.isEmpty()) {
                     // Find specific dimension
                     String pattern = dimensionType + "=" + dimensionValue;
                     int dimStart = attributes.indexOf(pattern);
                     if (dimStart >= 0) {
-                        return new SourcePosition(bracketStart + 2 + dimStart, 
-                                                   bracketStart + 2 + dimStart + pattern.length() - 1, lineNum);
+                        return new SourcePosition(bracketStart + 2 + dimStart,
+                                bracketStart + 2 + dimStart + pattern.length() - 1, lineNum);
                     }
                 } else {
                     // Missing dimension - position at end of attributes
@@ -514,33 +435,34 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
     /**
      * Finds the column position of poster attribute in video macro.
      */
     private SourcePosition findPosterPosition(StructuralNode block, BlockValidationContext context, String poster) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for attributes bracket
         int bracketStart = sourceLine.indexOf("[");
         if (bracketStart >= 0) {
             int bracketEnd = sourceLine.indexOf("]", bracketStart);
             if (bracketEnd > bracketStart) {
                 String attributes = sourceLine.substring(bracketStart + 1, bracketEnd);
-                
+
                 if (poster != null && !poster.isEmpty()) {
                     // Find poster= pattern
                     String posterPattern = "poster=" + poster;
@@ -556,26 +478,27 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                 }
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
     /**
      * Finds the column position for controls attribute in video macro.
      */
     private SourcePosition findSourcePosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int lineNum = block.getSourceLocation().getLineNumber();
         if (lineNum <= 0 || lineNum > fileLines.size()) {
             return new SourcePosition(1, 1, lineNum);
         }
-        
+
         String sourceLine = fileLines.get(lineNum - 1);
-        
+
         // Look for attributes bracket
         int bracketStart = sourceLine.indexOf("[");
         if (bracketStart >= 0) {
@@ -584,29 +507,30 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                 return new SourcePosition(bracketEnd + 1, bracketEnd + 1, lineNum);
             }
         }
-        
+
         return new SourcePosition(1, 1, lineNum);
     }
-    
+
     /**
      * Finds the column position for caption in video macro.
      */
     private SourcePosition findCaptionPosition(StructuralNode block, BlockValidationContext context) {
         List<String> fileLines = fileCache.getFileLines(context.getFilename());
         if (fileLines.isEmpty() || block.getSourceLocation() == null) {
-            return new SourcePosition(1, 1, block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
+            return new SourcePosition(1, 1,
+                    block.getSourceLocation() != null ? block.getSourceLocation().getLineNumber() : 1);
         }
-        
+
         int videoLineNum = block.getSourceLocation().getLineNumber();
         String caption = block.getTitle();
-        
+
         // Caption (title) is typically on the line before the video macro
         if (caption != null && !caption.isEmpty() && videoLineNum > 1) {
             // Check line before video
             int captionLineNum = videoLineNum - 1;
             if (captionLineNum <= fileLines.size()) {
                 String captionLine = fileLines.get(captionLineNum - 1);
-                
+
                 // Check if line starts with "." followed by caption
                 if (captionLine.startsWith(".")) {
                     // Caption starts at column 1 (the dot) and ends at the line length
@@ -614,13 +538,9 @@ public final class VideoBlockValidator extends AbstractBlockValidator<VideoBlock
                 }
             }
         }
-        
+
         // Default to video line if caption not found
         return new SourcePosition(1, 1, videoLineNum);
     }
-    
-    
-    
-    
-    
+
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/AttributeRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/AttributeRule.java
@@ -6,10 +6,10 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 public interface AttributeRule {
-    
+
     String getRuleId();
-    
+
     List<ValidationMessage> validate(String attributeName, String value, SourceLocation location);
-    
+
     boolean isApplicable(String attributeName);
 }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/LengthRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/LengthRule.java
@@ -32,51 +32,45 @@ public final class LengthRule implements AttributeRule {
     @Override
     public List<ValidationMessage> validate(String attributeName, String value, SourceLocation location) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         LengthConfig config = lengthConfigs.get(attributeName);
         if (config != null && value != null) {
             int length = value.length();
-            
+
             if (config.hasMinLength() && length < config.getMinLength()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(config.getSeverity())
-                    .ruleId(LENGTH_MIN)
-                    .message("Attribute '" + attributeName + "' is too short: actual '" + value + "' (" + length + " characters), expected minimum " + config.getMinLength() + " characters")
-                    .location(location)
-                    .attributeName(attributeName)
-                    .actualValue(value + " (" + length + " characters)")
-                    .expectedValue("Minimum " + config.getMinLength() + " characters")
-                    .errorType(ErrorType.OUT_OF_RANGE)
-                    .addSuggestion(Suggestion.builder()
-                        .description("Provide a longer value for the attribute")
-                        .addExample("Add more descriptive content")
-                        .addExample("Expand the value to at least " + config.getMinLength() + " characters")
-                        .explanation("Attribute value must be at least " + config.getMinLength() + " characters long")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(LENGTH_MIN)
+                        .message("Attribute '" + attributeName + "' is too short: actual '" + value + "' (" + length
+                                + " characters), expected minimum " + config.getMinLength() + " characters")
+                        .location(location).attributeName(attributeName)
+                        .actualValue(value + " (" + length + " characters)")
+                        .expectedValue("Minimum " + config.getMinLength() + " characters")
+                        .errorType(ErrorType.OUT_OF_RANGE)
+                        .addSuggestion(Suggestion.builder().description("Provide a longer value for the attribute")
+                                .addExample("Add more descriptive content")
+                                .addExample("Expand the value to at least " + config.getMinLength() + " characters")
+                                .explanation("Attribute value must be at least " + config.getMinLength()
+                                        + " characters long")
+                                .build())
+                        .build());
             }
-            
+
             if (config.hasMaxLength() && length > config.getMaxLength()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(config.getSeverity())
-                    .ruleId(LENGTH_MAX)
-                    .message("Attribute '" + attributeName + "' is too long: actual '" + value + "' (" + length + " characters), expected maximum " + config.getMaxLength() + " characters")
-                    .location(location)
-                    .attributeName(attributeName)
-                    .actualValue(value + " (" + length + " characters)")
-                    .expectedValue("Maximum " + config.getMaxLength() + " characters")
-                    .errorType(ErrorType.OUT_OF_RANGE)
-                    .addSuggestion(Suggestion.builder()
-                        .description("Shorten the attribute value")
-                        .addExample("Reduce to " + config.getMaxLength() + " characters or less")
-                        .addExample("Use more concise wording")
-                        .addExample("Remove unnecessary details")
-                        .explanation("Attribute value must not exceed " + config.getMaxLength() + " characters")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(LENGTH_MAX)
+                        .message("Attribute '" + attributeName + "' is too long: actual '" + value + "' (" + length
+                                + " characters), expected maximum " + config.getMaxLength() + " characters")
+                        .location(location).attributeName(attributeName)
+                        .actualValue(value + " (" + length + " characters)")
+                        .expectedValue("Maximum " + config.getMaxLength() + " characters")
+                        .errorType(ErrorType.OUT_OF_RANGE)
+                        .addSuggestion(Suggestion.builder().description("Shorten the attribute value")
+                                .addExample("Reduce to " + config.getMaxLength() + " characters or less")
+                                .addExample("Use more concise wording").addExample("Remove unnecessary details")
+                                .explanation("Attribute value must not exceed " + config.getMaxLength() + " characters")
+                                .build())
+                        .build());
             }
         }
-        
+
         return messages;
     }
 
@@ -95,26 +89,27 @@ public final class LengthRule implements AttributeRule {
         private Builder() {
         }
 
-        public Builder addLengthConstraint(String attributeName, Integer minLength, Integer maxLength, Severity severity) {
+        public Builder addLengthConstraint(String attributeName, Integer minLength, Integer maxLength,
+                Severity severity) {
             Objects.requireNonNull(attributeName, "[" + getClass().getName() + "] attributeName must not be null");
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
-            
+
             if (minLength == null && maxLength == null) {
                 throw new IllegalArgumentException("At least one of minLength or maxLength must be specified");
             }
-            
+
             if (minLength != null && minLength < 0) {
                 throw new IllegalArgumentException("minLength must be non-negative");
             }
-            
+
             if (maxLength != null && maxLength < 1) {
                 throw new IllegalArgumentException("maxLength must be positive");
             }
-            
+
             if (minLength != null && maxLength != null && minLength > maxLength) {
                 throw new IllegalArgumentException("minLength cannot be greater than maxLength");
             }
-            
+
             lengthConfigs.put(attributeName, new LengthConfig(minLength, maxLength, severity));
             return this;
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/OrderRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/OrderRule.java
@@ -40,41 +40,41 @@ public final class OrderRule implements AttributeRule {
 
     public List<ValidationMessage> validateOrder() {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         for (Map.Entry<String, OrderConfig> entry : orderConfigs.entrySet()) {
             String attrName = entry.getKey();
             OrderConfig config = entry.getValue();
             AttributePosition actual = actualPositions.get(attrName);
-            
+
             if (actual != null && config.hasOrder()) {
                 for (Map.Entry<String, OrderConfig> otherEntry : orderConfigs.entrySet()) {
                     String otherAttrName = otherEntry.getKey();
                     OrderConfig otherConfig = otherEntry.getValue();
                     AttributePosition otherActual = actualPositions.get(otherAttrName);
-                    
+
                     if (!attrName.equals(otherAttrName) && otherActual != null && otherConfig.hasOrder()) {
                         if (config.getOrder() < otherConfig.getOrder() && actual.position > otherActual.position) {
-                            messages.add(ValidationMessage.builder()
-                                .severity(config.getSeverity())
-                                .ruleId(getRuleId())
-                                .message("Attribute '" + attrName + "' should appear before '" + otherAttrName + "': actual position line " + actual.location.getStartLine() + ", expected before line " + otherActual.location.getStartLine())
-                                .location(actual.location)
-                                .attributeName(attrName)
-                                .actualValue("Line " + actual.location.getStartLine())
-                                .expectedValue("Before line " + otherActual.location.getStartLine())
-                                .addSuggestion(Suggestion.builder()
-                                    .description("Reorder attributes according to configuration")
-                                    .addExample("Move ':" + attrName + ":' before ':" + otherAttrName + ":'")
-                                    .addExample("Rearrange document header attributes")
-                                    .explanation("Attributes should appear in the configured order for consistency")
-                                    .build())
-                                .build());
+                            messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(getRuleId())
+                                    .message("Attribute '" + attrName + "' should appear before '" + otherAttrName
+                                            + "': actual position line " + actual.location.getStartLine()
+                                            + ", expected before line " + otherActual.location.getStartLine())
+                                    .location(actual.location).attributeName(attrName)
+                                    .actualValue("Line " + actual.location.getStartLine())
+                                    .expectedValue("Before line " + otherActual.location.getStartLine())
+                                    .addSuggestion(Suggestion.builder()
+                                            .description("Reorder attributes according to configuration")
+                                            .addExample("Move ':" + attrName + ":' before ':" + otherAttrName + ":'")
+                                            .addExample("Rearrange document header attributes")
+                                            .explanation(
+                                                    "Attributes should appear in the configured order for consistency")
+                                            .build())
+                                    .build());
                         }
                     }
                 }
             }
         }
-        
+
         return messages;
     }
 
@@ -91,7 +91,7 @@ public final class OrderRule implements AttributeRule {
         public Builder addOrderConstraint(String attributeName, Integer order, Severity severity) {
             Objects.requireNonNull(attributeName, "[" + getClass().getName() + "] attributeName must not be null");
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
-            
+
             orderConfigs.put(attributeName, new OrderConfig(order, severity));
             return this;
         }

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/PatternRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/PatternRule.java
@@ -32,29 +32,25 @@ public final class PatternRule implements AttributeRule {
     @Override
     public List<ValidationMessage> validate(String attributeName, String value, SourceLocation location) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         PatternConfig config = patternConfigs.get(attributeName);
         if (config != null && value != null && !value.isEmpty()) {
             if (!config.getPattern().matcher(value).matches()) {
-                messages.add(ValidationMessage.builder()
-                    .severity(config.getSeverity())
-                    .ruleId(getRuleId())
-                    .message("Attribute '" + attributeName + "' does not match required pattern: actual '" + value + "', expected pattern '" + config.getPatternString() + "'")
-                    .location(location)
-                    .attributeName(attributeName)
-                    .actualValue(value)
-                    .expectedValue("Pattern '" + config.getPatternString() + "'")
-                    .errorType(ErrorType.INVALID_PATTERN)
-                    .addSuggestion(Suggestion.builder()
-                        .description("Format attribute value to match pattern")
-                        .addExample(":" + attributeName + ": [value matching pattern]")
-                        .addExample("Check pattern: " + config.getPatternString())
-                        .explanation("Attribute value must match the configured regex pattern for validation")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(getRuleId())
+                        .message("Attribute '" + attributeName + "' does not match required pattern: actual '" + value
+                                + "', expected pattern '" + config.getPatternString() + "'")
+                        .location(location).attributeName(attributeName).actualValue(value)
+                        .expectedValue("Pattern '" + config.getPatternString() + "'")
+                        .errorType(ErrorType.INVALID_PATTERN)
+                        .addSuggestion(Suggestion.builder().description("Format attribute value to match pattern")
+                                .addExample(":" + attributeName + ": [value matching pattern]")
+                                .addExample("Check pattern: " + config.getPatternString())
+                                .explanation("Attribute value must match the configured regex pattern for validation")
+                                .build())
+                        .build());
             }
         }
-        
+
         return messages;
     }
 
@@ -77,14 +73,15 @@ public final class PatternRule implements AttributeRule {
             Objects.requireNonNull(attributeName, "[" + getClass().getName() + "] attributeName must not be null");
             Objects.requireNonNull(pattern, "[" + getClass().getName() + "] pattern must not be null");
             Objects.requireNonNull(severity, "[" + getClass().getName() + "] severity must not be null");
-            
+
             try {
                 Pattern compiledPattern = Pattern.compile(pattern);
                 patternConfigs.put(attributeName, new PatternConfig(compiledPattern, pattern, severity));
             } catch (PatternSyntaxException e) {
-                throw new IllegalArgumentException("Invalid pattern for attribute '" + attributeName + "': " + e.getMessage());
+                throw new IllegalArgumentException(
+                        "Invalid pattern for attribute '" + attributeName + "': " + e.getMessage());
             }
-            
+
             return this;
         }
 

--- a/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/RequiredRule.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/validator/rules/RequiredRule.java
@@ -32,32 +32,24 @@ public final class RequiredRule implements AttributeRule {
     @Override
     public List<ValidationMessage> validate(String attributeName, String value, SourceLocation location) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         RequiredAttribute config = requiredAttributes.get(attributeName);
         if (config != null && config.isRequired() && value == null) {
-            messages.add(ValidationMessage.builder()
-                .severity(config.getSeverity())
-                .ruleId(getRuleId())
-                .message("Missing required attribute '" + attributeName + "'")
-                .location(location)
-                .attributeName(attributeName)
-                .actualValue(null)
-                .expectedValue("Attribute must be present")
-                .errorType(ErrorType.MISSING_VALUE)
-                .missingValueHint(getPlaceholderHint(attributeName))
-                .placeholderContext(PlaceholderContext.builder()
-                    .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                    .build())
-                .addSuggestion(Suggestion.builder()
-                    .description("Add required attribute")
-                    .fixedValue(":" + attributeName + ": value")
-                    .addExample(":" + attributeName + ": example-value")
-                    .addExample(":" + attributeName + ": ${defaultValue}")
-                    .explanation("This attribute is required and must be defined in the document header")
-                    .build())
-                .build());
+            messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(getRuleId())
+                    .message("Missing required attribute '" + attributeName + "'").location(location)
+                    .attributeName(attributeName).actualValue(null).expectedValue("Attribute must be present")
+                    .errorType(ErrorType.MISSING_VALUE).missingValueHint(getPlaceholderHint(attributeName))
+                    .placeholderContext(
+                            PlaceholderContext.builder().type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                    .addSuggestion(Suggestion.builder().description("Add required attribute")
+                            .fixedValue(":" + attributeName + ": value")
+                            .addExample(":" + attributeName + ": example-value")
+                            .addExample(":" + attributeName + ": ${defaultValue}")
+                            .explanation("This attribute is required and must be defined in the document header")
+                            .build())
+                    .build());
         }
-        
+
         return messages;
     }
 
@@ -66,41 +58,32 @@ public final class RequiredRule implements AttributeRule {
         return requiredAttributes.containsKey(attributeName);
     }
 
-    public List<ValidationMessage> validateMissingAttributes(Set<String> presentAttributes, SourceLocation documentLocation) {
+    public List<ValidationMessage> validateMissingAttributes(Set<String> presentAttributes,
+            SourceLocation documentLocation) {
         List<ValidationMessage> messages = new ArrayList<>();
-        
+
         for (Map.Entry<String, RequiredAttribute> entry : requiredAttributes.entrySet()) {
             String attrName = entry.getKey();
             RequiredAttribute config = entry.getValue();
-            
+
             if (config.isRequired() && !presentAttributes.contains(attrName)) {
-                messages.add(ValidationMessage.builder()
-                    .severity(config.getSeverity())
-                    .ruleId(getRuleId())
-                    .message("Missing required attribute '" + attrName + "'")
-                    .location(documentLocation)
-                    .attributeName(attrName)
-                    .actualValue(null)
-                    .expectedValue("Attribute must be present")
-                    .errorType(ErrorType.MISSING_VALUE)
-                    .missingValueHint(getPlaceholderHint(attrName))
-                    .placeholderContext(PlaceholderContext.builder()
-                        .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE)
-                        .build())
-                    .addSuggestion(Suggestion.builder()
-                        .description("Add required attribute to document header")
-                        .fixedValue(":" + attrName + ": value")
-                        .addExample(":" + attrName + ": example-value")
-                        .addExample(":" + attrName + ": ${defaultValue}")
-                        .explanation("Required attributes must be defined in the document header")
-                        .build())
-                    .build());
+                messages.add(ValidationMessage.builder().severity(config.getSeverity()).ruleId(getRuleId())
+                        .message("Missing required attribute '" + attrName + "'").location(documentLocation)
+                        .attributeName(attrName).actualValue(null).expectedValue("Attribute must be present")
+                        .errorType(ErrorType.MISSING_VALUE).missingValueHint(getPlaceholderHint(attrName))
+                        .placeholderContext(PlaceholderContext.builder()
+                                .type(PlaceholderContext.PlaceholderType.INSERT_BEFORE).build())
+                        .addSuggestion(Suggestion.builder().description("Add required attribute to document header")
+                                .fixedValue(":" + attrName + ": value").addExample(":" + attrName + ": example-value")
+                                .addExample(":" + attrName + ": ${defaultValue}")
+                                .explanation("Required attributes must be defined in the document header").build())
+                        .build());
             }
         }
-        
+
         return messages;
     }
-    
+
     private String getPlaceholderHint(String attributeName) {
         return ":" + attributeName + ": value";
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/CLIRunnerOutputConfigTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/CLIRunnerOutputConfigTest.java
@@ -27,16 +27,14 @@ class CLIRunnerOutputConfigTest {
     @Test
     void testLoadPredefinedOutputConfig() throws IOException {
         CLIRunner runner = new CLIRunner();
-        
+
         // Test with predefined name
-        CLIConfig config = CLIConfig.builder()
-            .inputPatterns(java.util.List.of("*.adoc"))
-            .outputConfigFormat(OutputFormat.SIMPLE)
-            .build();
-        
+        CLIConfig config = CLIConfig.builder().inputPatterns(java.util.List.of("*.adoc"))
+                .outputConfigFormat(OutputFormat.SIMPLE).build();
+
         // Use reflection to access private method
         OutputConfiguration outputConfig = invokeLoadOutputConfiguration(runner, config);
-        
+
         assertNotNull(outputConfig);
         assertEquals(OutputFormat.SIMPLE, outputConfig.getFormat());
     }
@@ -44,24 +42,22 @@ class CLIRunnerOutputConfigTest {
     @Test
     void testLoadCustomOutputConfigFile() throws IOException {
         CLIRunner runner = new CLIRunner();
-        
+
         // Create a custom config file
         Path customConfig = tempDir.resolve("custom.yaml");
         Files.writeString(customConfig, """
-            output:
-              format: compact
-              display:
-                contextLines: 0
-                useColors: false
-            """);
-        
-        CLIConfig config = CLIConfig.builder()
-            .inputPatterns(java.util.List.of("*.adoc"))
-            .outputConfigFile(customConfig)
-            .build();
-        
+                output:
+                  format: compact
+                  display:
+                    contextLines: 0
+                    useColors: false
+                """);
+
+        CLIConfig config = CLIConfig.builder().inputPatterns(java.util.List.of("*.adoc")).outputConfigFile(customConfig)
+                .build();
+
         OutputConfiguration outputConfig = invokeLoadOutputConfiguration(runner, config);
-        
+
         assertNotNull(outputConfig);
         assertEquals(OutputFormat.COMPACT, outputConfig.getFormat());
         assertEquals(0, outputConfig.getDisplay().getContextLines());
@@ -71,39 +67,32 @@ class CLIRunnerOutputConfigTest {
     @Test
     void testDefaultOutputConfig() throws IOException {
         CLIRunner runner = new CLIRunner();
-        
+
         // No output config specified
-        CLIConfig config = CLIConfig.builder()
-            .inputPatterns(java.util.List.of("*.adoc"))
-            .build();
-        
+        CLIConfig config = CLIConfig.builder().inputPatterns(java.util.List.of("*.adoc")).build();
+
         OutputConfiguration outputConfig = invokeLoadOutputConfiguration(runner, config);
-        
+
         assertNotNull(outputConfig);
         // Should default to enhanced
         assertEquals(OutputFormat.ENHANCED, outputConfig.getFormat());
     }
 
-
     @Test
     void testNonExistentConfigFile() {
         CLIRunner runner = new CLIRunner();
-        
+
         Path nonExistentFile = Paths.get("non-existent-config.yaml");
-        CLIConfig config = CLIConfig.builder()
-            .inputPatterns(java.util.List.of("*.adoc"))
-            .outputConfigFile(nonExistentFile)
-            .build();
-        
-        IOException exception = assertThrows(IOException.class, 
-            () -> invokeLoadOutputConfiguration(runner, config));
-        
+        CLIConfig config = CLIConfig.builder().inputPatterns(java.util.List.of("*.adoc"))
+                .outputConfigFile(nonExistentFile).build();
+
+        IOException exception = assertThrows(IOException.class, () -> invokeLoadOutputConfiguration(runner, config));
+
         assertTrue(exception.getMessage().contains("Output configuration file not found"));
     }
 
     // Helper method to invoke private method via reflection
-    private OutputConfiguration invokeLoadOutputConfiguration(CLIRunner runner, CLIConfig config) 
-            throws IOException {
+    private OutputConfiguration invokeLoadOutputConfiguration(CLIRunner runner, CLIConfig config) throws IOException {
         try {
             var method = CLIRunner.class.getDeclaredMethod("loadOutputConfiguration", CLIConfig.class);
             method.setAccessible(true);

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/MainCLIOutputConfigTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/MainCLIOutputConfigTest.java
@@ -16,20 +16,16 @@ class MainCLIOutputConfigTest {
     @Test
     void testOutputConfigParsing() {
         MainCLI cli = new MainCLI();
-        
+
         // Capture output
         ByteArrayOutputStream errContent = new ByteArrayOutputStream();
         PrintStream originalErr = System.err;
         System.setErr(new PrintStream(errContent));
-        
+
         try {
             // Test with predefined config name
-            int exitCode = cli.run(new String[]{
-                "lint",
-                "--input", "test.adoc",
-                "--output-config", "simple"
-            });
-            
+            int exitCode = cli.run(new String[]{"lint", "--input", "test.adoc", "--output-config", "simple"});
+
             // Should fail because test.adoc doesn't exist, but parsing should succeed
             assertEquals(2, exitCode);
         } finally {
@@ -40,19 +36,16 @@ class MainCLIOutputConfigTest {
     @Test
     void testOutputConfigFileParsing() {
         MainCLI cli = new MainCLI();
-        
+
         ByteArrayOutputStream errContent = new ByteArrayOutputStream();
         PrintStream originalErr = System.err;
         System.setErr(new PrintStream(errContent));
-        
+
         try {
             // Test with custom config file
-            int exitCode = cli.run(new String[]{
-                "lint",
-                "--input", "test.adoc",
-                "--output-config-file", "custom-output.yaml"
-            });
-            
+            int exitCode = cli
+                    .run(new String[]{"lint", "--input", "test.adoc", "--output-config-file", "custom-output.yaml"});
+
             // Should fail because files don't exist, but parsing should succeed
             assertEquals(2, exitCode);
         } finally {
@@ -63,20 +56,16 @@ class MainCLIOutputConfigTest {
     @Test
     void testBothOutputConfigOptionsError() {
         MainCLI cli = new MainCLI();
-        
+
         ByteArrayOutputStream errContent = new ByteArrayOutputStream();
         PrintStream originalErr = System.err;
         System.setErr(new PrintStream(errContent));
-        
+
         try {
             // Test with both options - should fail
-            int exitCode = cli.run(new String[]{
-                "lint",
-                "--input", "test.adoc",
-                "--output-config", "simple",
-                "--output-config-file", "custom.yaml"
-            });
-            
+            int exitCode = cli.run(new String[]{"lint", "--input", "test.adoc", "--output-config", "simple",
+                    "--output-config-file", "custom.yaml"});
+
             assertEquals(2, exitCode);
             String error = errContent.toString();
             assertTrue(error.contains("Cannot use both --output-config and --output-config-file"));
@@ -88,19 +77,15 @@ class MainCLIOutputConfigTest {
     @Test
     void testInvalidOutputConfigName() {
         MainCLI cli = new MainCLI();
-        
+
         ByteArrayOutputStream errContent = new ByteArrayOutputStream();
         PrintStream originalErr = System.err;
         System.setErr(new PrintStream(errContent));
-        
+
         try {
             // Test with invalid config name
-            int exitCode = cli.run(new String[]{
-                "lint",
-                "--input", "test.adoc",
-                "--output-config", "invalid-name"
-            });
-            
+            int exitCode = cli.run(new String[]{"lint", "--input", "test.adoc", "--output-config", "invalid-name"});
+
             assertEquals(2, exitCode);
             String error = errContent.toString();
             assertTrue(error.contains("Invalid output config name: invalid-name"));
@@ -113,15 +98,15 @@ class MainCLIOutputConfigTest {
     @Test
     void testHelpShowsBothOptions() {
         MainCLI cli = new MainCLI();
-        
+
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         PrintStream originalOut = System.out;
         System.setOut(new PrintStream(outContent));
-        
+
         try {
             // Test lint command help which shows the output options
             int exitCode = cli.run(new String[]{"lint", "--help"});
-            
+
             assertEquals(0, exitCode);
             String output = outContent.toString();
             assertTrue(output.contains("--output-config"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/OutputConfigIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/OutputConfigIntegrationTest.java
@@ -21,7 +21,7 @@ class OutputConfigIntegrationTest {
     void testLoadEnhancedConfig() throws IOException {
         OutputConfigurationLoader loader = new OutputConfigurationLoader();
         OutputConfiguration config = loader.loadPredefinedConfiguration(OutputFormat.ENHANCED);
-        
+
         assertNotNull(config);
         assertEquals(OutputFormat.ENHANCED, config.getFormat());
         assertEquals(3, config.getDisplay().getContextLines());
@@ -35,7 +35,7 @@ class OutputConfigIntegrationTest {
     void testLoadSimpleConfig() throws IOException {
         OutputConfigurationLoader loader = new OutputConfigurationLoader();
         OutputConfiguration config = loader.loadPredefinedConfiguration(OutputFormat.SIMPLE);
-        
+
         assertNotNull(config);
         assertEquals(OutputFormat.SIMPLE, config.getFormat());
         assertEquals(1, config.getDisplay().getContextLines());
@@ -47,7 +47,7 @@ class OutputConfigIntegrationTest {
     void testLoadCompactConfig() throws IOException {
         OutputConfigurationLoader loader = new OutputConfigurationLoader();
         OutputConfiguration config = loader.loadPredefinedConfiguration(OutputFormat.COMPACT);
-        
+
         assertNotNull(config);
         assertEquals(OutputFormat.COMPACT, config.getFormat());
         assertEquals(0, config.getDisplay().getContextLines());

--- a/src/test/java/com/dataliquid/asciidoc/linter/cli/VersionInfoTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/cli/VersionInfoTest.java
@@ -9,48 +9,48 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests for VersionInfo class.
  */
 class VersionInfoTest {
-    
+
     @Test
     @DisplayName("getInstance should return singleton instance")
     void testSingletonInstance() {
         VersionInfo instance1 = VersionInfo.getInstance();
         VersionInfo instance2 = VersionInfo.getInstance();
-        
+
         assertSame(instance1, instance2, "Should return the same instance");
     }
-    
+
     @Test
     @DisplayName("getArtifactId should return expected value")
     void testGetArtifactId() {
         VersionInfo versionInfo = VersionInfo.getInstance();
-        
+
         assertEquals("asciidoc-linter", versionInfo.getArtifactId());
     }
-    
+
     @Test
     @DisplayName("getGroupId should return expected value")
     void testGetGroupId() {
         VersionInfo versionInfo = VersionInfo.getInstance();
-        
+
         assertEquals("com.dataliquid", versionInfo.getGroupId());
     }
-    
+
     @Test
     @DisplayName("getVersion should return non-null value")
     void testGetVersion() {
         VersionInfo versionInfo = VersionInfo.getInstance();
-        
+
         assertNotNull(versionInfo.getVersion());
         // In development environment, it should be "<unknown>"
         // In built JAR, it would be the actual version from pom.properties
     }
-    
+
     @Test
     @DisplayName("getFullVersion should return formatted string")
     void testGetFullVersion() {
         VersionInfo versionInfo = VersionInfo.getInstance();
         String fullVersion = versionInfo.getFullVersion();
-        
+
         assertNotNull(fullVersion);
         assertEquals("asciidoc-linter <unknown>", fullVersion);
         // Should be "<unknown> <unknown>" in dev or "asciidoc-linter X.Y.Z" in JAR

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlockTest.java
@@ -20,51 +20,32 @@ import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 
 @DisplayName("AdmonitionBlock Tests")
 class AdmonitionBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build block with all properties")
         void shouldBuildCompleteBlock() {
             // Given
-            AdmonitionBlock.TypeConfig typeConfig = AdmonitionBlock.TypeConfig.builder()
-                .required(true)
-                .allowed(List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"))
-                .severity(Severity.ERROR)
-                .build();
-                
-            AdmonitionBlock.TitleConfig titleConfig = AdmonitionBlock.TitleConfig.builder()
-                .required(true)
-                .pattern("^[A-Z].*")
-                .minLength(3)
-                .maxLength(50)
-                .severity(Severity.ERROR)
-                .build();
-                
-            AdmonitionBlock.ContentConfig contentConfig = AdmonitionBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(10)
-                .maxLength(500)
-                .severity(Severity.WARN)
-                .build();
-                
-            AdmonitionBlock.IconConfig iconConfig = AdmonitionBlock.IconConfig.builder()
-                .required(false)
-                .pattern("^(fa-|icon-|octicon-).*$")
-                .severity(Severity.INFO)
-                .build();
-            
+            AdmonitionBlock.TypeConfig typeConfig = AdmonitionBlock.TypeConfig.builder().required(true)
+                    .allowed(List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION")).severity(Severity.ERROR)
+                    .build();
+
+            AdmonitionBlock.TitleConfig titleConfig = AdmonitionBlock.TitleConfig.builder().required(true)
+                    .pattern("^[A-Z].*").minLength(3).maxLength(50).severity(Severity.ERROR).build();
+
+            AdmonitionBlock.ContentConfig contentConfig = AdmonitionBlock.ContentConfig.builder().required(true)
+                    .minLength(10).maxLength(500).severity(Severity.WARN).build();
+
+            AdmonitionBlock.IconConfig iconConfig = AdmonitionBlock.IconConfig.builder().required(false)
+                    .pattern("^(fa-|icon-|octicon-).*$").severity(Severity.INFO).build();
+
             // When
-            AdmonitionBlock block = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .type(typeConfig)
-                .title(titleConfig)
-                .content(contentConfig)
-                .icon(iconConfig)
-                .build();
-            
+            AdmonitionBlock block = AdmonitionBlock.builder().severity(Severity.ERROR).type(typeConfig)
+                    .title(titleConfig).content(contentConfig).icon(iconConfig).build();
+
             // Then
             assertNotNull(block);
             assertEquals(Severity.ERROR, block.getSeverity());
@@ -73,74 +54,62 @@ class AdmonitionBlockTest {
             assertEquals(contentConfig, block.getContent());
             assertEquals(iconConfig, block.getIcon());
         }
-        
+
         @Test
         @DisplayName("should throw exception when severity is missing")
         void shouldThrowExceptionWhenSeverityMissing() {
             // When & Then
-            assertThrows(NullPointerException.class, () -> 
-                AdmonitionBlock.builder().build()
-            );
+            assertThrows(NullPointerException.class, () -> AdmonitionBlock.builder().build());
         }
     }
-    
+
     @Nested
     @DisplayName("TypeConfig Tests")
     class TypeConfigTests {
-        
+
         @Test
         @DisplayName("should build type config with all properties")
         void shouldBuildCompleteTypeConfig() {
             // Given
             List<String> allowedTypes = List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION");
-            
+
             // When
-            AdmonitionBlock.TypeConfig config = AdmonitionBlock.TypeConfig.builder()
-                .required(true)
-                .allowed(allowedTypes)
-                .severity(Severity.ERROR)
-                .build();
-            
+            AdmonitionBlock.TypeConfig config = AdmonitionBlock.TypeConfig.builder().required(true)
+                    .allowed(allowedTypes).severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertEquals(allowedTypes, config.getAllowed());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle empty allowed list")
         void shouldHandleEmptyAllowedList() {
             // When
-            AdmonitionBlock.TypeConfig config = AdmonitionBlock.TypeConfig.builder()
-                .required(false)
-                .build();
-            
+            AdmonitionBlock.TypeConfig config = AdmonitionBlock.TypeConfig.builder().required(false).build();
+
             // Then
             assertFalse(config.isRequired());
             assertNotNull(config.getAllowed());
             assertTrue(config.getAllowed().isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("TitleConfig Tests")
     class TitleConfigTests {
-        
+
         @Test
         @DisplayName("should build title config with all properties")
         void shouldBuildCompleteTitleConfig() {
             // Given
             String patternStr = "^[A-Z][A-Za-z\\s]{2,49}$";
-            
+
             // When
-            AdmonitionBlock.TitleConfig config = AdmonitionBlock.TitleConfig.builder()
-                .required(true)
-                .pattern(patternStr)
-                .minLength(3)
-                .maxLength(50)
-                .severity(Severity.ERROR)
-                .build();
-            
+            AdmonitionBlock.TitleConfig config = AdmonitionBlock.TitleConfig.builder().required(true)
+                    .pattern(patternStr).minLength(3).maxLength(50).severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertNotNull(config.getPattern());
@@ -149,46 +118,35 @@ class AdmonitionBlockTest {
             assertEquals(50, config.getMaxLength());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle pattern as Pattern object")
         void shouldHandlePatternObject() {
             // Given
             Pattern pattern = Pattern.compile("^[A-Z].*");
-            
+
             // When
-            AdmonitionBlock.TitleConfig config = AdmonitionBlock.TitleConfig.builder()
-                .pattern(pattern)
-                .build();
-            
+            AdmonitionBlock.TitleConfig config = AdmonitionBlock.TitleConfig.builder().pattern(pattern).build();
+
             // Then
             assertEquals(pattern, config.getPattern());
         }
     }
-    
+
     @Nested
     @DisplayName("ContentConfig Tests")
     class ContentConfigTests {
-        
+
         @Test
         @DisplayName("should build content config with all properties")
         void shouldBuildCompleteContentConfig() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(1)
-                .max(10)
-                .severity(Severity.INFO)
-                .build();
-            
+            LineConfig lineConfig = LineConfig.builder().min(1).max(10).severity(Severity.INFO).build();
+
             // When
-            AdmonitionBlock.ContentConfig config = AdmonitionBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(10)
-                .maxLength(500)
-                .lines(lineConfig)
-                .severity(Severity.WARN)
-                .build();
-            
+            AdmonitionBlock.ContentConfig config = AdmonitionBlock.ContentConfig.builder().required(true).minLength(10)
+                    .maxLength(500).lines(lineConfig).severity(Severity.WARN).build();
+
             // Then
             assertTrue(config.isRequired());
             assertEquals(10, config.getMinLength());
@@ -196,14 +154,13 @@ class AdmonitionBlockTest {
             assertNotNull(config.getLines());
             assertEquals(Severity.WARN, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build minimal content config")
         void shouldBuildMinimalContentConfig() {
             // When
-            AdmonitionBlock.ContentConfig config = AdmonitionBlock.ContentConfig.builder()
-                .build();
-            
+            AdmonitionBlock.ContentConfig config = AdmonitionBlock.ContentConfig.builder().build();
+
             // Then
             assertFalse(config.isRequired());
             assertNull(config.getMinLength());
@@ -212,106 +169,76 @@ class AdmonitionBlockTest {
             assertNull(config.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("IconConfig Tests")
     class IconConfigTests {
-        
+
         @Test
         @DisplayName("should build icon config with all properties")
         void shouldBuildCompleteIconConfig() {
             // When
-            AdmonitionBlock.IconConfig config = AdmonitionBlock.IconConfig.builder()
-                .required(false)
-                .pattern("^(fa-|icon-|octicon-).*$")
-                .severity(Severity.INFO)
-                .build();
-            
+            AdmonitionBlock.IconConfig config = AdmonitionBlock.IconConfig.builder().required(false)
+                    .pattern("^(fa-|icon-|octicon-).*$").severity(Severity.INFO).build();
+
             // Then
             assertFalse(config.isRequired());
             assertNotNull(config.getPattern());
             assertEquals("^(fa-|icon-|octicon-).*$", config.getPattern().pattern());
             assertEquals(Severity.INFO, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle pattern as Pattern object")
         void shouldHandlePatternObject() {
             // Given
             Pattern pattern = Pattern.compile("^icon-.*");
-            
+
             // When
-            AdmonitionBlock.IconConfig config = AdmonitionBlock.IconConfig.builder()
-                .pattern(pattern)
-                .build();
-            
+            AdmonitionBlock.IconConfig config = AdmonitionBlock.IconConfig.builder().pattern(pattern).build();
+
             // Then
             assertEquals(pattern, config.getPattern());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should implement equals and hashCode correctly")
         void shouldImplementEqualsAndHashCode() {
             // Given
-            AdmonitionBlock.TitleConfig title1 = AdmonitionBlock.TitleConfig.builder()
-                .required(true)
-                .pattern("^[A-Z].*")
-                .minLength(3)
-                .maxLength(50)
-                .severity(Severity.ERROR)
-                .build();
-                
-            AdmonitionBlock.TitleConfig title2 = AdmonitionBlock.TitleConfig.builder()
-                .required(true)
-                .pattern("^[A-Z].*")
-                .minLength(3)
-                .maxLength(50)
-                .severity(Severity.ERROR)
-                .build();
-                
-            AdmonitionBlock block1 = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .title(title1)
-                .build();
-                
-            AdmonitionBlock block2 = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .title(title2)
-                .build();
-                
-            AdmonitionBlock block3 = AdmonitionBlock.builder()
-                .severity(Severity.WARN)
-                .title(title1)
-                .build();
-            
+            AdmonitionBlock.TitleConfig title1 = AdmonitionBlock.TitleConfig.builder().required(true)
+                    .pattern("^[A-Z].*").minLength(3).maxLength(50).severity(Severity.ERROR).build();
+
+            AdmonitionBlock.TitleConfig title2 = AdmonitionBlock.TitleConfig.builder().required(true)
+                    .pattern("^[A-Z].*").minLength(3).maxLength(50).severity(Severity.ERROR).build();
+
+            AdmonitionBlock block1 = AdmonitionBlock.builder().severity(Severity.ERROR).title(title1).build();
+
+            AdmonitionBlock block2 = AdmonitionBlock.builder().severity(Severity.ERROR).title(title2).build();
+
+            AdmonitionBlock block3 = AdmonitionBlock.builder().severity(Severity.WARN).title(title1).build();
+
             // Then
             assertEquals(block1, block2);
             assertNotEquals(block1, block3);
             assertEquals(block1.hashCode(), block2.hashCode());
             assertNotEquals(block1.hashCode(), block3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should handle pattern equality correctly")
         void shouldHandlePatternEquality() {
             // Given
-            AdmonitionBlock.TitleConfig config1 = AdmonitionBlock.TitleConfig.builder()
-                .pattern("^[A-Z].*")
-                .build();
-                
-            AdmonitionBlock.TitleConfig config2 = AdmonitionBlock.TitleConfig.builder()
-                .pattern("^[A-Z].*")
-                .build();
-                
-            AdmonitionBlock.TitleConfig config3 = AdmonitionBlock.TitleConfig.builder()
-                .pattern("^[a-z].*")
-                .build();
-            
+            AdmonitionBlock.TitleConfig config1 = AdmonitionBlock.TitleConfig.builder().pattern("^[A-Z].*").build();
+
+            AdmonitionBlock.TitleConfig config2 = AdmonitionBlock.TitleConfig.builder().pattern("^[A-Z].*").build();
+
+            AdmonitionBlock.TitleConfig config3 = AdmonitionBlock.TitleConfig.builder().pattern("^[a-z].*").build();
+
             // Then
             assertEquals(config1, config2);
             assertNotEquals(config1, config3);

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlockTest.java
@@ -18,85 +18,65 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("AudioBlock")
 class AudioBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build AudioBlock with all attributes")
         void shouldBuildAudioBlockWithAllAttributes() {
             // Given
-            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern("^(https?://|\\./|/).*\\.(mp3|ogg|wav|m4a)$")
-                    .severity(Severity.ERROR)
+            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder().required(true)
+                    .pattern("^(https?://|\\./|/).*\\.(mp3|ogg|wav|m4a)$").severity(Severity.ERROR).build();
+
+            AudioBlock.AutoplayConfig autoplayRule = AudioBlock.AutoplayConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.ControlsConfig controlsRule = AudioBlock.ControlsConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.LoopConfig loopRule = AudioBlock.LoopConfig.builder().allowed(true).severity(Severity.INFO)
                     .build();
-                    
-            AudioBlock.AutoplayConfig autoplayRule = AudioBlock.AutoplayConfig.builder()
-                    .allowed(false)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.ControlsConfig controlsRule = AudioBlock.ControlsConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.LoopConfig loopRule = AudioBlock.LoopConfig.builder()
-                    .allowed(true)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            AudioBlock.OptionsConfig optionsRule = AudioBlock.OptionsConfig.builder()
-                    .autoplay(autoplayRule)
-                    .controls(controlsRule)
-                    .loop(loopRule)
-                    .build();
-                    
-            AudioBlock.TitleConfig titleRule = AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .maxLength(100)
-                    .severity(Severity.WARN)
-                    .build();
-            
+
+            AudioBlock.OptionsConfig optionsRule = AudioBlock.OptionsConfig.builder().autoplay(autoplayRule)
+                    .controls(controlsRule).loop(loopRule).build();
+
+            AudioBlock.TitleConfig titleRule = AudioBlock.TitleConfig.builder().required(true).minLength(10)
+                    .maxLength(100).severity(Severity.WARN).build();
+
             // When
-            AudioBlock audio = AudioBlock.builder()
-                    .severity(Severity.INFO)
-                    .url(urlRule)
-                    .options(optionsRule)
-                    .title(titleRule)
-                    .build();
-            
+            AudioBlock audio = AudioBlock.builder().severity(Severity.INFO).url(urlRule).options(optionsRule)
+                    .title(titleRule).build();
+
             // Then
             assertEquals(Severity.INFO, audio.getSeverity());
-            
+
             assertNotNull(audio.getUrl());
             assertTrue(audio.getUrl().isRequired());
             assertNotNull(audio.getUrl().getPattern());
             assertEquals(Severity.ERROR, audio.getUrl().getSeverity());
-            
+
             assertNotNull(audio.getOptions());
             assertNotNull(audio.getOptions().getAutoplay());
             assertFalse(audio.getOptions().getAutoplay().isAllowed());
             assertEquals(Severity.ERROR, audio.getOptions().getAutoplay().getSeverity());
-            
+
             assertNotNull(audio.getOptions().getControls());
             assertTrue(audio.getOptions().getControls().isRequired());
             assertEquals(Severity.ERROR, audio.getOptions().getControls().getSeverity());
-            
+
             assertNotNull(audio.getOptions().getLoop());
             assertTrue(audio.getOptions().getLoop().isAllowed());
             assertEquals(Severity.INFO, audio.getOptions().getLoop().getSeverity());
-            
+
             assertNotNull(audio.getTitle());
             assertTrue(audio.getTitle().isRequired());
             assertEquals(10, audio.getTitle().getMinLength());
             assertEquals(100, audio.getTitle().getMaxLength());
             assertEquals(Severity.WARN, audio.getTitle().getSeverity());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
@@ -106,149 +86,124 @@ class AudioBlockTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("UrlConfig Tests")
     class UrlConfigTests {
-        
+
         @Test
         @DisplayName("should create UrlConfig with string pattern")
         void shouldCreateUrlConfigWithStringPattern() {
             // Given & When
-            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern("^https?://.*\\.mp3$")
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder().required(true).pattern("^https?://.*\\.mp3$")
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertTrue(urlRule.isRequired());
             assertNotNull(urlRule.getPattern());
             assertEquals("^https?://.*\\.mp3$", urlRule.getPattern().pattern());
             assertEquals(Severity.ERROR, urlRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create UrlConfig with Pattern object")
         void shouldCreateUrlConfigWithPatternObject() {
             // Given
             Pattern pattern = Pattern.compile(".*\\.(ogg|wav)$");
-            
+
             // When
-            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder()
-                    .required(false)
-                    .pattern(pattern)
-                    .build();
-            
+            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder().required(false).pattern(pattern).build();
+
             // Then
             assertFalse(urlRule.isRequired());
             assertEquals(pattern, urlRule.getPattern());
             assertNull(urlRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle null pattern and severity")
         void shouldHandleNullPatternAndSeverity() {
             // Given & When
-            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern((String) null)
-                    .build();
-            
+            AudioBlock.UrlConfig urlRule = AudioBlock.UrlConfig.builder().required(true).pattern((String) null).build();
+
             // Then
             assertTrue(urlRule.isRequired());
             assertNull(urlRule.getPattern());
             assertNull(urlRule.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("OptionsConfig Tests")
     class OptionsConfigTests {
-        
+
         @Test
         @DisplayName("should create OptionsConfig with all options")
         void shouldCreateOptionsConfigWithAllOptions() {
             // Given
-            AudioBlock.AutoplayConfig autoplay = AudioBlock.AutoplayConfig.builder()
-                    .allowed(false)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.ControlsConfig controls = AudioBlock.ControlsConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.LoopConfig loop = AudioBlock.LoopConfig.builder()
-                    .allowed(true)
-                    .build();
-            
+            AudioBlock.AutoplayConfig autoplay = AudioBlock.AutoplayConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.ControlsConfig controls = AudioBlock.ControlsConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.LoopConfig loop = AudioBlock.LoopConfig.builder().allowed(true).build();
+
             // When
-            AudioBlock.OptionsConfig options = AudioBlock.OptionsConfig.builder()
-                    .autoplay(autoplay)
-                    .controls(controls)
-                    .loop(loop)
-                    .build();
-            
+            AudioBlock.OptionsConfig options = AudioBlock.OptionsConfig.builder().autoplay(autoplay).controls(controls)
+                    .loop(loop).build();
+
             // Then
             assertNotNull(options.getAutoplay());
             assertFalse(options.getAutoplay().isAllowed());
             assertEquals(Severity.ERROR, options.getAutoplay().getSeverity());
-            
+
             assertNotNull(options.getControls());
             assertTrue(options.getControls().isRequired());
             assertEquals(Severity.ERROR, options.getControls().getSeverity());
-            
+
             assertNotNull(options.getLoop());
             assertTrue(options.getLoop().isAllowed());
             assertNull(options.getLoop().getSeverity());
         }
-        
+
         @Test
         @DisplayName("should allow null options")
         void shouldAllowNullOptions() {
             // Given & When
-            AudioBlock.OptionsConfig options = AudioBlock.OptionsConfig.builder()
-                    .build();
-            
+            AudioBlock.OptionsConfig options = AudioBlock.OptionsConfig.builder().build();
+
             // Then
             assertNull(options.getAutoplay());
             assertNull(options.getControls());
             assertNull(options.getLoop());
         }
     }
-    
+
     @Nested
     @DisplayName("TitleConfig Tests")
     class TitleConfigTests {
-        
+
         @Test
         @DisplayName("should create TitleConfig with length constraints")
         void shouldCreateTitleConfigWithLengthConstraints() {
             // Given & When
-            AudioBlock.TitleConfig title = AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .maxLength(100)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            AudioBlock.TitleConfig title = AudioBlock.TitleConfig.builder().required(true).minLength(10).maxLength(100)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertTrue(title.isRequired());
             assertEquals(10, title.getMinLength());
             assertEquals(100, title.getMaxLength());
             assertEquals(Severity.WARN, title.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should allow optional title")
         void shouldAllowOptionalTitle() {
             // Given & When
-            AudioBlock.TitleConfig title = AudioBlock.TitleConfig.builder()
-                    .required(false)
-                    .build();
-            
+            AudioBlock.TitleConfig title = AudioBlock.TitleConfig.builder().required(false).build();
+
             // Then
             assertFalse(title.isRequired());
             assertNull(title.getMinLength());
@@ -256,138 +211,86 @@ class AudioBlockTest {
             assertNull(title.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should correctly implement equals and hashCode")
         void shouldCorrectlyImplementEqualsAndHashCode() {
             // Given
-            AudioBlock.UrlConfig url1 = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern(".*\\.mp3$")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.UrlConfig url2 = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern(".*\\.mp3$")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.TitleConfig title1 = AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            AudioBlock.TitleConfig title2 = AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .severity(Severity.WARN)
-                    .build();
-                    
+            AudioBlock.UrlConfig url1 = AudioBlock.UrlConfig.builder().required(true).pattern(".*\\.mp3$")
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.UrlConfig url2 = AudioBlock.UrlConfig.builder().required(true).pattern(".*\\.mp3$")
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.TitleConfig title1 = AudioBlock.TitleConfig.builder().required(true).minLength(10)
+                    .severity(Severity.WARN).build();
+
+            AudioBlock.TitleConfig title2 = AudioBlock.TitleConfig.builder().required(true).minLength(10)
+                    .severity(Severity.WARN).build();
+
             // When
-            AudioBlock audio1 = AudioBlock.builder()
-                    .severity(Severity.INFO)
-                    .url(url1)
-                    .title(title1)
-                    .build();
-                    
-            AudioBlock audio2 = AudioBlock.builder()
-                    .severity(Severity.INFO)
-                    .url(url2)
-                    .title(title2)
-                    .build();
-                    
-            AudioBlock audio3 = AudioBlock.builder()
-                    .severity(Severity.ERROR)
-                    .url(url1)
-                    .title(title1)
-                    .build();
-            
+            AudioBlock audio1 = AudioBlock.builder().severity(Severity.INFO).url(url1).title(title1).build();
+
+            AudioBlock audio2 = AudioBlock.builder().severity(Severity.INFO).url(url2).title(title2).build();
+
+            AudioBlock audio3 = AudioBlock.builder().severity(Severity.ERROR).url(url1).title(title1).build();
+
             // Then
             assertEquals(audio1, audio2);
             assertNotEquals(audio1, audio3);
             assertEquals(audio1.hashCode(), audio2.hashCode());
             assertNotEquals(audio1.hashCode(), audio3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should test inner class equals and hashCode")
         void shouldTestInnerClassEqualsAndHashCode() {
             // Given
-            AudioBlock.UrlConfig url1 = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern("test")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.UrlConfig url2 = AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern("test")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.AutoplayConfig autoplay1 = AudioBlock.AutoplayConfig.builder()
-                    .allowed(false)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.AutoplayConfig autoplay2 = AudioBlock.AutoplayConfig.builder()
-                    .allowed(false)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.ControlsConfig controls1 = AudioBlock.ControlsConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.ControlsConfig controls2 = AudioBlock.ControlsConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            AudioBlock.LoopConfig loop1 = AudioBlock.LoopConfig.builder()
-                    .allowed(true)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            AudioBlock.LoopConfig loop2 = AudioBlock.LoopConfig.builder()
-                    .allowed(true)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            AudioBlock.TitleConfig title1 = AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            AudioBlock.TitleConfig title2 = AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            AudioBlock.UrlConfig url1 = AudioBlock.UrlConfig.builder().required(true).pattern("test")
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.UrlConfig url2 = AudioBlock.UrlConfig.builder().required(true).pattern("test")
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.AutoplayConfig autoplay1 = AudioBlock.AutoplayConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.AutoplayConfig autoplay2 = AudioBlock.AutoplayConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.ControlsConfig controls1 = AudioBlock.ControlsConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.ControlsConfig controls2 = AudioBlock.ControlsConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.LoopConfig loop1 = AudioBlock.LoopConfig.builder().allowed(true).severity(Severity.INFO).build();
+
+            AudioBlock.LoopConfig loop2 = AudioBlock.LoopConfig.builder().allowed(true).severity(Severity.INFO).build();
+
+            AudioBlock.TitleConfig title1 = AudioBlock.TitleConfig.builder().required(true).minLength(5).maxLength(50)
+                    .severity(Severity.WARN).build();
+
+            AudioBlock.TitleConfig title2 = AudioBlock.TitleConfig.builder().required(true).minLength(5).maxLength(50)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertEquals(url1, url2);
             assertEquals(url1.hashCode(), url2.hashCode());
-            
+
             assertEquals(autoplay1, autoplay2);
             assertEquals(autoplay1.hashCode(), autoplay2.hashCode());
-            
+
             assertEquals(controls1, controls2);
             assertEquals(controls1.hashCode(), controls2.hashCode());
-            
+
             assertEquals(loop1, loop2);
             assertEquals(loop1.hashCode(), loop2.hashCode());
-            
+
             assertEquals(title1, title2);
             assertEquals(title1.hashCode(), title2.hashCode());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlockTest.java
@@ -16,57 +16,36 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("DlistBlock")
 class DlistBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build DlistBlock with all attributes")
         void shouldBuildDlistBlockWithAllAttributes() {
             // Given
-            DlistBlock.TermsConfig termsConfig = DlistBlock.TermsConfig.builder()
-                    .min(1)
-                    .max(20)
-                    .pattern("^[A-Z].*")
-                    .minLength(3)
-                    .maxLength(50)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            DlistBlock.DescriptionsConfig descriptionsConfig = DlistBlock.DescriptionsConfig.builder()
-                    .required(true)
-                    .min(1)
-                    .max(5)
-                    .pattern(".*\\.$")
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            DlistBlock.NestingLevelConfig nestingConfig = DlistBlock.NestingLevelConfig.builder()
-                    .max(3)
-                    .severity(Severity.INFO)
-                    .build();
-                    
+            DlistBlock.TermsConfig termsConfig = DlistBlock.TermsConfig.builder().min(1).max(20).pattern("^[A-Z].*")
+                    .minLength(3).maxLength(50).severity(Severity.ERROR).build();
+
+            DlistBlock.DescriptionsConfig descriptionsConfig = DlistBlock.DescriptionsConfig.builder().required(true)
+                    .min(1).max(5).pattern(".*\\.$").severity(Severity.WARN).build();
+
+            DlistBlock.NestingLevelConfig nestingConfig = DlistBlock.NestingLevelConfig.builder().max(3)
+                    .severity(Severity.INFO).build();
+
             DlistBlock.DelimiterStyleConfig delimiterConfig = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::", ":::"})
-                    .consistent(true)
-                    .severity(Severity.WARN)
-                    .build();
-            
+                    .allowedDelimiters(new String[]{"::", ":::"}).consistent(true).severity(Severity.WARN).build();
+
             // When
-            DlistBlock dlist = DlistBlock.builder()
-                    .name("glossary-list")
-                    .severity(Severity.ERROR)
-                    .terms(termsConfig)
-                    .descriptions(descriptionsConfig)
-                    .nestingLevel(nestingConfig)
-                    .delimiterStyle(delimiterConfig)
+            DlistBlock dlist = DlistBlock.builder().name("glossary-list").severity(Severity.ERROR).terms(termsConfig)
+                    .descriptions(descriptionsConfig).nestingLevel(nestingConfig).delimiterStyle(delimiterConfig)
                     .build();
-            
+
             // Then
             assertEquals("glossary-list", dlist.getName());
             assertEquals(Severity.ERROR, dlist.getSeverity());
-            
+
             assertNotNull(dlist.getTerms());
             assertEquals(1, dlist.getTerms().getMin());
             assertEquals(20, dlist.getTerms().getMax());
@@ -74,32 +53,30 @@ class DlistBlockTest {
             assertEquals(3, dlist.getTerms().getMinLength());
             assertEquals(50, dlist.getTerms().getMaxLength());
             assertEquals(Severity.ERROR, dlist.getTerms().getSeverity());
-            
+
             assertNotNull(dlist.getDescriptions());
             assertTrue(dlist.getDescriptions().getRequired());
             assertEquals(1, dlist.getDescriptions().getMin());
             assertEquals(5, dlist.getDescriptions().getMax());
             assertEquals(".*\\.$", dlist.getDescriptions().getPattern());
             assertEquals(Severity.WARN, dlist.getDescriptions().getSeverity());
-            
+
             assertNotNull(dlist.getNestingLevel());
             assertEquals(3, dlist.getNestingLevel().getMax());
             assertEquals(Severity.INFO, dlist.getNestingLevel().getSeverity());
-            
+
             assertNotNull(dlist.getDelimiterStyle());
             assertArrayEquals(new String[]{"::", ":::"}, dlist.getDelimiterStyle().getAllowedDelimiters());
             assertTrue(dlist.getDelimiterStyle().getConsistent());
             assertEquals(Severity.WARN, dlist.getDelimiterStyle().getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build DlistBlock with minimal attributes")
         void shouldBuildDlistBlockWithMinimalAttributes() {
             // When
-            DlistBlock dlist = DlistBlock.builder()
-                    .severity(Severity.WARN)
-                    .build();
-            
+            DlistBlock dlist = DlistBlock.builder().severity(Severity.WARN).build();
+
             // Then
             assertNull(dlist.getName());
             assertEquals(Severity.WARN, dlist.getSeverity());
@@ -108,7 +85,7 @@ class DlistBlockTest {
             assertNull(dlist.getNestingLevel());
             assertNull(dlist.getDelimiterStyle());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
@@ -118,24 +95,18 @@ class DlistBlockTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("TermsConfig Tests")
     class TermsConfigTests {
-        
+
         @Test
         @DisplayName("should create TermsConfig with all properties")
         void shouldCreateTermsConfigWithAllProperties() {
             // When
-            DlistBlock.TermsConfig termsConfig = DlistBlock.TermsConfig.builder()
-                    .min(2)
-                    .max(10)
-                    .pattern("^[A-Z].*")
-                    .minLength(5)
-                    .maxLength(100)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            DlistBlock.TermsConfig termsConfig = DlistBlock.TermsConfig.builder().min(2).max(10).pattern("^[A-Z].*")
+                    .minLength(5).maxLength(100).severity(Severity.ERROR).build();
+
             // Then
             assertEquals(2, termsConfig.getMin());
             assertEquals(10, termsConfig.getMax());
@@ -144,16 +115,13 @@ class DlistBlockTest {
             assertEquals(100, termsConfig.getMaxLength());
             assertEquals(Severity.ERROR, termsConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create TermsConfig with partial properties")
         void shouldCreateTermsConfigWithPartialProperties() {
             // When
-            DlistBlock.TermsConfig termsConfig = DlistBlock.TermsConfig.builder()
-                    .min(1)
-                    .pattern("[A-Za-z]+")
-                    .build();
-            
+            DlistBlock.TermsConfig termsConfig = DlistBlock.TermsConfig.builder().min(1).pattern("[A-Za-z]+").build();
+
             // Then
             assertEquals(1, termsConfig.getMin());
             assertNull(termsConfig.getMax());
@@ -163,23 +131,18 @@ class DlistBlockTest {
             assertNull(termsConfig.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("DescriptionsConfig Tests")
     class DescriptionsConfigTests {
-        
+
         @Test
         @DisplayName("should create DescriptionsConfig with all properties")
         void shouldCreateDescriptionsConfigWithAllProperties() {
             // When
-            DlistBlock.DescriptionsConfig descriptionsConfig = DlistBlock.DescriptionsConfig.builder()
-                    .required(true)
-                    .min(1)
-                    .max(3)
-                    .pattern("^\\w+")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            DlistBlock.DescriptionsConfig descriptionsConfig = DlistBlock.DescriptionsConfig.builder().required(true)
+                    .min(1).max(3).pattern("^\\w+").severity(Severity.WARN).build();
+
             // Then
             assertTrue(descriptionsConfig.getRequired());
             assertEquals(1, descriptionsConfig.getMin());
@@ -187,15 +150,14 @@ class DlistBlockTest {
             assertEquals("^\\w+", descriptionsConfig.getPattern());
             assertEquals(Severity.WARN, descriptionsConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create DescriptionsConfig with only required flag")
         void shouldCreateDescriptionsConfigWithOnlyRequired() {
             // When
-            DlistBlock.DescriptionsConfig descriptionsConfig = DlistBlock.DescriptionsConfig.builder()
-                    .required(false)
+            DlistBlock.DescriptionsConfig descriptionsConfig = DlistBlock.DescriptionsConfig.builder().required(false)
                     .build();
-            
+
             // Then
             assertEquals(false, descriptionsConfig.getRequired());
             assertNull(descriptionsConfig.getMin());
@@ -204,164 +166,116 @@ class DlistBlockTest {
             assertNull(descriptionsConfig.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("DelimiterStyleConfig Tests")
     class DelimiterStyleConfigTests {
-        
+
         @Test
         @DisplayName("should create DelimiterStyleConfig with all properties")
         void shouldCreateDelimiterStyleConfigWithAllProperties() {
             // When
             DlistBlock.DelimiterStyleConfig delimiterConfig = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::", ":::", "::::"})
-                    .consistent(true)
-                    .severity(Severity.INFO)
+                    .allowedDelimiters(new String[]{"::", ":::", "::::"}).consistent(true).severity(Severity.INFO)
                     .build();
-            
+
             // Then
             assertArrayEquals(new String[]{"::", ":::", "::::"}, delimiterConfig.getAllowedDelimiters());
             assertTrue(delimiterConfig.getConsistent());
             assertEquals(Severity.INFO, delimiterConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create DelimiterStyleConfig with single delimiter")
         void shouldCreateDelimiterStyleConfigWithSingleDelimiter() {
             // When
             DlistBlock.DelimiterStyleConfig delimiterConfig = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::"})
-                    .consistent(false)
-                    .build();
-            
+                    .allowedDelimiters(new String[]{"::"}).consistent(false).build();
+
             // Then
             assertArrayEquals(new String[]{"::"}, delimiterConfig.getAllowedDelimiters());
             assertEquals(false, delimiterConfig.getConsistent());
             assertNull(delimiterConfig.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should correctly implement equals and hashCode for DlistBlock")
         void shouldCorrectlyImplementEqualsAndHashCodeForDlistBlock() {
             // Given
-            DlistBlock.TermsConfig terms1 = DlistBlock.TermsConfig.builder()
-                    .min(1)
-                    .max(10)
-                    .pattern("^[A-Z]")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            DlistBlock.TermsConfig terms2 = DlistBlock.TermsConfig.builder()
-                    .min(1)
-                    .max(10)
-                    .pattern("^[A-Z]")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            DlistBlock.DescriptionsConfig desc1 = DlistBlock.DescriptionsConfig.builder()
-                    .required(true)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            DlistBlock.DescriptionsConfig desc2 = DlistBlock.DescriptionsConfig.builder()
-                    .required(true)
-                    .severity(Severity.WARN)
-                    .build();
-                    
+            DlistBlock.TermsConfig terms1 = DlistBlock.TermsConfig.builder().min(1).max(10).pattern("^[A-Z]")
+                    .severity(Severity.ERROR).build();
+
+            DlistBlock.TermsConfig terms2 = DlistBlock.TermsConfig.builder().min(1).max(10).pattern("^[A-Z]")
+                    .severity(Severity.ERROR).build();
+
+            DlistBlock.DescriptionsConfig desc1 = DlistBlock.DescriptionsConfig.builder().required(true)
+                    .severity(Severity.WARN).build();
+
+            DlistBlock.DescriptionsConfig desc2 = DlistBlock.DescriptionsConfig.builder().required(true)
+                    .severity(Severity.WARN).build();
+
             // When
-            DlistBlock dlist1 = DlistBlock.builder()
-                    .severity(Severity.ERROR)
-                    .terms(terms1)
-                    .descriptions(desc1)
-                    .build();
-                    
-            DlistBlock dlist2 = DlistBlock.builder()
-                    .severity(Severity.ERROR)
-                    .terms(terms2)
-                    .descriptions(desc2)
-                    .build();
-                    
-            DlistBlock dlist3 = DlistBlock.builder()
-                    .severity(Severity.WARN)
-                    .terms(terms1)
-                    .descriptions(desc1)
-                    .build();
-            
+            DlistBlock dlist1 = DlistBlock.builder().severity(Severity.ERROR).terms(terms1).descriptions(desc1).build();
+
+            DlistBlock dlist2 = DlistBlock.builder().severity(Severity.ERROR).terms(terms2).descriptions(desc2).build();
+
+            DlistBlock dlist3 = DlistBlock.builder().severity(Severity.WARN).terms(terms1).descriptions(desc1).build();
+
             // Then
             assertEquals(dlist1, dlist2);
             assertNotEquals(dlist1, dlist3);
             assertEquals(dlist1.hashCode(), dlist2.hashCode());
             assertNotEquals(dlist1.hashCode(), dlist3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should test inner class equals and hashCode")
         void shouldTestInnerClassEqualsAndHashCode() {
             // Given
-            DlistBlock.TermsConfig terms1 = DlistBlock.TermsConfig.builder()
-                    .min(2)
-                    .pattern("\\w+")
-                    .minLength(3)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            DlistBlock.TermsConfig terms2 = DlistBlock.TermsConfig.builder()
-                    .min(2)
-                    .pattern("\\w+")
-                    .minLength(3)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            DlistBlock.NestingLevelConfig nesting1 = DlistBlock.NestingLevelConfig.builder()
-                    .max(2)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            DlistBlock.NestingLevelConfig nesting2 = DlistBlock.NestingLevelConfig.builder()
-                    .max(2)
-                    .severity(Severity.INFO)
-                    .build();
-                    
+            DlistBlock.TermsConfig terms1 = DlistBlock.TermsConfig.builder().min(2).pattern("\\w+").minLength(3)
+                    .severity(Severity.ERROR).build();
+
+            DlistBlock.TermsConfig terms2 = DlistBlock.TermsConfig.builder().min(2).pattern("\\w+").minLength(3)
+                    .severity(Severity.ERROR).build();
+
+            DlistBlock.NestingLevelConfig nesting1 = DlistBlock.NestingLevelConfig.builder().max(2)
+                    .severity(Severity.INFO).build();
+
+            DlistBlock.NestingLevelConfig nesting2 = DlistBlock.NestingLevelConfig.builder().max(2)
+                    .severity(Severity.INFO).build();
+
             DlistBlock.DelimiterStyleConfig delimiter1 = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::"})
-                    .consistent(true)
-                    .severity(Severity.WARN)
-                    .build();
-                    
+                    .allowedDelimiters(new String[]{"::"}).consistent(true).severity(Severity.WARN).build();
+
             DlistBlock.DelimiterStyleConfig delimiter2 = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::"})
-                    .consistent(true)
-                    .severity(Severity.WARN)
-                    .build();
-            
+                    .allowedDelimiters(new String[]{"::"}).consistent(true).severity(Severity.WARN).build();
+
             // Then
             assertEquals(terms1, terms2);
             assertEquals(terms1.hashCode(), terms2.hashCode());
-            
+
             assertEquals(nesting1, nesting2);
             assertEquals(nesting1.hashCode(), nesting2.hashCode());
-            
+
             assertEquals(delimiter1, delimiter2);
             assertEquals(delimiter1.hashCode(), delimiter2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should handle different delimiter arrays")
         void shouldHandleDifferentDelimiterArrays() {
             // Given
             DlistBlock.DelimiterStyleConfig delimiter1 = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::", ":::"})
-                    .build();
-                    
+                    .allowedDelimiters(new String[]{"::", ":::"}).build();
+
             DlistBlock.DelimiterStyleConfig delimiter2 = DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::", "::::"})
-                    .build();
-            
+                    .allowedDelimiters(new String[]{"::", "::::"}).build();
+
             // Then
             assertNotEquals(delimiter1, delimiter2);
             assertNotEquals(delimiter1.hashCode(), delimiter2.hashCode());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlockTest.java
@@ -18,20 +18,17 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("ExampleBlock")
 class ExampleBlockTest {
-    
+
     @Nested
     @DisplayName("Builder")
     class BuilderTest {
-        
+
         @Test
         @DisplayName("should build with minimal configuration")
         void shouldBuildWithMinimalConfiguration() {
             // Given/When
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("example-1")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ExampleBlock block = ExampleBlock.builder().name("example-1").severity(Severity.WARN).build();
+
             // Then
             assertNotNull(block);
             assertEquals("example-1", block.getName());
@@ -39,33 +36,21 @@ class ExampleBlockTest {
             assertNull(block.getCaption());
             assertNull(block.getCollapsible());
         }
-        
+
         @Test
         @DisplayName("should build with full configuration")
         void shouldBuildWithFullConfiguration() {
             // Given
-            ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Example \\d+:.*")
-                    .minLength(10)
-                    .maxLength(100)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            ExampleBlock.CollapsibleConfig collapsible = ExampleBlock.CollapsibleConfig.builder()
-                    .required(false)
-                    .allowed(Arrays.asList(true, false))
-                    .severity(Severity.INFO)
-                    .build();
-            
+            ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder().required(true)
+                    .pattern("^Example \\d+:.*").minLength(10).maxLength(100).severity(Severity.ERROR).build();
+
+            ExampleBlock.CollapsibleConfig collapsible = ExampleBlock.CollapsibleConfig.builder().required(false)
+                    .allowed(Arrays.asList(true, false)).severity(Severity.INFO).build();
+
             // When
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("example-full")
-                    .severity(Severity.WARN)
-                    .caption(caption)
-                    .collapsible(collapsible)
-                    .build();
-            
+            ExampleBlock block = ExampleBlock.builder().name("example-full").severity(Severity.WARN).caption(caption)
+                    .collapsible(collapsible).build();
+
             // Then
             assertNotNull(block);
             assertEquals("example-full", block.getName());
@@ -74,23 +59,19 @@ class ExampleBlockTest {
             assertNotNull(block.getCollapsible());
         }
     }
-    
+
     @Nested
     @DisplayName("CaptionConfig")
     class CaptionConfigTest {
-        
+
         @Test
         @DisplayName("should build with all properties")
         void shouldBuildWithAllProperties() {
             // Given/When
-            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*")
-                    .minLength(15)
-                    .maxLength(100)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder().required(true)
+                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*").minLength(15).maxLength(100)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertNotNull(config.getPattern());
@@ -99,69 +80,47 @@ class ExampleBlockTest {
             assertEquals(100, config.getMaxLength());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle null pattern")
         void shouldHandleNullPattern() {
             // Given/When
-            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder()
-                    .required(false)
-                    .pattern(null)
+            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder().required(false).pattern(null)
                     .build();
-            
+
             // Then
             assertNull(config.getPattern());
         }
-        
+
         @Test
         @DisplayName("should have correct equals and hashCode")
         void shouldHaveCorrectEqualsAndHashCode() {
             // Given
-            ExampleBlock.CaptionConfig config1 = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Example.*")
-                    .minLength(10)
-                    .maxLength(50)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            ExampleBlock.CaptionConfig config2 = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Example.*")
-                    .minLength(10)
-                    .maxLength(50)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            ExampleBlock.CaptionConfig config3 = ExampleBlock.CaptionConfig.builder()
-                    .required(false)
-                    .pattern("^Example.*")
-                    .minLength(10)
-                    .maxLength(50)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ExampleBlock.CaptionConfig config1 = ExampleBlock.CaptionConfig.builder().required(true)
+                    .pattern("^Example.*").minLength(10).maxLength(50).severity(Severity.WARN).build();
+
+            ExampleBlock.CaptionConfig config2 = ExampleBlock.CaptionConfig.builder().required(true)
+                    .pattern("^Example.*").minLength(10).maxLength(50).severity(Severity.WARN).build();
+
+            ExampleBlock.CaptionConfig config3 = ExampleBlock.CaptionConfig.builder().required(false)
+                    .pattern("^Example.*").minLength(10).maxLength(50).severity(Severity.WARN).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
-        
+
         @Test
         @DisplayName("should have meaningful toString")
         void shouldHaveMeaningfulToString() {
             // Given
-            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Example.*")
-                    .minLength(10)
-                    .maxLength(50)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder().required(true)
+                    .pattern("^Example.*").minLength(10).maxLength(50).severity(Severity.ERROR).build();
+
             // When
             String result = config.toString();
-            
+
             // Then
             assertTrue(result.contains("required=true"));
             assertTrue(result.contains("pattern=^Example.*"));
@@ -170,140 +129,101 @@ class ExampleBlockTest {
             assertTrue(result.contains("severity=ERROR"));
         }
     }
-    
+
     @Nested
     @DisplayName("CollapsibleConfig")
     class CollapsibleConfigTest {
-        
+
         @Test
         @DisplayName("should build with all properties")
         void shouldBuildWithAllProperties() {
             // Given
             List<Boolean> allowed = Arrays.asList(true, false);
-            
+
             // When
-            ExampleBlock.CollapsibleConfig config = ExampleBlock.CollapsibleConfig.builder()
-                    .required(false)
-                    .allowed(allowed)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            ExampleBlock.CollapsibleConfig config = ExampleBlock.CollapsibleConfig.builder().required(false)
+                    .allowed(allowed).severity(Severity.INFO).build();
+
             // Then
             assertFalse(config.isRequired());
             assertEquals(allowed, config.getAllowed());
             assertEquals(Severity.INFO, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should have correct equals and hashCode")
         void shouldHaveCorrectEqualsAndHashCode() {
             // Given
             List<Boolean> allowed = Arrays.asList(true, false);
-            
-            ExampleBlock.CollapsibleConfig config1 = ExampleBlock.CollapsibleConfig.builder()
-                    .required(false)
-                    .allowed(allowed)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            ExampleBlock.CollapsibleConfig config2 = ExampleBlock.CollapsibleConfig.builder()
-                    .required(false)
-                    .allowed(allowed)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            ExampleBlock.CollapsibleConfig config3 = ExampleBlock.CollapsibleConfig.builder()
-                    .required(true)
-                    .allowed(allowed)
-                    .severity(Severity.INFO)
-                    .build();
-            
+
+            ExampleBlock.CollapsibleConfig config1 = ExampleBlock.CollapsibleConfig.builder().required(false)
+                    .allowed(allowed).severity(Severity.INFO).build();
+
+            ExampleBlock.CollapsibleConfig config2 = ExampleBlock.CollapsibleConfig.builder().required(false)
+                    .allowed(allowed).severity(Severity.INFO).build();
+
+            ExampleBlock.CollapsibleConfig config3 = ExampleBlock.CollapsibleConfig.builder().required(true)
+                    .allowed(allowed).severity(Severity.INFO).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
-        
+
         @Test
         @DisplayName("should have meaningful toString")
         void shouldHaveMeaningfulToString() {
             // Given
             List<Boolean> allowed = Arrays.asList(true, false);
-            ExampleBlock.CollapsibleConfig config = ExampleBlock.CollapsibleConfig.builder()
-                    .required(false)
-                    .allowed(allowed)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            ExampleBlock.CollapsibleConfig config = ExampleBlock.CollapsibleConfig.builder().required(false)
+                    .allowed(allowed).severity(Severity.INFO).build();
+
             // When
             String result = config.toString();
-            
+
             // Then
             assertTrue(result.contains("required=false"));
             assertTrue(result.contains("allowed=[true, false]"));
             assertTrue(result.contains("severity=INFO"));
         }
     }
-    
+
     @Test
     @DisplayName("should have correct equals and hashCode")
     void shouldHaveCorrectEqualsAndHashCode() {
         // Given
-        ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder()
-                .required(true)
-                .pattern("^Example.*")
+        ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder().required(true).pattern("^Example.*")
                 .build();
-                
-        ExampleBlock block1 = ExampleBlock.builder()
-                .name("example-1")
-                .severity(Severity.WARN)
-                .caption(caption)
-                .build();
-                
-        ExampleBlock block2 = ExampleBlock.builder()
-                .name("example-1")
-                .severity(Severity.WARN)
-                .caption(caption)
-                .build();
-                
-        ExampleBlock block3 = ExampleBlock.builder()
-                .name("example-2")
-                .severity(Severity.WARN)
-                .caption(caption)
-                .build();
-        
+
+        ExampleBlock block1 = ExampleBlock.builder().name("example-1").severity(Severity.WARN).caption(caption).build();
+
+        ExampleBlock block2 = ExampleBlock.builder().name("example-1").severity(Severity.WARN).caption(caption).build();
+
+        ExampleBlock block3 = ExampleBlock.builder().name("example-2").severity(Severity.WARN).caption(caption).build();
+
         // Then
         assertEquals(block1, block2);
         assertEquals(block1.hashCode(), block2.hashCode());
         assertNotEquals(block1, block3);
     }
-    
+
     @Test
     @DisplayName("should have meaningful toString")
     void shouldHaveMeaningfulToString() {
         // Given
-        ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder()
-                .required(true)
-                .pattern("^Example.*")
-                .severity(Severity.ERROR)
-                .build();
-                
-        ExampleBlock.CollapsibleConfig collapsible = ExampleBlock.CollapsibleConfig.builder()
-                .required(false)
-                .allowed(Arrays.asList(true, false))
-                .severity(Severity.INFO)
-                .build();
-                
-        ExampleBlock block = ExampleBlock.builder()
-                .name("example-test")
-                .severity(Severity.WARN)
-                .caption(caption)
-                .collapsible(collapsible)
-                .build();
-        
+        ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder().required(true).pattern("^Example.*")
+                .severity(Severity.ERROR).build();
+
+        ExampleBlock.CollapsibleConfig collapsible = ExampleBlock.CollapsibleConfig.builder().required(false)
+                .allowed(Arrays.asList(true, false)).severity(Severity.INFO).build();
+
+        ExampleBlock block = ExampleBlock.builder().name("example-test").severity(Severity.WARN).caption(caption)
+                .collapsible(collapsible).build();
+
         // When
         String result = block.toString();
-        
+
         // Then
         assertTrue(result.contains("name='example-test'"));
         assertTrue(result.contains("severity=WARN"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlockTest.java
@@ -18,70 +18,54 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("ImageBlock")
 class ImageBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build ImageBlock with all attributes")
         void shouldBuildImageBlockWithAllAttributes() {
             // Given
             ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder()
-                    .pattern("^https?://.*\\.(jpg|jpeg|png|gif|svg)$")
-                    .required(true)
-                    .build();
-                    
-            ImageBlock.DimensionConfig heightRule = ImageBlock.DimensionConfig.builder()
-                    .minValue(100)
-                    .maxValue(2000)
-                    .required(false)
-                    .build();
-                    
-            ImageBlock.DimensionConfig widthRule = ImageBlock.DimensionConfig.builder()
-                    .minValue(100)
-                    .maxValue(3000)
-                    .required(false)
-                    .build();
-                    
-            ImageBlock.AltTextConfig altRule = ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .maxLength(200)
-                    .build();
-            
+                    .pattern("^https?://.*\\.(jpg|jpeg|png|gif|svg)$").required(true).build();
+
+            ImageBlock.DimensionConfig heightRule = ImageBlock.DimensionConfig.builder().minValue(100).maxValue(2000)
+                    .required(false).build();
+
+            ImageBlock.DimensionConfig widthRule = ImageBlock.DimensionConfig.builder().minValue(100).maxValue(3000)
+                    .required(false).build();
+
+            ImageBlock.AltTextConfig altRule = ImageBlock.AltTextConfig.builder().required(true).minLength(10)
+                    .maxLength(200).build();
+
             // When
-            ImageBlock image = ImageBlock.builder()
-                    .severity(Severity.ERROR)
-                    .url(urlRule)
-                    .height(heightRule)
-                    .width(widthRule)
-                    .alt(altRule)
-                    .build();
-            
+            ImageBlock image = ImageBlock.builder().severity(Severity.ERROR).url(urlRule).height(heightRule)
+                    .width(widthRule).alt(altRule).build();
+
             // Then
             assertEquals(Severity.ERROR, image.getSeverity());
-            
+
             assertNotNull(image.getUrl());
             assertTrue(image.getUrl().isRequired());
             assertNotNull(image.getUrl().getPattern());
-            
+
             assertNotNull(image.getHeight());
             assertFalse(image.getHeight().isRequired());
             assertEquals(100, image.getHeight().getMinValue());
             assertEquals(2000, image.getHeight().getMaxValue());
-            
+
             assertNotNull(image.getWidth());
             assertFalse(image.getWidth().isRequired());
             assertEquals(100, image.getWidth().getMinValue());
             assertEquals(3000, image.getWidth().getMaxValue());
-            
+
             assertNotNull(image.getAlt());
             assertTrue(image.getAlt().isRequired());
             assertEquals(10, image.getAlt().getMinLength());
             assertEquals(200, image.getAlt().getMaxLength());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
@@ -91,225 +75,165 @@ class ImageBlockTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("UrlConfig Tests")
     class UrlConfigTests {
-        
+
         @Test
         @DisplayName("should create UrlConfig with string pattern")
         void shouldCreateUrlConfigWithStringPattern() {
             // Given & When
-            ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder()
-                    .pattern("^https://.*")
-                    .required(true)
-                    .build();
-            
+            ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder().pattern("^https://.*").required(true).build();
+
             // Then
             assertNotNull(urlRule.getPattern());
             assertEquals("^https://.*", urlRule.getPattern().pattern());
             assertTrue(urlRule.isRequired());
         }
-        
+
         @Test
         @DisplayName("should create UrlConfig with Pattern object")
         void shouldCreateUrlConfigWithPatternObject() {
             // Given
             Pattern pattern = Pattern.compile(".*\\.png$");
-            
+
             // When
-            ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder()
-                    .pattern(pattern)
-                    .required(false)
-                    .build();
-            
+            ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder().pattern(pattern).required(false).build();
+
             // Then
             assertEquals(pattern, urlRule.getPattern());
             assertFalse(urlRule.isRequired());
         }
-        
+
         @Test
         @DisplayName("should handle null pattern")
         void shouldHandleNullPattern() {
             // Given & When
-            ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder()
-                    .pattern((String) null)
-                    .build();
-            
+            ImageBlock.UrlConfig urlRule = ImageBlock.UrlConfig.builder().pattern((String) null).build();
+
             // Then
             assertNull(urlRule.getPattern());
         }
     }
-    
+
     @Nested
     @DisplayName("DimensionConfig Tests")
     class DimensionConfigTests {
-        
+
         @Test
         @DisplayName("should create DimensionConfig with min and max values")
         void shouldCreateDimensionConfigWithMinAndMaxValues() {
             // Given & When
-            ImageBlock.DimensionConfig dimension = ImageBlock.DimensionConfig.builder()
-                    .minValue(50)
-                    .maxValue(1000)
-                    .required(true)
-                    .build();
-            
+            ImageBlock.DimensionConfig dimension = ImageBlock.DimensionConfig.builder().minValue(50).maxValue(1000)
+                    .required(true).build();
+
             // Then
             assertEquals(50, dimension.getMinValue());
             assertEquals(1000, dimension.getMaxValue());
             assertTrue(dimension.isRequired());
         }
-        
+
         @Test
         @DisplayName("should allow optional dimensions")
         void shouldAllowOptionalDimensions() {
             // Given & When
-            ImageBlock.DimensionConfig dimension = ImageBlock.DimensionConfig.builder()
-                    .required(false)
-                    .build();
-            
+            ImageBlock.DimensionConfig dimension = ImageBlock.DimensionConfig.builder().required(false).build();
+
             // Then
             assertNull(dimension.getMinValue());
             assertNull(dimension.getMaxValue());
             assertFalse(dimension.isRequired());
         }
     }
-    
+
     @Nested
     @DisplayName("AltTextConfig Tests")
     class AltTextConfigTests {
-        
+
         @Test
         @DisplayName("should create AltTextConfig with length constraints")
         void shouldCreateAltTextConfigWithLengthConstraints() {
             // Given & When
-            ImageBlock.AltTextConfig altText = ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(150)
-                    .build();
-            
+            ImageBlock.AltTextConfig altText = ImageBlock.AltTextConfig.builder().required(true).minLength(5)
+                    .maxLength(150).build();
+
             // Then
             assertTrue(altText.isRequired());
             assertEquals(5, altText.getMinLength());
             assertEquals(150, altText.getMaxLength());
         }
-        
+
         @Test
         @DisplayName("should allow optional alt text")
         void shouldAllowOptionalAltText() {
             // Given & When
-            ImageBlock.AltTextConfig altText = ImageBlock.AltTextConfig.builder()
-                    .required(false)
-                    .build();
-            
+            ImageBlock.AltTextConfig altText = ImageBlock.AltTextConfig.builder().required(false).build();
+
             // Then
             assertFalse(altText.isRequired());
             assertNull(altText.getMinLength());
             assertNull(altText.getMaxLength());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should correctly implement equals and hashCode")
         void shouldCorrectlyImplementEqualsAndHashCode() {
             // Given
-            ImageBlock.UrlConfig url1 = ImageBlock.UrlConfig.builder()
-                    .pattern(".*\\.jpg$")
-                    .required(true)
-                    .build();
-                    
-            ImageBlock.UrlConfig url2 = ImageBlock.UrlConfig.builder()
-                    .pattern(".*\\.jpg$")
-                    .required(true)
-                    .build();
-                    
-            ImageBlock.AltTextConfig alt1 = ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .build();
-                    
-            ImageBlock.AltTextConfig alt2 = ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .build();
-                    
+            ImageBlock.UrlConfig url1 = ImageBlock.UrlConfig.builder().pattern(".*\\.jpg$").required(true).build();
+
+            ImageBlock.UrlConfig url2 = ImageBlock.UrlConfig.builder().pattern(".*\\.jpg$").required(true).build();
+
+            ImageBlock.AltTextConfig alt1 = ImageBlock.AltTextConfig.builder().required(true).minLength(10).build();
+
+            ImageBlock.AltTextConfig alt2 = ImageBlock.AltTextConfig.builder().required(true).minLength(10).build();
+
             // When
-            ImageBlock image1 = ImageBlock.builder()
-                    .severity(Severity.WARN)
-                    .url(url1)
-                    .alt(alt1)
-                    .build();
-                    
-            ImageBlock image2 = ImageBlock.builder()
-                    .severity(Severity.WARN)
-                    .url(url2)
-                    .alt(alt2)
-                    .build();
-                    
-            ImageBlock image3 = ImageBlock.builder()
-                    .severity(Severity.ERROR)
-                    .url(url1)
-                    .alt(alt1)
-                    .build();
-            
+            ImageBlock image1 = ImageBlock.builder().severity(Severity.WARN).url(url1).alt(alt1).build();
+
+            ImageBlock image2 = ImageBlock.builder().severity(Severity.WARN).url(url2).alt(alt2).build();
+
+            ImageBlock image3 = ImageBlock.builder().severity(Severity.ERROR).url(url1).alt(alt1).build();
+
             // Then
             assertEquals(image1, image2);
             assertNotEquals(image1, image3);
             assertEquals(image1.hashCode(), image2.hashCode());
             assertNotEquals(image1.hashCode(), image3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should test inner class equals and hashCode")
         void shouldTestInnerClassEqualsAndHashCode() {
             // Given
-            ImageBlock.UrlConfig url1 = ImageBlock.UrlConfig.builder()
-                    .pattern("test")
-                    .required(true)
+            ImageBlock.UrlConfig url1 = ImageBlock.UrlConfig.builder().pattern("test").required(true).build();
+
+            ImageBlock.UrlConfig url2 = ImageBlock.UrlConfig.builder().pattern("test").required(true).build();
+
+            ImageBlock.DimensionConfig dim1 = ImageBlock.DimensionConfig.builder().minValue(100).maxValue(200)
+                    .required(false).build();
+
+            ImageBlock.DimensionConfig dim2 = ImageBlock.DimensionConfig.builder().minValue(100).maxValue(200)
+                    .required(false).build();
+
+            ImageBlock.AltTextConfig alt1 = ImageBlock.AltTextConfig.builder().required(true).minLength(5).maxLength(50)
                     .build();
-                    
-            ImageBlock.UrlConfig url2 = ImageBlock.UrlConfig.builder()
-                    .pattern("test")
-                    .required(true)
+
+            ImageBlock.AltTextConfig alt2 = ImageBlock.AltTextConfig.builder().required(true).minLength(5).maxLength(50)
                     .build();
-                    
-            ImageBlock.DimensionConfig dim1 = ImageBlock.DimensionConfig.builder()
-                    .minValue(100)
-                    .maxValue(200)
-                    .required(false)
-                    .build();
-                    
-            ImageBlock.DimensionConfig dim2 = ImageBlock.DimensionConfig.builder()
-                    .minValue(100)
-                    .maxValue(200)
-                    .required(false)
-                    .build();
-                    
-            ImageBlock.AltTextConfig alt1 = ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .build();
-                    
-            ImageBlock.AltTextConfig alt2 = ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .build();
-            
+
             // Then
             assertEquals(url1, url2);
             assertEquals(url1.hashCode(), url2.hashCode());
-            
+
             assertEquals(dim1, dim2);
             assertEquals(dim1.hashCode(), dim2.hashCode());
-            
+
             assertEquals(alt1, alt2);
             assertEquals(alt1.hashCode(), alt2.hashCode());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlockTest.java
@@ -21,73 +21,54 @@ import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 
 @DisplayName("ListingBlock")
 class ListingBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build ListingBlock with all attributes")
         void shouldBuildListingBlockWithAllAttributes() {
             // Given
-            ListingBlock.LanguageConfig languageRule = ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("java", "python", "javascript", "yaml"))
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            LineConfig linesRule = LineConfig.builder()
-                    .min(3)
-                    .max(100)
-                    .build();
-                    
-            ListingBlock.TitleConfig titleRule = ListingBlock.TitleConfig.builder()
-                    .required(true)
-                    .pattern("^(Example|Beispiel|Listing)\\s+\\d+")
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            ListingBlock.CalloutsConfig calloutsRule = ListingBlock.CalloutsConfig.builder()
-                    .allowed(true)
-                    .max(10)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            ListingBlock.LanguageConfig languageRule = ListingBlock.LanguageConfig.builder().required(true)
+                    .allowed(Arrays.asList("java", "python", "javascript", "yaml")).severity(Severity.ERROR).build();
+
+            LineConfig linesRule = LineConfig.builder().min(3).max(100).build();
+
+            ListingBlock.TitleConfig titleRule = ListingBlock.TitleConfig.builder().required(true)
+                    .pattern("^(Example|Beispiel|Listing)\\s+\\d+").severity(Severity.WARN).build();
+
+            ListingBlock.CalloutsConfig calloutsRule = ListingBlock.CalloutsConfig.builder().allowed(true).max(10)
+                    .severity(Severity.INFO).build();
+
             // When
-            ListingBlock listing = ListingBlock.builder()
-                    .name("api-examples")
-                    .severity(Severity.ERROR)
-                    .language(languageRule)
-                    .lines(linesRule)
-                    .title(titleRule)
-                    .callouts(calloutsRule)
-                    .build();
-            
+            ListingBlock listing = ListingBlock.builder().name("api-examples").severity(Severity.ERROR)
+                    .language(languageRule).lines(linesRule).title(titleRule).callouts(calloutsRule).build();
+
             // Then
             assertEquals("api-examples", listing.getName());
             assertEquals(Severity.ERROR, listing.getSeverity());
-            
+
             assertNotNull(listing.getLanguage());
             assertTrue(listing.getLanguage().isRequired());
-            assertEquals(Arrays.asList("java", "python", "javascript", "yaml"), 
-                        listing.getLanguage().getAllowed());
+            assertEquals(Arrays.asList("java", "python", "javascript", "yaml"), listing.getLanguage().getAllowed());
             assertEquals(Severity.ERROR, listing.getLanguage().getSeverity());
-            
+
             assertNotNull(listing.getLines());
             assertEquals(3, listing.getLines().min());
             assertEquals(100, listing.getLines().max());
-            
+
             assertNotNull(listing.getTitle());
             assertTrue(listing.getTitle().isRequired());
             assertNotNull(listing.getTitle().getPattern());
             assertEquals(Severity.WARN, listing.getTitle().getSeverity());
-            
+
             assertNotNull(listing.getCallouts());
             assertTrue(listing.getCallouts().isAllowed());
             assertEquals(10, listing.getCallouts().getMax());
             assertEquals(Severity.INFO, listing.getCallouts().getSeverity());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
@@ -97,230 +78,175 @@ class ListingBlockTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("LanguageConfig Tests")
     class LanguageConfigTests {
-        
+
         @Test
         @DisplayName("should create LanguageConfig with allowed languages")
         void shouldCreateLanguageConfigWithAllowedLanguages() {
             // Given
             List<String> allowedLanguages = Arrays.asList("java", "kotlin", "scala");
-            
+
             // When
-            ListingBlock.LanguageConfig languageRule = ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(allowedLanguages)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            ListingBlock.LanguageConfig languageRule = ListingBlock.LanguageConfig.builder().required(true)
+                    .allowed(allowedLanguages).severity(Severity.ERROR).build();
+
             // Then
             assertTrue(languageRule.isRequired());
             assertEquals(allowedLanguages, languageRule.getAllowed());
             assertEquals(Severity.ERROR, languageRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle empty allowed list")
         void shouldHandleEmptyAllowedList() {
             // When
-            ListingBlock.LanguageConfig languageRule = ListingBlock.LanguageConfig.builder()
-                    .required(false)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ListingBlock.LanguageConfig languageRule = ListingBlock.LanguageConfig.builder().required(false)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertFalse(languageRule.isRequired());
             assertTrue(languageRule.getAllowed().isEmpty());
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("TitleConfig Tests")
     class TitleConfigTests {
-        
+
         @Test
         @DisplayName("should create TitleConfig with string pattern")
         void shouldCreateTitleConfigWithStringPattern() {
             // Given & When
-            ListingBlock.TitleConfig titleRule = ListingBlock.TitleConfig.builder()
-                    .required(true)
-                    .pattern("^Listing \\d+:")
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            ListingBlock.TitleConfig titleRule = ListingBlock.TitleConfig.builder().required(true)
+                    .pattern("^Listing \\d+:").severity(Severity.ERROR).build();
+
             // Then
             assertTrue(titleRule.isRequired());
             assertNotNull(titleRule.getPattern());
             assertEquals("^Listing \\d+:", titleRule.getPattern().pattern());
             assertEquals(Severity.ERROR, titleRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create TitleConfig with Pattern object")
         void shouldCreateTitleConfigWithPatternObject() {
             // Given
             Pattern pattern = Pattern.compile("^Example.*");
-            
+
             // When
-            ListingBlock.TitleConfig titleRule = ListingBlock.TitleConfig.builder()
-                    .required(false)
-                    .pattern(pattern)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ListingBlock.TitleConfig titleRule = ListingBlock.TitleConfig.builder().required(false).pattern(pattern)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertFalse(titleRule.isRequired());
             assertEquals(pattern, titleRule.getPattern());
             assertEquals(Severity.WARN, titleRule.getSeverity());
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("CalloutsConfig Tests")
     class CalloutsConfigTests {
-        
+
         @Test
         @DisplayName("should create CalloutsConfig with max limit")
         void shouldCreateCalloutsConfigWithMaxLimit() {
             // Given & When
-            ListingBlock.CalloutsConfig calloutsRule = ListingBlock.CalloutsConfig.builder()
-                    .allowed(true)
-                    .max(15)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            ListingBlock.CalloutsConfig calloutsRule = ListingBlock.CalloutsConfig.builder().allowed(true).max(15)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertTrue(calloutsRule.isAllowed());
             assertEquals(15, calloutsRule.getMax());
             assertEquals(Severity.INFO, calloutsRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create CalloutsConfig without max limit")
         void shouldCreateCalloutsConfigWithoutMaxLimit() {
             // Given & When
-            ListingBlock.CalloutsConfig calloutsRule = ListingBlock.CalloutsConfig.builder()
-                    .allowed(false)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            ListingBlock.CalloutsConfig calloutsRule = ListingBlock.CalloutsConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertFalse(calloutsRule.isAllowed());
             assertNull(calloutsRule.getMax());
             assertEquals(Severity.ERROR, calloutsRule.getSeverity());
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should correctly implement equals and hashCode")
         void shouldCorrectlyImplementEqualsAndHashCode() {
             // Given
-            ListingBlock.LanguageConfig lang1 = ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("java", "python"))
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            ListingBlock.LanguageConfig lang2 = ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("java", "python"))
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            ListingBlock.TitleConfig title1 = ListingBlock.TitleConfig.builder()
-                    .required(true)
-                    .pattern("^Example.*")
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            ListingBlock.TitleConfig title2 = ListingBlock.TitleConfig.builder()
-                    .required(true)
-                    .pattern("^Example.*")
-                    .severity(Severity.WARN)
-                    .build();
-                    
+            ListingBlock.LanguageConfig lang1 = ListingBlock.LanguageConfig.builder().required(true)
+                    .allowed(Arrays.asList("java", "python")).severity(Severity.ERROR).build();
+
+            ListingBlock.LanguageConfig lang2 = ListingBlock.LanguageConfig.builder().required(true)
+                    .allowed(Arrays.asList("java", "python")).severity(Severity.ERROR).build();
+
+            ListingBlock.TitleConfig title1 = ListingBlock.TitleConfig.builder().required(true).pattern("^Example.*")
+                    .severity(Severity.WARN).build();
+
+            ListingBlock.TitleConfig title2 = ListingBlock.TitleConfig.builder().required(true).pattern("^Example.*")
+                    .severity(Severity.WARN).build();
+
             // When
-            ListingBlock listing1 = ListingBlock.builder()
-                    .severity(Severity.ERROR)
-                    .language(lang1)
-                    .title(title1)
+            ListingBlock listing1 = ListingBlock.builder().severity(Severity.ERROR).language(lang1).title(title1)
                     .build();
-                    
-            ListingBlock listing2 = ListingBlock.builder()
-                    .severity(Severity.ERROR)
-                    .language(lang2)
-                    .title(title2)
+
+            ListingBlock listing2 = ListingBlock.builder().severity(Severity.ERROR).language(lang2).title(title2)
                     .build();
-                    
-            ListingBlock listing3 = ListingBlock.builder()
-                    .severity(Severity.WARN)
-                    .language(lang1)
-                    .title(title1)
+
+            ListingBlock listing3 = ListingBlock.builder().severity(Severity.WARN).language(lang1).title(title1)
                     .build();
-            
+
             // Then
             assertEquals(listing1, listing2);
             assertNotEquals(listing1, listing3);
             assertEquals(listing1.hashCode(), listing2.hashCode());
             assertNotEquals(listing1.hashCode(), listing3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should test inner class equals and hashCode")
         void shouldTestInnerClassEqualsAndHashCode() {
             // Given
-            ListingBlock.LanguageConfig lang1 = ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("java"))
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            ListingBlock.LanguageConfig lang2 = ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("java"))
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            ListingBlock.TitleConfig title1 = ListingBlock.TitleConfig.builder()
-                    .required(false)
-                    .pattern("test")
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            ListingBlock.TitleConfig title2 = ListingBlock.TitleConfig.builder()
-                    .required(false)
-                    .pattern("test")
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            ListingBlock.CalloutsConfig callouts1 = ListingBlock.CalloutsConfig.builder()
-                    .allowed(true)
-                    .max(5)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            ListingBlock.CalloutsConfig callouts2 = ListingBlock.CalloutsConfig.builder()
-                    .allowed(true)
-                    .max(5)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ListingBlock.LanguageConfig lang1 = ListingBlock.LanguageConfig.builder().required(true)
+                    .allowed(Arrays.asList("java")).severity(Severity.ERROR).build();
+
+            ListingBlock.LanguageConfig lang2 = ListingBlock.LanguageConfig.builder().required(true)
+                    .allowed(Arrays.asList("java")).severity(Severity.ERROR).build();
+
+            ListingBlock.TitleConfig title1 = ListingBlock.TitleConfig.builder().required(false).pattern("test")
+                    .severity(Severity.INFO).build();
+
+            ListingBlock.TitleConfig title2 = ListingBlock.TitleConfig.builder().required(false).pattern("test")
+                    .severity(Severity.INFO).build();
+
+            ListingBlock.CalloutsConfig callouts1 = ListingBlock.CalloutsConfig.builder().allowed(true).max(5)
+                    .severity(Severity.WARN).build();
+
+            ListingBlock.CalloutsConfig callouts2 = ListingBlock.CalloutsConfig.builder().allowed(true).max(5)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertEquals(lang1, lang2);
             assertEquals(lang1.hashCode(), lang2.hashCode());
-            
+
             assertEquals(title1, title2);
             assertEquals(title1.hashCode(), title2.hashCode());
-            
+
             assertEquals(callouts1, callouts2);
             assertEquals(callouts1.hashCode(), callouts2.hashCode());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlockTest.java
@@ -20,45 +20,27 @@ import com.dataliquid.asciidoc.linter.config.blocks.LiteralBlock.TitleConfig;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 
 class LiteralBlockTest {
-    
+
     @Nested
     @DisplayName("LiteralBlock")
     class LiteralBlockTests {
-        
+
         @Test
         @DisplayName("should create LiteralBlock with builder")
         void shouldCreateLiteralBlockWithBuilder() {
             // Given
-            TitleConfig titleConfig = TitleConfig.builder()
-                .required(false)
-                .minLength(5)
-                .maxLength(50)
-                .severity(Severity.INFO)
-                .build();
-                
-            LinesConfig linesConfig = LinesConfig.builder()
-                .min(1)
-                .max(50)
-                .severity(Severity.WARN)
-                .build();
-                
-            IndentationConfig indentationConfig = IndentationConfig.builder()
-                .required(false)
-                .consistent(true)
-                .minSpaces(0)
-                .maxSpaces(8)
-                .severity(Severity.INFO)
-                .build();
-            
+            TitleConfig titleConfig = TitleConfig.builder().required(false).minLength(5).maxLength(50)
+                    .severity(Severity.INFO).build();
+
+            LinesConfig linesConfig = LinesConfig.builder().min(1).max(50).severity(Severity.WARN).build();
+
+            IndentationConfig indentationConfig = IndentationConfig.builder().required(false).consistent(true)
+                    .minSpaces(0).maxSpaces(8).severity(Severity.INFO).build();
+
             // When
-            LiteralBlock block = LiteralBlock.builder()
-                .name("Config Example")
-                .severity(Severity.INFO)
-                .title(titleConfig)
-                .lines(linesConfig)
-                .indentation(indentationConfig)
-                .build();
-            
+            LiteralBlock block = LiteralBlock.builder().name("Config Example").severity(Severity.INFO)
+                    .title(titleConfig).lines(linesConfig).indentation(indentationConfig).build();
+
             // Then
             assertNotNull(block);
             assertEquals("Config Example", block.getName());
@@ -68,197 +50,139 @@ class LiteralBlockTest {
             assertEquals(linesConfig, block.getLines());
             assertEquals(indentationConfig, block.getIndentation());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
-            assertThrows(NullPointerException.class, () ->
-                LiteralBlock.builder()
-                    .name("Invalid Block")
-                    .build()
-            );
+            assertThrows(NullPointerException.class, () -> LiteralBlock.builder().name("Invalid Block").build());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            TitleConfig titleConfig = TitleConfig.builder()
-                .required(true)
-                .severity(Severity.INFO)
-                .build();
-                
-            LiteralBlock block1 = LiteralBlock.builder()
-                .severity(Severity.WARN)
-                .title(titleConfig)
-                .build();
-                
-            LiteralBlock block2 = LiteralBlock.builder()
-                .severity(Severity.WARN)
-                .title(titleConfig)
-                .build();
-                
-            LiteralBlock block3 = LiteralBlock.builder()
-                .severity(Severity.ERROR)
-                .title(titleConfig)
-                .build();
-            
+            TitleConfig titleConfig = TitleConfig.builder().required(true).severity(Severity.INFO).build();
+
+            LiteralBlock block1 = LiteralBlock.builder().severity(Severity.WARN).title(titleConfig).build();
+
+            LiteralBlock block2 = LiteralBlock.builder().severity(Severity.WARN).title(titleConfig).build();
+
+            LiteralBlock block3 = LiteralBlock.builder().severity(Severity.ERROR).title(titleConfig).build();
+
             // Then
             assertEquals(block1, block2);
             assertEquals(block1.hashCode(), block2.hashCode());
             assertNotEquals(block1, block3);
         }
     }
-    
+
     @Nested
     @DisplayName("TitleConfig")
     class TitleConfigTests {
-        
+
         @Test
         @DisplayName("should create TitleConfig with builder")
         void shouldCreateTitleConfigWithBuilder() {
             // When
-            TitleConfig config = TitleConfig.builder()
-                .required(false)
-                .minLength(5)
-                .maxLength(50)
-                .severity(Severity.INFO)
-                .build();
-            
+            TitleConfig config = TitleConfig.builder().required(false).minLength(5).maxLength(50)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertFalse(config.isRequired());
             assertEquals(5, config.getMinLength());
             assertEquals(50, config.getMaxLength());
             assertEquals(Severity.INFO, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle optional fields")
         void shouldHandleOptionalFields() {
             // When
-            TitleConfig config = TitleConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TitleConfig config = TitleConfig.builder().required(true).severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertNull(config.getMinLength());
             assertNull(config.getMaxLength());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            TitleConfig config1 = TitleConfig.builder()
-                .required(false)
-                .minLength(10)
-                .maxLength(100)
-                .severity(Severity.WARN)
-                .build();
-                
-            TitleConfig config2 = TitleConfig.builder()
-                .required(false)
-                .minLength(10)
-                .maxLength(100)
-                .severity(Severity.WARN)
-                .build();
-                
-            TitleConfig config3 = TitleConfig.builder()
-                .required(true)
-                .minLength(10)
-                .maxLength(100)
-                .severity(Severity.WARN)
-                .build();
-            
+            TitleConfig config1 = TitleConfig.builder().required(false).minLength(10).maxLength(100)
+                    .severity(Severity.WARN).build();
+
+            TitleConfig config2 = TitleConfig.builder().required(false).minLength(10).maxLength(100)
+                    .severity(Severity.WARN).build();
+
+            TitleConfig config3 = TitleConfig.builder().required(true).minLength(10).maxLength(100)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("LinesConfig")
     class LinesConfigTests {
-        
+
         @Test
         @DisplayName("should create LinesConfig with builder")
         void shouldCreateLinesConfigWithBuilder() {
             // When
-            LinesConfig config = LinesConfig.builder()
-                .min(1)
-                .max(50)
-                .severity(Severity.WARN)
-                .build();
-            
+            LinesConfig config = LinesConfig.builder().min(1).max(50).severity(Severity.WARN).build();
+
             // Then
             assertEquals(1, config.getMin());
             assertEquals(50, config.getMax());
             assertEquals(Severity.WARN, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle optional fields")
         void shouldHandleOptionalFields() {
             // When
-            LinesConfig config = LinesConfig.builder()
-                .severity(Severity.INFO)
-                .build();
-            
+            LinesConfig config = LinesConfig.builder().severity(Severity.INFO).build();
+
             // Then
             assertNull(config.getMin());
             assertNull(config.getMax());
             assertEquals(Severity.INFO, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            LinesConfig config1 = LinesConfig.builder()
-                .min(5)
-                .max(100)
-                .severity(Severity.ERROR)
-                .build();
-                
-            LinesConfig config2 = LinesConfig.builder()
-                .min(5)
-                .max(100)
-                .severity(Severity.ERROR)
-                .build();
-                
-            LinesConfig config3 = LinesConfig.builder()
-                .min(10)
-                .max(100)
-                .severity(Severity.ERROR)
-                .build();
-            
+            LinesConfig config1 = LinesConfig.builder().min(5).max(100).severity(Severity.ERROR).build();
+
+            LinesConfig config2 = LinesConfig.builder().min(5).max(100).severity(Severity.ERROR).build();
+
+            LinesConfig config3 = LinesConfig.builder().min(10).max(100).severity(Severity.ERROR).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("IndentationConfig")
     class IndentationConfigTests {
-        
+
         @Test
         @DisplayName("should create IndentationConfig with builder")
         void shouldCreateIndentationConfigWithBuilder() {
             // When
-            IndentationConfig config = IndentationConfig.builder()
-                .required(false)
-                .consistent(true)
-                .minSpaces(0)
-                .maxSpaces(8)
-                .severity(Severity.INFO)
-                .build();
-            
+            IndentationConfig config = IndentationConfig.builder().required(false).consistent(true).minSpaces(0)
+                    .maxSpaces(8).severity(Severity.INFO).build();
+
             // Then
             assertFalse(config.isRequired());
             assertTrue(config.isConsistent());
@@ -266,15 +190,13 @@ class LiteralBlockTest {
             assertEquals(8, config.getMaxSpaces());
             assertEquals(Severity.INFO, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle default boolean values")
         void shouldHandleDefaultBooleanValues() {
             // When
-            IndentationConfig config = IndentationConfig.builder()
-                .severity(Severity.WARN)
-                .build();
-            
+            IndentationConfig config = IndentationConfig.builder().severity(Severity.WARN).build();
+
             // Then
             assertFalse(config.isRequired());
             assertFalse(config.isConsistent());
@@ -282,107 +204,63 @@ class LiteralBlockTest {
             assertNull(config.getMaxSpaces());
             assertEquals(Severity.WARN, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            IndentationConfig config1 = IndentationConfig.builder()
-                .required(true)
-                .consistent(true)
-                .minSpaces(2)
-                .maxSpaces(4)
-                .severity(Severity.ERROR)
-                .build();
-                
-            IndentationConfig config2 = IndentationConfig.builder()
-                .required(true)
-                .consistent(true)
-                .minSpaces(2)
-                .maxSpaces(4)
-                .severity(Severity.ERROR)
-                .build();
-                
-            IndentationConfig config3 = IndentationConfig.builder()
-                .required(true)
-                .consistent(false)
-                .minSpaces(2)
-                .maxSpaces(4)
-                .severity(Severity.ERROR)
-                .build();
-            
+            IndentationConfig config1 = IndentationConfig.builder().required(true).consistent(true).minSpaces(2)
+                    .maxSpaces(4).severity(Severity.ERROR).build();
+
+            IndentationConfig config2 = IndentationConfig.builder().required(true).consistent(true).minSpaces(2)
+                    .maxSpaces(4).severity(Severity.ERROR).build();
+
+            IndentationConfig config3 = IndentationConfig.builder().required(true).consistent(false).minSpaces(2)
+                    .maxSpaces(4).severity(Severity.ERROR).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("Integration with AbstractBlock")
     class IntegrationTests {
-        
+
         @Test
         @DisplayName("should inherit occurrence from AbstractBlock")
         void shouldInheritOccurrenceFromAbstractBlock() {
             // Given
-            OccurrenceConfig occurrence = OccurrenceConfig.builder()
-                .min(0)
-                .max(3)
-                .severity(Severity.INFO)
-                .build();
-            
+            OccurrenceConfig occurrence = OccurrenceConfig.builder().min(0).max(3).severity(Severity.INFO).build();
+
             // When
-            LiteralBlock block = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .occurrence(occurrence)
-                .build();
-            
+            LiteralBlock block = LiteralBlock.builder().severity(Severity.INFO).occurrence(occurrence).build();
+
             // Then
             assertEquals(occurrence, block.getOccurrence());
         }
-        
+
         @Test
         @DisplayName("should support full configuration")
         void shouldSupportFullConfiguration() {
             // Given
-            TitleConfig titleConfig = TitleConfig.builder()
-                .required(false)
-                .minLength(5)
-                .maxLength(50)
-                .severity(Severity.INFO)
-                .build();
-                
-            LinesConfig linesConfig = LinesConfig.builder()
-                .min(1)
-                .max(50)
-                .severity(Severity.WARN)
-                .build();
-                
-            IndentationConfig indentationConfig = IndentationConfig.builder()
-                .required(false)
-                .consistent(true)
-                .minSpaces(0)
-                .maxSpaces(8)
-                .severity(Severity.INFO)
-                .build();
-                
-            OccurrenceConfig occurrence = OccurrenceConfig.builder()
-                .min(0)
-                .max(3)
-                .severity(Severity.INFO)
-                .build();
-            
+            TitleConfig titleConfig = TitleConfig.builder().required(false).minLength(5).maxLength(50)
+                    .severity(Severity.INFO).build();
+
+            LinesConfig linesConfig = LinesConfig.builder().min(1).max(50).severity(Severity.WARN).build();
+
+            IndentationConfig indentationConfig = IndentationConfig.builder().required(false).consistent(true)
+                    .minSpaces(0).maxSpaces(8).severity(Severity.INFO).build();
+
+            OccurrenceConfig occurrence = OccurrenceConfig.builder().min(0).max(3).severity(Severity.INFO).build();
+
             // When
-            LiteralBlock block = LiteralBlock.builder()
-                .name("Literal Block")
-                .severity(Severity.INFO)
-                .occurrence(occurrence)
-                .title(titleConfig)
-                .lines(linesConfig)
-                .indentation(indentationConfig)
-                .build();
-            
+            LiteralBlock block = LiteralBlock.builder().name("Literal Block").severity(Severity.INFO)
+                    .occurrence(occurrence).title(titleConfig).lines(linesConfig).indentation(indentationConfig)
+                    .build();
+
             // Then
             assertEquals("Literal Block", block.getName());
             assertEquals(Severity.INFO, block.getSeverity());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlockTest.java
@@ -24,44 +24,28 @@ import com.dataliquid.asciidoc.linter.config.blocks.PassBlock.TypeConfig;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 
 class PassBlockTest {
-    
+
     @Nested
     @DisplayName("PassBlock")
     class PassBlockTests {
-        
+
         @Test
         @DisplayName("should create PassBlock with builder")
         void shouldCreatePassBlockWithBuilder() {
             // Given
-            TypeConfig typeConfig = TypeConfig.builder()
-                .required(true)
-                .allowed(Arrays.asList("html", "xml", "svg"))
-                .severity(Severity.ERROR)
-                .build();
-                
-            ContentConfig contentConfig = ContentConfig.builder()
-                .required(true)
-                .maxLength(1000)
-                .pattern("^<[^>]+>.*</[^>]+>$")
-                .severity(Severity.ERROR)
-                .build();
-                
-            ReasonConfig reasonConfig = ReasonConfig.builder()
-                .required(true)
-                .minLength(20)
-                .maxLength(200)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TypeConfig typeConfig = TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml", "svg"))
+                    .severity(Severity.ERROR).build();
+
+            ContentConfig contentConfig = ContentConfig.builder().required(true).maxLength(1000)
+                    .pattern("^<[^>]+>.*</[^>]+>$").severity(Severity.ERROR).build();
+
+            ReasonConfig reasonConfig = ReasonConfig.builder().required(true).minLength(20).maxLength(200)
+                    .severity(Severity.ERROR).build();
+
             // When
-            PassBlock block = PassBlock.builder()
-                .name("Custom HTML Pass")
-                .severity(Severity.ERROR)
-                .type(typeConfig)
-                .content(contentConfig)
-                .reason(reasonConfig)
-                .build();
-            
+            PassBlock block = PassBlock.builder().name("Custom HTML Pass").severity(Severity.ERROR).type(typeConfig)
+                    .content(contentConfig).reason(reasonConfig).build();
+
             // Then
             assertNotNull(block);
             assertEquals("Custom HTML Pass", block.getName());
@@ -71,351 +55,244 @@ class PassBlockTest {
             assertEquals(contentConfig, block.getContent());
             assertEquals(reasonConfig, block.getReason());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
-            assertThrows(NullPointerException.class, () ->
-                PassBlock.builder()
-                    .name("Invalid Block")
-                    .build()
-            );
+            assertThrows(NullPointerException.class, () -> PassBlock.builder().name("Invalid Block").build());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            TypeConfig typeConfig = TypeConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-                
-            PassBlock block1 = PassBlock.builder()
-                .severity(Severity.WARN)
-                .type(typeConfig)
-                .build();
-                
-            PassBlock block2 = PassBlock.builder()
-                .severity(Severity.WARN)
-                .type(typeConfig)
-                .build();
-                
-            PassBlock block3 = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .type(typeConfig)
-                .build();
-            
+            TypeConfig typeConfig = TypeConfig.builder().required(true).severity(Severity.ERROR).build();
+
+            PassBlock block1 = PassBlock.builder().severity(Severity.WARN).type(typeConfig).build();
+
+            PassBlock block2 = PassBlock.builder().severity(Severity.WARN).type(typeConfig).build();
+
+            PassBlock block3 = PassBlock.builder().severity(Severity.ERROR).type(typeConfig).build();
+
             // Then
             assertEquals(block1, block2);
             assertEquals(block1.hashCode(), block2.hashCode());
             assertNotEquals(block1, block3);
         }
     }
-    
+
     @Nested
     @DisplayName("TypeConfig")
     class TypeConfigTests {
-        
+
         @Test
         @DisplayName("should create TypeConfig with builder")
         void shouldCreateTypeConfigWithBuilder() {
             // Given
             List<String> allowed = Arrays.asList("html", "xml", "svg");
-            
+
             // When
-            TypeConfig config = TypeConfig.builder()
-                .required(true)
-                .allowed(allowed)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TypeConfig config = TypeConfig.builder().required(true).allowed(allowed).severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertEquals(allowed, config.getAllowed());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle empty allowed list")
         void shouldHandleEmptyAllowedList() {
             // When
-            TypeConfig config = TypeConfig.builder()
-                .required(false)
-                .severity(Severity.WARN)
-                .build();
-            
+            TypeConfig config = TypeConfig.builder().required(false).severity(Severity.WARN).build();
+
             // Then
             assertFalse(config.isRequired());
             assertTrue(config.getAllowed().isEmpty());
             assertEquals(Severity.WARN, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should make allowed list immutable")
         void shouldMakeAllowedListImmutable() {
             // Given
             List<String> allowed = Arrays.asList("html", "xml");
-            TypeConfig config = TypeConfig.builder()
-                .allowed(allowed)
-                .severity(Severity.INFO)
-                .build();
-            
+            TypeConfig config = TypeConfig.builder().allowed(allowed).severity(Severity.INFO).build();
+
             // Then
-            assertThrows(UnsupportedOperationException.class, () ->
-                config.getAllowed().add("svg")
-            );
+            assertThrows(UnsupportedOperationException.class, () -> config.getAllowed().add("svg"));
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            TypeConfig config1 = TypeConfig.builder()
-                .required(true)
-                .allowed(Arrays.asList("html", "xml"))
-                .severity(Severity.ERROR)
-                .build();
-                
-            TypeConfig config2 = TypeConfig.builder()
-                .required(true)
-                .allowed(Arrays.asList("html", "xml"))
-                .severity(Severity.ERROR)
-                .build();
-                
-            TypeConfig config3 = TypeConfig.builder()
-                .required(false)
-                .allowed(Arrays.asList("html", "xml"))
-                .severity(Severity.ERROR)
-                .build();
-            
+            TypeConfig config1 = TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml"))
+                    .severity(Severity.ERROR).build();
+
+            TypeConfig config2 = TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml"))
+                    .severity(Severity.ERROR).build();
+
+            TypeConfig config3 = TypeConfig.builder().required(false).allowed(Arrays.asList("html", "xml"))
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("ContentConfig")
     class ContentConfigTests {
-        
+
         @Test
         @DisplayName("should create ContentConfig with builder")
         void shouldCreateContentConfigWithBuilder() {
             // Given
             Pattern pattern = Pattern.compile("^<[^>]+>.*</[^>]+>$");
-            
+
             // When
-            ContentConfig config = ContentConfig.builder()
-                .required(true)
-                .maxLength(1000)
-                .pattern(pattern)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ContentConfig config = ContentConfig.builder().required(true).maxLength(1000).pattern(pattern)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertEquals(1000, config.getMaxLength());
             assertEquals(pattern.pattern(), config.getPattern().pattern());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should accept pattern as string")
         void shouldAcceptPatternAsString() {
             // When
-            ContentConfig config = ContentConfig.builder()
-                .pattern("^<div.*>.*</div>$")
-                .severity(Severity.WARN)
-                .build();
-            
+            ContentConfig config = ContentConfig.builder().pattern("^<div.*>.*</div>$").severity(Severity.WARN).build();
+
             // Then
             assertNotNull(config.getPattern());
             assertEquals("^<div.*>.*</div>$", config.getPattern().pattern());
         }
-        
+
         @Test
         @DisplayName("should handle null pattern")
         void shouldHandleNullPattern() {
             // When
-            ContentConfig config = ContentConfig.builder()
-                .required(false)
-                .maxLength(500)
-                .pattern((Pattern) null)
-                .severity(Severity.INFO)
-                .build();
-            
+            ContentConfig config = ContentConfig.builder().required(false).maxLength(500).pattern((Pattern) null)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertNull(config.getPattern());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode with pattern")
         void shouldSupportEqualsAndHashCodeWithPattern() {
             // Given
-            ContentConfig config1 = ContentConfig.builder()
-                .required(true)
-                .maxLength(1000)
-                .pattern("^<[^>]+>.*$")
-                .severity(Severity.ERROR)
-                .build();
-                
-            ContentConfig config2 = ContentConfig.builder()
-                .required(true)
-                .maxLength(1000)
-                .pattern("^<[^>]+>.*$")
-                .severity(Severity.ERROR)
-                .build();
-                
-            ContentConfig config3 = ContentConfig.builder()
-                .required(true)
-                .maxLength(1000)
-                .pattern("^<div>.*$")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ContentConfig config1 = ContentConfig.builder().required(true).maxLength(1000).pattern("^<[^>]+>.*$")
+                    .severity(Severity.ERROR).build();
+
+            ContentConfig config2 = ContentConfig.builder().required(true).maxLength(1000).pattern("^<[^>]+>.*$")
+                    .severity(Severity.ERROR).build();
+
+            ContentConfig config3 = ContentConfig.builder().required(true).maxLength(1000).pattern("^<div>.*$")
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("ReasonConfig")
     class ReasonConfigTests {
-        
+
         @Test
         @DisplayName("should create ReasonConfig with builder")
         void shouldCreateReasonConfigWithBuilder() {
             // When
-            ReasonConfig config = ReasonConfig.builder()
-                .required(true)
-                .minLength(20)
-                .maxLength(200)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ReasonConfig config = ReasonConfig.builder().required(true).minLength(20).maxLength(200)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertTrue(config.isRequired());
             assertEquals(20, config.getMinLength());
             assertEquals(200, config.getMaxLength());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should handle optional lengths")
         void shouldHandleOptionalLengths() {
             // When
-            ReasonConfig config = ReasonConfig.builder()
-                .required(false)
-                .severity(Severity.WARN)
-                .build();
-            
+            ReasonConfig config = ReasonConfig.builder().required(false).severity(Severity.WARN).build();
+
             // Then
             assertFalse(config.isRequired());
             assertNull(config.getMinLength());
             assertNull(config.getMaxLength());
             assertEquals(Severity.WARN, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
             // Given
-            ReasonConfig config1 = ReasonConfig.builder()
-                .required(true)
-                .minLength(10)
-                .maxLength(100)
-                .severity(Severity.ERROR)
-                .build();
-                
-            ReasonConfig config2 = ReasonConfig.builder()
-                .required(true)
-                .minLength(10)
-                .maxLength(100)
-                .severity(Severity.ERROR)
-                .build();
-                
-            ReasonConfig config3 = ReasonConfig.builder()
-                .required(true)
-                .minLength(20)
-                .maxLength(100)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ReasonConfig config1 = ReasonConfig.builder().required(true).minLength(10).maxLength(100)
+                    .severity(Severity.ERROR).build();
+
+            ReasonConfig config2 = ReasonConfig.builder().required(true).minLength(10).maxLength(100)
+                    .severity(Severity.ERROR).build();
+
+            ReasonConfig config3 = ReasonConfig.builder().required(true).minLength(20).maxLength(100)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("Integration with AbstractBlock")
     class IntegrationTests {
-        
+
         @Test
         @DisplayName("should inherit occurrence from AbstractBlock")
         void shouldInheritOccurrenceFromAbstractBlock() {
             // Given
-            OccurrenceConfig occurrence = OccurrenceConfig.builder()
-                .min(0)
-                .max(1)
-                .severity(Severity.ERROR)
-                .build();
-            
+            OccurrenceConfig occurrence = OccurrenceConfig.builder().min(0).max(1).severity(Severity.ERROR).build();
+
             // When
-            PassBlock block = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .occurrence(occurrence)
-                .build();
-            
+            PassBlock block = PassBlock.builder().severity(Severity.ERROR).occurrence(occurrence).build();
+
             // Then
             assertEquals(occurrence, block.getOccurrence());
         }
-        
+
         @Test
         @DisplayName("should support full configuration")
         void shouldSupportFullConfiguration() {
             // Given
-            TypeConfig typeConfig = TypeConfig.builder()
-                .required(true)
-                .allowed(Arrays.asList("html", "xml", "svg"))
-                .severity(Severity.ERROR)
-                .build();
-                
-            ContentConfig contentConfig = ContentConfig.builder()
-                .required(true)
-                .maxLength(1000)
-                .pattern("^<[^>]+>.*</[^>]+>$")
-                .severity(Severity.ERROR)
-                .build();
-                
-            ReasonConfig reasonConfig = ReasonConfig.builder()
-                .required(true)
-                .minLength(20)
-                .maxLength(200)
-                .severity(Severity.ERROR)
-                .build();
-                
-            OccurrenceConfig occurrence = OccurrenceConfig.builder()
-                .min(0)
-                .max(1)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TypeConfig typeConfig = TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml", "svg"))
+                    .severity(Severity.ERROR).build();
+
+            ContentConfig contentConfig = ContentConfig.builder().required(true).maxLength(1000)
+                    .pattern("^<[^>]+>.*</[^>]+>$").severity(Severity.ERROR).build();
+
+            ReasonConfig reasonConfig = ReasonConfig.builder().required(true).minLength(20).maxLength(200)
+                    .severity(Severity.ERROR).build();
+
+            OccurrenceConfig occurrence = OccurrenceConfig.builder().min(0).max(1).severity(Severity.ERROR).build();
+
             // When
-            PassBlock block = PassBlock.builder()
-                .name("Passthrough Block")
-                .severity(Severity.ERROR)
-                .occurrence(occurrence)
-                .type(typeConfig)
-                .content(contentConfig)
-                .reason(reasonConfig)
-                .build();
-            
+            PassBlock block = PassBlock.builder().name("Passthrough Block").severity(Severity.ERROR)
+                    .occurrence(occurrence).type(typeConfig).content(contentConfig).reason(reasonConfig).build();
+
             // Then
             assertEquals("Passthrough Block", block.getName());
             assertEquals(Severity.ERROR, block.getSeverity());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlockTest.java
@@ -18,77 +18,48 @@ import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 
 @DisplayName("QuoteBlock Configuration Tests")
 class QuoteBlockTest {
-    
+
     @Test
     @DisplayName("should return QUOTE as block type")
     void shouldReturnCorrectBlockType() {
-        QuoteBlock block = QuoteBlock.builder()
-                .severity(Severity.INFO)
-                .build();
-        
+        QuoteBlock block = QuoteBlock.builder().severity(Severity.INFO).build();
+
         assertEquals(BlockType.QUOTE, block.getType());
     }
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build with minimal configuration")
         void shouldBuildWithMinimalConfig() {
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .build();
-            
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN).build();
+
             assertNotNull(block);
             assertEquals(Severity.WARN, block.getSeverity());
             assertNull(block.getAttribution());
             assertNull(block.getCitation());
             assertNull(block.getContent());
         }
-        
+
         @Test
         @DisplayName("should build with complete configuration")
         void shouldBuildWithCompleteConfig() {
-            QuoteBlock.AttributionConfig attribution = QuoteBlock.AttributionConfig.builder()
-                    .required(true)
-                    .minLength(3)
-                    .maxLength(100)
-                    .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
-                    .severity(Severity.ERROR)
-                    .build();
-            
-            QuoteBlock.CitationConfig citation = QuoteBlock.CitationConfig.builder()
-                    .required(false)
-                    .minLength(5)
-                    .maxLength(200)
-                    .pattern("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$")
-                    .severity(Severity.WARN)
-                    .build();
-            
-            QuoteBlock.ContentConfig content = QuoteBlock.ContentConfig.builder()
-                    .required(true)
-                    .minLength(20)
+            QuoteBlock.AttributionConfig attribution = QuoteBlock.AttributionConfig.builder().required(true)
+                    .minLength(3).maxLength(100).pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$").severity(Severity.ERROR).build();
+
+            QuoteBlock.CitationConfig citation = QuoteBlock.CitationConfig.builder().required(false).minLength(5)
+                    .maxLength(200).pattern("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$").severity(Severity.WARN).build();
+
+            QuoteBlock.ContentConfig content = QuoteBlock.ContentConfig.builder().required(true).minLength(20)
                     .maxLength(1000)
-                    .lines(QuoteBlock.LinesConfig.builder()
-                            .min(1)
-                            .max(20)
-                            .severity(Severity.INFO)
-                            .build())
-                    .build();
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .name("important-quote")
-                    .severity(Severity.INFO)
-                    .occurrence(OccurrenceConfig.builder()
-                            .min(0)
-                            .max(3)
-                            .build())
-                    .attribution(attribution)
-                    .citation(citation)
-                    .content(content)
-                    .build();
-            
+                    .lines(QuoteBlock.LinesConfig.builder().min(1).max(20).severity(Severity.INFO).build()).build();
+
+            QuoteBlock block = QuoteBlock.builder().name("important-quote").severity(Severity.INFO)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(3).build()).attribution(attribution)
+                    .citation(citation).content(content).build();
+
             assertNotNull(block);
             assertEquals("important-quote", block.getName());
             assertEquals(Severity.INFO, block.getSeverity());
@@ -102,44 +73,36 @@ class QuoteBlockTest {
             assertNotNull(block.getContent());
             assertTrue(block.getContent().isRequired());
         }
-        
+
         @Test
         @DisplayName("should throw exception when severity is null")
         void shouldThrowWhenSeverityNull() {
-            assertThrows(NullPointerException.class, () -> 
-                    QuoteBlock.builder().build(),
-                    "severity is required"
-            );
+            assertThrows(NullPointerException.class, () -> QuoteBlock.builder().build(), "severity is required");
         }
     }
-    
+
     @Nested
     @DisplayName("AttributionConfig Tests")
     class AttributionConfigTests {
-        
+
         @Test
         @DisplayName("should build with default values")
         void shouldBuildWithDefaults() {
             QuoteBlock.AttributionConfig config = QuoteBlock.AttributionConfig.builder().build();
-            
+
             assertFalse(config.isRequired());
             assertNull(config.getMinLength());
             assertNull(config.getMaxLength());
             assertNull(config.getPattern());
             assertNull(config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build with all values")
         void shouldBuildWithAllValues() {
-            QuoteBlock.AttributionConfig config = QuoteBlock.AttributionConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            QuoteBlock.AttributionConfig config = QuoteBlock.AttributionConfig.builder().required(true).minLength(5)
+                    .maxLength(50).pattern("^[A-Z].*").severity(Severity.ERROR).build();
+
             assertTrue(config.isRequired());
             assertEquals(5, config.getMinLength());
             assertEquals(50, config.getMaxLength());
@@ -147,61 +110,47 @@ class QuoteBlockTest {
             assertEquals("^[A-Z].*", config.getPattern().pattern());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should implement equals and hashCode correctly")
         void shouldImplementEqualsAndHashCode() {
-            QuoteBlock.AttributionConfig config1 = QuoteBlock.AttributionConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .pattern("^[A-Z].*")
-                    .build();
-            
-            QuoteBlock.AttributionConfig config2 = QuoteBlock.AttributionConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .pattern("^[A-Z].*")
-                    .build();
-            
-            QuoteBlock.AttributionConfig config3 = QuoteBlock.AttributionConfig.builder()
-                    .required(false)
-                    .minLength(5)
-                    .pattern("^[A-Z].*")
-                    .build();
-            
+            QuoteBlock.AttributionConfig config1 = QuoteBlock.AttributionConfig.builder().required(true).minLength(5)
+                    .pattern("^[A-Z].*").build();
+
+            QuoteBlock.AttributionConfig config2 = QuoteBlock.AttributionConfig.builder().required(true).minLength(5)
+                    .pattern("^[A-Z].*").build();
+
+            QuoteBlock.AttributionConfig config3 = QuoteBlock.AttributionConfig.builder().required(false).minLength(5)
+                    .pattern("^[A-Z].*").build();
+
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("CitationConfig Tests")
     class CitationConfigTests {
-        
+
         @Test
         @DisplayName("should build with default values")
         void shouldBuildWithDefaults() {
             QuoteBlock.CitationConfig config = QuoteBlock.CitationConfig.builder().build();
-            
+
             assertFalse(config.isRequired());
             assertNull(config.getMinLength());
             assertNull(config.getMaxLength());
             assertNull(config.getPattern());
             assertNull(config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build with all values")
         void shouldBuildWithAllValues() {
-            QuoteBlock.CitationConfig config = QuoteBlock.CitationConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .maxLength(100)
-                    .pattern("^[A-Za-z0-9\\\\s]+$")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            QuoteBlock.CitationConfig config = QuoteBlock.CitationConfig.builder().required(true).minLength(10)
+                    .maxLength(100).pattern("^[A-Za-z0-9\\\\s]+$").severity(Severity.WARN).build();
+
             assertTrue(config.isRequired());
             assertEquals(10, config.getMinLength());
             assertEquals(100, config.getMaxLength());
@@ -210,38 +159,31 @@ class QuoteBlockTest {
             assertEquals(Severity.WARN, config.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("ContentConfig Tests")
     class ContentConfigTests {
-        
+
         @Test
         @DisplayName("should build with default values")
         void shouldBuildWithDefaults() {
             QuoteBlock.ContentConfig config = QuoteBlock.ContentConfig.builder().build();
-            
+
             assertFalse(config.isRequired());
             assertNull(config.getMinLength());
             assertNull(config.getMaxLength());
             assertNull(config.getLines());
         }
-        
+
         @Test
         @DisplayName("should build with all values")
         void shouldBuildWithAllValues() {
-            QuoteBlock.LinesConfig lines = QuoteBlock.LinesConfig.builder()
-                    .min(2)
-                    .max(10)
-                    .severity(Severity.INFO)
+            QuoteBlock.LinesConfig lines = QuoteBlock.LinesConfig.builder().min(2).max(10).severity(Severity.INFO)
                     .build();
-            
-            QuoteBlock.ContentConfig config = QuoteBlock.ContentConfig.builder()
-                    .required(true)
-                    .minLength(50)
-                    .maxLength(500)
-                    .lines(lines)
-                    .build();
-            
+
+            QuoteBlock.ContentConfig config = QuoteBlock.ContentConfig.builder().required(true).minLength(50)
+                    .maxLength(500).lines(lines).build();
+
             assertTrue(config.isRequired());
             assertEquals(50, config.getMinLength());
             assertEquals(500, config.getMaxLength());
@@ -250,118 +192,81 @@ class QuoteBlockTest {
             assertEquals(10, config.getLines().getMax());
         }
     }
-    
+
     @Nested
     @DisplayName("LinesConfig Tests")
     class LinesConfigTests {
-        
+
         @Test
         @DisplayName("should build with default values")
         void shouldBuildWithDefaults() {
             QuoteBlock.LinesConfig config = QuoteBlock.LinesConfig.builder().build();
-            
+
             assertNull(config.getMin());
             assertNull(config.getMax());
             assertNull(config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build with all values")
         void shouldBuildWithAllValues() {
-            QuoteBlock.LinesConfig config = QuoteBlock.LinesConfig.builder()
-                    .min(1)
-                    .max(20)
-                    .severity(Severity.WARN)
+            QuoteBlock.LinesConfig config = QuoteBlock.LinesConfig.builder().min(1).max(20).severity(Severity.WARN)
                     .build();
-            
+
             assertEquals(1, config.getMin());
             assertEquals(20, config.getMax());
             assertEquals(Severity.WARN, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should implement equals and hashCode correctly")
         void shouldImplementEqualsAndHashCode() {
-            QuoteBlock.LinesConfig config1 = QuoteBlock.LinesConfig.builder()
-                    .min(5)
-                    .max(10)
-                    .severity(Severity.INFO)
+            QuoteBlock.LinesConfig config1 = QuoteBlock.LinesConfig.builder().min(5).max(10).severity(Severity.INFO)
                     .build();
-            
-            QuoteBlock.LinesConfig config2 = QuoteBlock.LinesConfig.builder()
-                    .min(5)
-                    .max(10)
-                    .severity(Severity.INFO)
+
+            QuoteBlock.LinesConfig config2 = QuoteBlock.LinesConfig.builder().min(5).max(10).severity(Severity.INFO)
                     .build();
-            
-            QuoteBlock.LinesConfig config3 = QuoteBlock.LinesConfig.builder()
-                    .min(5)
-                    .max(15)
-                    .severity(Severity.INFO)
+
+            QuoteBlock.LinesConfig config3 = QuoteBlock.LinesConfig.builder().min(5).max(15).severity(Severity.INFO)
                     .build();
-            
+
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should implement equals correctly")
         void shouldImplementEquals() {
-            QuoteBlock block1 = QuoteBlock.builder()
-                    .name("quote1")
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .build())
-                    .build();
-            
-            QuoteBlock block2 = QuoteBlock.builder()
-                    .name("quote1")
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .build())
-                    .build();
-            
-            QuoteBlock block3 = QuoteBlock.builder()
-                    .name("quote2")
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .build())
-                    .build();
-            
+            QuoteBlock block1 = QuoteBlock.builder().name("quote1").severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().required(true).build()).build();
+
+            QuoteBlock block2 = QuoteBlock.builder().name("quote1").severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().required(true).build()).build();
+
+            QuoteBlock block3 = QuoteBlock.builder().name("quote2").severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().required(true).build()).build();
+
             assertEquals(block1, block2);
             assertNotEquals(block1, block3);
             assertNotEquals(block1, null);
             assertNotEquals(block1, new Object());
         }
-        
+
         @Test
         @DisplayName("should implement hashCode consistently")
         void shouldImplementHashCode() {
-            QuoteBlock block1 = QuoteBlock.builder()
-                    .severity(Severity.ERROR)
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .required(false)
-                            .maxLength(100)
-                            .build())
-                    .build();
-            
-            QuoteBlock block2 = QuoteBlock.builder()
-                    .severity(Severity.ERROR)
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .required(false)
-                            .maxLength(100)
-                            .build())
-                    .build();
-            
+            QuoteBlock block1 = QuoteBlock.builder().severity(Severity.ERROR)
+                    .citation(QuoteBlock.CitationConfig.builder().required(false).maxLength(100).build()).build();
+
+            QuoteBlock block2 = QuoteBlock.builder().severity(Severity.ERROR)
+                    .citation(QuoteBlock.CitationConfig.builder().required(false).maxLength(100).build()).build();
+
             assertEquals(block1.hashCode(), block2.hashCode());
         }
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlockTest.java
@@ -18,24 +18,21 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("SidebarBlock")
 class SidebarBlockTest {
-    
+
     @Nested
     @DisplayName("Builder")
     class BuilderTest {
-        
+
         @Test
         @DisplayName("should build with required fields")
         void shouldBuildWithRequiredFields() {
             // Given
             String name = "sidebar-test";
             Severity severity = Severity.WARN;
-            
+
             // When
-            SidebarBlock block = SidebarBlock.builder()
-                .name(name)
-                .severity(severity)
-                .build();
-            
+            SidebarBlock block = SidebarBlock.builder().name(name).severity(severity).build();
+
             // Then
             assertEquals(name, block.getName());
             assertEquals(severity, block.getSeverity());
@@ -44,45 +41,25 @@ class SidebarBlockTest {
             assertNull(block.getContent());
             assertNull(block.getPosition());
         }
-        
+
         @Test
         @DisplayName("should build with all fields")
         void shouldBuildWithAllFields() {
             // Given
             String name = "sidebar-full";
             Severity severity = Severity.ERROR;
-            SidebarBlock.TitleConfig title = SidebarBlock.TitleConfig.builder()
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*$")
-                .severity(Severity.INFO)
-                .build();
-            SidebarBlock.ContentConfig content = SidebarBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(50)
-                .maxLength(800)
-                .lines(SidebarBlock.LinesConfig.builder()
-                    .min(3)
-                    .max(30)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            SidebarBlock.PositionConfig position = SidebarBlock.PositionConfig.builder()
-                .required(false)
-                .allowed(List.of("left", "right", "float"))
-                .severity(Severity.INFO)
-                .build();
-            
+            SidebarBlock.TitleConfig title = SidebarBlock.TitleConfig.builder().required(true).minLength(5)
+                    .maxLength(50).pattern("^[A-Z].*$").severity(Severity.INFO).build();
+            SidebarBlock.ContentConfig content = SidebarBlock.ContentConfig.builder().required(true).minLength(50)
+                    .maxLength(800)
+                    .lines(SidebarBlock.LinesConfig.builder().min(3).max(30).severity(Severity.INFO).build()).build();
+            SidebarBlock.PositionConfig position = SidebarBlock.PositionConfig.builder().required(false)
+                    .allowed(List.of("left", "right", "float")).severity(Severity.INFO).build();
+
             // When
-            SidebarBlock block = SidebarBlock.builder()
-                .name(name)
-                .severity(severity)
-                .title(title)
-                .content(content)
-                .position(position)
-                .build();
-            
+            SidebarBlock block = SidebarBlock.builder().name(name).severity(severity).title(title).content(content)
+                    .position(position).build();
+
             // Then
             assertEquals(name, block.getName());
             assertEquals(severity, block.getSeverity());
@@ -90,24 +67,20 @@ class SidebarBlockTest {
             assertEquals(content, block.getContent());
             assertEquals(position, block.getPosition());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
             // When/Then
-            assertThrows(NullPointerException.class, () ->
-                SidebarBlock.builder()
-                    .name("test")
-                    .build(),
-                "severity is required"
-            );
+            assertThrows(NullPointerException.class, () -> SidebarBlock.builder().name("test").build(),
+                    "severity is required");
         }
     }
-    
+
     @Nested
     @DisplayName("TitleConfig")
     class TitleConfigTest {
-        
+
         @Test
         @DisplayName("should build with all fields")
         void shouldBuildWithAllFields() {
@@ -118,16 +91,11 @@ class SidebarBlockTest {
             String patternStr = "^[A-Z].*$";
             Pattern pattern = Pattern.compile(patternStr);
             Severity severity = Severity.WARN;
-            
+
             // When
-            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder()
-                .required(required)
-                .minLength(minLength)
-                .maxLength(maxLength)
-                .pattern(pattern)
-                .severity(severity)
-                .build();
-            
+            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder().required(required).minLength(minLength)
+                    .maxLength(maxLength).pattern(pattern).severity(severity).build();
+
             // Then
             assertEquals(required, config.isRequired());
             assertEquals(minLength, config.getMinLength());
@@ -135,74 +103,55 @@ class SidebarBlockTest {
             assertEquals(pattern.pattern(), config.getPattern().pattern());
             assertEquals(severity, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build with pattern string")
         void shouldBuildWithPatternString() {
             // Given
             String patternStr = "^[A-Z].*$";
-            
+
             // When
-            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder()
-                .pattern(patternStr)
-                .build();
-            
+            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder().pattern(patternStr).build();
+
             // Then
             assertNotNull(config.getPattern());
             assertEquals(patternStr, config.getPattern().pattern());
         }
-        
+
         @Test
         @DisplayName("should handle null pattern string")
         void shouldHandleNullPatternString() {
             // When
-            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder()
-                .pattern((String) null)
-                .build();
-            
+            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder().pattern((String) null).build();
+
             // Then
             assertNull(config.getPattern());
         }
-        
+
         @Test
         @DisplayName("should implement equals and hashCode")
         void shouldImplementEqualsAndHashCode() {
             // Given
-            SidebarBlock.TitleConfig config1 = SidebarBlock.TitleConfig.builder()
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*$")
-                .severity(Severity.INFO)
-                .build();
-            
-            SidebarBlock.TitleConfig config2 = SidebarBlock.TitleConfig.builder()
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*$")
-                .severity(Severity.INFO)
-                .build();
-            
-            SidebarBlock.TitleConfig config3 = SidebarBlock.TitleConfig.builder()
-                .required(false)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*$")
-                .severity(Severity.INFO)
-                .build();
-            
+            SidebarBlock.TitleConfig config1 = SidebarBlock.TitleConfig.builder().required(true).minLength(5)
+                    .maxLength(50).pattern("^[A-Z].*$").severity(Severity.INFO).build();
+
+            SidebarBlock.TitleConfig config2 = SidebarBlock.TitleConfig.builder().required(true).minLength(5)
+                    .maxLength(50).pattern("^[A-Z].*$").severity(Severity.INFO).build();
+
+            SidebarBlock.TitleConfig config3 = SidebarBlock.TitleConfig.builder().required(false).minLength(5)
+                    .maxLength(50).pattern("^[A-Z].*$").severity(Severity.INFO).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("ContentConfig")
     class ContentConfigTest {
-        
+
         @Test
         @DisplayName("should build with all fields")
         void shouldBuildWithAllFields() {
@@ -210,68 +159,46 @@ class SidebarBlockTest {
             boolean required = true;
             Integer minLength = 50;
             Integer maxLength = 800;
-            SidebarBlock.LinesConfig lines = SidebarBlock.LinesConfig.builder()
-                .min(3)
-                .max(30)
-                .severity(Severity.INFO)
-                .build();
-            
+            SidebarBlock.LinesConfig lines = SidebarBlock.LinesConfig.builder().min(3).max(30).severity(Severity.INFO)
+                    .build();
+
             // When
-            SidebarBlock.ContentConfig config = SidebarBlock.ContentConfig.builder()
-                .required(required)
-                .minLength(minLength)
-                .maxLength(maxLength)
-                .lines(lines)
-                .build();
-            
+            SidebarBlock.ContentConfig config = SidebarBlock.ContentConfig.builder().required(required)
+                    .minLength(minLength).maxLength(maxLength).lines(lines).build();
+
             // Then
             assertEquals(required, config.isRequired());
             assertEquals(minLength, config.getMinLength());
             assertEquals(maxLength, config.getMaxLength());
             assertEquals(lines, config.getLines());
         }
-        
+
         @Test
         @DisplayName("should implement equals and hashCode")
         void shouldImplementEqualsAndHashCode() {
             // Given
-            SidebarBlock.LinesConfig lines = SidebarBlock.LinesConfig.builder()
-                .min(3)
-                .max(30)
-                .build();
-            
-            SidebarBlock.ContentConfig config1 = SidebarBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(50)
-                .maxLength(800)
-                .lines(lines)
-                .build();
-            
-            SidebarBlock.ContentConfig config2 = SidebarBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(50)
-                .maxLength(800)
-                .lines(lines)
-                .build();
-            
-            SidebarBlock.ContentConfig config3 = SidebarBlock.ContentConfig.builder()
-                .required(false)
-                .minLength(50)
-                .maxLength(800)
-                .lines(lines)
-                .build();
-            
+            SidebarBlock.LinesConfig lines = SidebarBlock.LinesConfig.builder().min(3).max(30).build();
+
+            SidebarBlock.ContentConfig config1 = SidebarBlock.ContentConfig.builder().required(true).minLength(50)
+                    .maxLength(800).lines(lines).build();
+
+            SidebarBlock.ContentConfig config2 = SidebarBlock.ContentConfig.builder().required(true).minLength(50)
+                    .maxLength(800).lines(lines).build();
+
+            SidebarBlock.ContentConfig config3 = SidebarBlock.ContentConfig.builder().required(false).minLength(50)
+                    .maxLength(800).lines(lines).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("LinesConfig")
     class LinesConfigTest {
-        
+
         @Test
         @DisplayName("should build with all fields")
         void shouldBuildWithAllFields() {
@@ -279,53 +206,41 @@ class SidebarBlockTest {
             Integer min = 3;
             Integer max = 30;
             Severity severity = Severity.INFO;
-            
+
             // When
-            SidebarBlock.LinesConfig config = SidebarBlock.LinesConfig.builder()
-                .min(min)
-                .max(max)
-                .severity(severity)
-                .build();
-            
+            SidebarBlock.LinesConfig config = SidebarBlock.LinesConfig.builder().min(min).max(max).severity(severity)
+                    .build();
+
             // Then
             assertEquals(min, config.getMin());
             assertEquals(max, config.getMax());
             assertEquals(severity, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should implement equals and hashCode")
         void shouldImplementEqualsAndHashCode() {
             // Given
-            SidebarBlock.LinesConfig config1 = SidebarBlock.LinesConfig.builder()
-                .min(3)
-                .max(30)
-                .severity(Severity.INFO)
-                .build();
-            
-            SidebarBlock.LinesConfig config2 = SidebarBlock.LinesConfig.builder()
-                .min(3)
-                .max(30)
-                .severity(Severity.INFO)
-                .build();
-            
-            SidebarBlock.LinesConfig config3 = SidebarBlock.LinesConfig.builder()
-                .min(5)
-                .max(30)
-                .severity(Severity.INFO)
-                .build();
-            
+            SidebarBlock.LinesConfig config1 = SidebarBlock.LinesConfig.builder().min(3).max(30).severity(Severity.INFO)
+                    .build();
+
+            SidebarBlock.LinesConfig config2 = SidebarBlock.LinesConfig.builder().min(3).max(30).severity(Severity.INFO)
+                    .build();
+
+            SidebarBlock.LinesConfig config3 = SidebarBlock.LinesConfig.builder().min(5).max(30).severity(Severity.INFO)
+                    .build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("PositionConfig")
     class PositionConfigTest {
-        
+
         @Test
         @DisplayName("should build with all fields")
         void shouldBuildWithAllFields() {
@@ -333,81 +248,55 @@ class SidebarBlockTest {
             boolean required = false;
             List<String> allowed = List.of("left", "right", "float");
             Severity severity = Severity.INFO;
-            
+
             // When
-            SidebarBlock.PositionConfig config = SidebarBlock.PositionConfig.builder()
-                .required(required)
-                .allowed(allowed)
-                .severity(severity)
-                .build();
-            
+            SidebarBlock.PositionConfig config = SidebarBlock.PositionConfig.builder().required(required)
+                    .allowed(allowed).severity(severity).build();
+
             // Then
             assertEquals(required, config.isRequired());
             assertEquals(allowed, config.getAllowed());
             assertEquals(severity, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should implement equals and hashCode")
         void shouldImplementEqualsAndHashCode() {
             // Given
             List<String> allowed = List.of("left", "right");
-            
-            SidebarBlock.PositionConfig config1 = SidebarBlock.PositionConfig.builder()
-                .required(false)
-                .allowed(allowed)
-                .severity(Severity.INFO)
-                .build();
-            
-            SidebarBlock.PositionConfig config2 = SidebarBlock.PositionConfig.builder()
-                .required(false)
-                .allowed(allowed)
-                .severity(Severity.INFO)
-                .build();
-            
-            SidebarBlock.PositionConfig config3 = SidebarBlock.PositionConfig.builder()
-                .required(true)
-                .allowed(allowed)
-                .severity(Severity.INFO)
-                .build();
-            
+
+            SidebarBlock.PositionConfig config1 = SidebarBlock.PositionConfig.builder().required(false).allowed(allowed)
+                    .severity(Severity.INFO).build();
+
+            SidebarBlock.PositionConfig config2 = SidebarBlock.PositionConfig.builder().required(false).allowed(allowed)
+                    .severity(Severity.INFO).build();
+
+            SidebarBlock.PositionConfig config3 = SidebarBlock.PositionConfig.builder().required(true).allowed(allowed)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
             assertNotEquals(config1, config3);
         }
     }
-    
+
     @Nested
     @DisplayName("equals and hashCode")
     class EqualsAndHashCodeTest {
-        
+
         @Test
         @DisplayName("should implement equals and hashCode")
         void shouldImplementEqualsAndHashCode() {
             // Given
-            SidebarBlock.TitleConfig title = SidebarBlock.TitleConfig.builder()
-                .required(true)
-                .build();
-            
-            SidebarBlock block1 = SidebarBlock.builder()
-                .name("sidebar1")
-                .severity(Severity.ERROR)
-                .title(title)
-                .build();
-            
-            SidebarBlock block2 = SidebarBlock.builder()
-                .name("sidebar1")
-                .severity(Severity.ERROR)
-                .title(title)
-                .build();
-            
-            SidebarBlock block3 = SidebarBlock.builder()
-                .name("sidebar2")
-                .severity(Severity.ERROR)
-                .title(title)
-                .build();
-            
+            SidebarBlock.TitleConfig title = SidebarBlock.TitleConfig.builder().required(true).build();
+
+            SidebarBlock block1 = SidebarBlock.builder().name("sidebar1").severity(Severity.ERROR).title(title).build();
+
+            SidebarBlock block2 = SidebarBlock.builder().name("sidebar1").severity(Severity.ERROR).title(title).build();
+
+            SidebarBlock block3 = SidebarBlock.builder().name("sidebar2").severity(Severity.ERROR).title(title).build();
+
             // Then
             assertEquals(block1, block2);
             assertEquals(block1.hashCode(), block2.hashCode());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlockTest.java
@@ -18,90 +18,66 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("TableBlock")
 class TableBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build TableBlock with all attributes")
         void shouldBuildTableBlockWithAllAttributes() {
             // Given
-            TableBlock.DimensionConfig columnsRule = TableBlock.DimensionConfig.builder()
-                    .min(2)
-                    .max(10)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            TableBlock.DimensionConfig rowsRule = TableBlock.DimensionConfig.builder()
-                    .min(1)
-                    .max(100)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            TableBlock.HeaderConfig headerRule = TableBlock.HeaderConfig.builder()
-                    .required(true)
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            TableBlock.CaptionConfig captionRule = TableBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Table \\d+:")
-                    .minLength(10)
-                    .maxLength(200)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder()
-                    .style("grid")
-                    .borders(true)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            TableBlock.DimensionConfig columnsRule = TableBlock.DimensionConfig.builder().min(2).max(10)
+                    .severity(Severity.ERROR).build();
+
+            TableBlock.DimensionConfig rowsRule = TableBlock.DimensionConfig.builder().min(1).max(100)
+                    .severity(Severity.WARN).build();
+
+            TableBlock.HeaderConfig headerRule = TableBlock.HeaderConfig.builder().required(true).pattern("^[A-Z].*")
+                    .severity(Severity.ERROR).build();
+
+            TableBlock.CaptionConfig captionRule = TableBlock.CaptionConfig.builder().required(true)
+                    .pattern("^Table \\d+:").minLength(10).maxLength(200).severity(Severity.WARN).build();
+
+            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder().style("grid").borders(true)
+                    .severity(Severity.INFO).build();
+
             // When
-            TableBlock table = TableBlock.builder()
-                    .name("data-tables")
-                    .severity(Severity.ERROR)
-                    .columns(columnsRule)
-                    .rows(rowsRule)
-                    .header(headerRule)
-                    .caption(captionRule)
-                    .format(formatRule)
-                    .build();
-            
+            TableBlock table = TableBlock.builder().name("data-tables").severity(Severity.ERROR).columns(columnsRule)
+                    .rows(rowsRule).header(headerRule).caption(captionRule).format(formatRule).build();
+
             // Then
             assertEquals("data-tables", table.getName());
             assertEquals(Severity.ERROR, table.getSeverity());
-            
+
             assertNotNull(table.getColumns());
             assertEquals(2, table.getColumns().getMin());
             assertEquals(10, table.getColumns().getMax());
             assertEquals(Severity.ERROR, table.getColumns().getSeverity());
-            
+
             assertNotNull(table.getRows());
             assertEquals(1, table.getRows().getMin());
             assertEquals(100, table.getRows().getMax());
             assertEquals(Severity.WARN, table.getRows().getSeverity());
-            
+
             assertNotNull(table.getHeader());
             assertTrue(table.getHeader().isRequired());
             assertNotNull(table.getHeader().getPattern());
             assertEquals(Severity.ERROR, table.getHeader().getSeverity());
-            
+
             assertNotNull(table.getCaption());
             assertTrue(table.getCaption().isRequired());
             assertNotNull(table.getCaption().getPattern());
             assertEquals(10, table.getCaption().getMinLength());
             assertEquals(200, table.getCaption().getMaxLength());
             assertEquals(Severity.WARN, table.getCaption().getSeverity());
-            
+
             assertNotNull(table.getFormat());
             assertEquals("grid", table.getFormat().getStyle());
             assertTrue(table.getFormat().getBorders());
             assertEquals(Severity.INFO, table.getFormat().getSeverity());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
@@ -111,130 +87,109 @@ class TableBlockTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("DimensionConfig Tests")
     class DimensionConfigTests {
-        
+
         @Test
         @DisplayName("should create DimensionConfig with min and max")
         void shouldCreateDimensionConfigWithMinAndMax() {
             // Given & When
-            TableBlock.DimensionConfig dimensionRule = TableBlock.DimensionConfig.builder()
-                    .min(3)
-                    .max(15)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            TableBlock.DimensionConfig dimensionRule = TableBlock.DimensionConfig.builder().min(3).max(15)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertEquals(3, dimensionRule.getMin());
             assertEquals(15, dimensionRule.getMax());
             assertEquals(Severity.ERROR, dimensionRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create DimensionConfig with only min")
         void shouldCreateDimensionConfigWithOnlyMin() {
             // When
-            TableBlock.DimensionConfig dimensionRule = TableBlock.DimensionConfig.builder()
-                    .min(5)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            TableBlock.DimensionConfig dimensionRule = TableBlock.DimensionConfig.builder().min(5)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertEquals(5, dimensionRule.getMin());
             assertNull(dimensionRule.getMax());
             assertEquals(Severity.WARN, dimensionRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create DimensionConfig with only max")
         void shouldCreateDimensionConfigWithOnlyMax() {
             // When
-            TableBlock.DimensionConfig dimensionRule = TableBlock.DimensionConfig.builder()
-                    .max(20)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            TableBlock.DimensionConfig dimensionRule = TableBlock.DimensionConfig.builder().max(20)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertNull(dimensionRule.getMin());
             assertEquals(20, dimensionRule.getMax());
             assertEquals(Severity.INFO, dimensionRule.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("HeaderConfig Tests")
     class HeaderConfigTests {
-        
+
         @Test
         @DisplayName("should create HeaderConfig with string pattern")
         void shouldCreateHeaderConfigWithStringPattern() {
             // Given & When
-            TableBlock.HeaderConfig headerRule = TableBlock.HeaderConfig.builder()
-                    .required(true)
-                    .pattern("^[A-Z][a-zA-Z\\s]+$")
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            TableBlock.HeaderConfig headerRule = TableBlock.HeaderConfig.builder().required(true)
+                    .pattern("^[A-Z][a-zA-Z\\s]+$").severity(Severity.ERROR).build();
+
             // Then
             assertTrue(headerRule.isRequired());
             assertNotNull(headerRule.getPattern());
             assertEquals("^[A-Z][a-zA-Z\\s]+$", headerRule.getPattern().pattern());
             assertEquals(Severity.ERROR, headerRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create HeaderConfig with Pattern object")
         void shouldCreateHeaderConfigWithPatternObject() {
             // Given
             Pattern pattern = Pattern.compile("^Header.*");
-            
+
             // When
-            TableBlock.HeaderConfig headerRule = TableBlock.HeaderConfig.builder()
-                    .required(false)
-                    .pattern(pattern)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            TableBlock.HeaderConfig headerRule = TableBlock.HeaderConfig.builder().required(false).pattern(pattern)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertFalse(headerRule.isRequired());
             assertEquals(pattern, headerRule.getPattern());
             assertEquals(Severity.WARN, headerRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should allow optional severity for HeaderConfig")
         void shouldAllowOptionalSeverityForHeaderConfig() {
             // Given & When
-            TableBlock.HeaderConfig config = TableBlock.HeaderConfig.builder()
-                    .required(true)
-                    .pattern("test")
-                    .build();
-                    
+            TableBlock.HeaderConfig config = TableBlock.HeaderConfig.builder().required(true).pattern("test").build();
+
             // Then
             assertNull(config.getSeverity());
             assertTrue(config.isRequired());
             assertNotNull(config.getPattern());
         }
     }
-    
+
     @Nested
     @DisplayName("CaptionConfig Tests")
     class CaptionConfigTests {
-        
+
         @Test
         @DisplayName("should create CaptionConfig with all attributes")
         void shouldCreateCaptionConfigWithAllAttributes() {
             // Given & When
-            TableBlock.CaptionConfig captionRule = TableBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Table \\d+: .*")
-                    .minLength(15)
-                    .maxLength(150)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            TableBlock.CaptionConfig captionRule = TableBlock.CaptionConfig.builder().required(true)
+                    .pattern("^Table \\d+: .*").minLength(15).maxLength(150).severity(Severity.ERROR).build();
+
             // Then
             assertTrue(captionRule.isRequired());
             assertNotNull(captionRule.getPattern());
@@ -242,18 +197,14 @@ class TableBlockTest {
             assertEquals(150, captionRule.getMaxLength());
             assertEquals(Severity.ERROR, captionRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create CaptionConfig without pattern")
         void shouldCreateCaptionConfigWithoutPattern() {
             // Given & When
-            TableBlock.CaptionConfig captionRule = TableBlock.CaptionConfig.builder()
-                    .required(false)
-                    .minLength(5)
-                    .maxLength(100)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            TableBlock.CaptionConfig captionRule = TableBlock.CaptionConfig.builder().required(false).minLength(5)
+                    .maxLength(100).severity(Severity.WARN).build();
+
             // Then
             assertFalse(captionRule.isRequired());
             assertNull(captionRule.getPattern());
@@ -261,17 +212,14 @@ class TableBlockTest {
             assertEquals(100, captionRule.getMaxLength());
             assertEquals(Severity.WARN, captionRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should allow optional severity for CaptionConfig")
         void shouldAllowOptionalSeverityForCaptionConfig() {
             // Given & When
-            TableBlock.CaptionConfig config = TableBlock.CaptionConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .maxLength(50)
-                    .build();
-                    
+            TableBlock.CaptionConfig config = TableBlock.CaptionConfig.builder().required(true).minLength(10)
+                    .maxLength(50).build();
+
             // Then
             assertNull(config.getSeverity());
             assertTrue(config.isRequired());
@@ -279,197 +227,135 @@ class TableBlockTest {
             assertEquals(50, config.getMaxLength());
         }
     }
-    
+
     @Nested
     @DisplayName("FormatConfig Tests")
     class FormatConfigTests {
-        
+
         @Test
         @DisplayName("should create FormatConfig with style and borders")
         void shouldCreateFormatConfigWithStyleAndBorders() {
             // Given & When
-            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder()
-                    .style("grid")
-                    .borders(true)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder().style("grid").borders(true)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertEquals("grid", formatRule.getStyle());
             assertTrue(formatRule.getBorders());
             assertEquals(Severity.INFO, formatRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create FormatConfig with only style")
         void shouldCreateFormatConfigWithOnlyStyle() {
             // Given & When
-            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder()
-                    .style("simple")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder().style("simple")
+                    .severity(Severity.WARN).build();
+
             // Then
             assertEquals("simple", formatRule.getStyle());
             assertNull(formatRule.getBorders());
             assertEquals(Severity.WARN, formatRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create FormatConfig with only borders")
         void shouldCreateFormatConfigWithOnlyBorders() {
             // Given & When
-            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder()
-                    .borders(false)
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            TableBlock.FormatConfig formatRule = TableBlock.FormatConfig.builder().borders(false)
+                    .severity(Severity.ERROR).build();
+
             // Then
             assertNull(formatRule.getStyle());
             assertFalse(formatRule.getBorders());
             assertEquals(Severity.ERROR, formatRule.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should allow optional severity for FormatConfig")
         void shouldAllowOptionalSeverityForFormatConfig() {
             // Given & When
-            TableBlock.FormatConfig config = TableBlock.FormatConfig.builder()
-                    .style("grid")
-                    .borders(true)
-                    .build();
-                    
+            TableBlock.FormatConfig config = TableBlock.FormatConfig.builder().style("grid").borders(true).build();
+
             // Then
             assertNull(config.getSeverity());
             assertEquals("grid", config.getStyle());
             assertTrue(config.getBorders());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should correctly implement equals and hashCode")
         void shouldCorrectlyImplementEqualsAndHashCode() {
             // Given
-            TableBlock.DimensionConfig columns1 = TableBlock.DimensionConfig.builder()
-                    .min(2)
-                    .max(8)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            TableBlock.DimensionConfig columns2 = TableBlock.DimensionConfig.builder()
-                    .min(2)
-                    .max(8)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            TableBlock.HeaderConfig header1 = TableBlock.HeaderConfig.builder()
-                    .required(true)
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            TableBlock.HeaderConfig header2 = TableBlock.HeaderConfig.builder()
-                    .required(true)
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.WARN)
-                    .build();
-                    
+            TableBlock.DimensionConfig columns1 = TableBlock.DimensionConfig.builder().min(2).max(8)
+                    .severity(Severity.ERROR).build();
+
+            TableBlock.DimensionConfig columns2 = TableBlock.DimensionConfig.builder().min(2).max(8)
+                    .severity(Severity.ERROR).build();
+
+            TableBlock.HeaderConfig header1 = TableBlock.HeaderConfig.builder().required(true).pattern("^[A-Z].*")
+                    .severity(Severity.WARN).build();
+
+            TableBlock.HeaderConfig header2 = TableBlock.HeaderConfig.builder().required(true).pattern("^[A-Z].*")
+                    .severity(Severity.WARN).build();
+
             // When
-            TableBlock table1 = TableBlock.builder()
-                    .severity(Severity.ERROR)
-                    .columns(columns1)
-                    .header(header1)
-                    .build();
-                    
-            TableBlock table2 = TableBlock.builder()
-                    .severity(Severity.ERROR)
-                    .columns(columns2)
-                    .header(header2)
-                    .build();
-                    
-            TableBlock table3 = TableBlock.builder()
-                    .severity(Severity.WARN)
-                    .columns(columns1)
-                    .header(header1)
-                    .build();
-            
+            TableBlock table1 = TableBlock.builder().severity(Severity.ERROR).columns(columns1).header(header1).build();
+
+            TableBlock table2 = TableBlock.builder().severity(Severity.ERROR).columns(columns2).header(header2).build();
+
+            TableBlock table3 = TableBlock.builder().severity(Severity.WARN).columns(columns1).header(header1).build();
+
             // Then
             assertEquals(table1, table2);
             assertNotEquals(table1, table3);
             assertEquals(table1.hashCode(), table2.hashCode());
             assertNotEquals(table1.hashCode(), table3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should test inner class equals and hashCode")
         void shouldTestInnerClassEqualsAndHashCode() {
             // Given
-            TableBlock.DimensionConfig dim1 = TableBlock.DimensionConfig.builder()
-                    .min(5)
-                    .max(10)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            TableBlock.DimensionConfig dim2 = TableBlock.DimensionConfig.builder()
-                    .min(5)
-                    .max(10)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            TableBlock.HeaderConfig header1 = TableBlock.HeaderConfig.builder()
-                    .required(false)
-                    .pattern("test")
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            TableBlock.HeaderConfig header2 = TableBlock.HeaderConfig.builder()
-                    .required(false)
-                    .pattern("test")
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            TableBlock.CaptionConfig caption1 = TableBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Table.*")
-                    .minLength(10)
-                    .maxLength(100)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            TableBlock.CaptionConfig caption2 = TableBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^Table.*")
-                    .minLength(10)
-                    .maxLength(100)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            TableBlock.FormatConfig format1 = TableBlock.FormatConfig.builder()
-                    .style("grid")
-                    .borders(true)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            TableBlock.FormatConfig format2 = TableBlock.FormatConfig.builder()
-                    .style("grid")
-                    .borders(true)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            TableBlock.DimensionConfig dim1 = TableBlock.DimensionConfig.builder().min(5).max(10)
+                    .severity(Severity.ERROR).build();
+
+            TableBlock.DimensionConfig dim2 = TableBlock.DimensionConfig.builder().min(5).max(10)
+                    .severity(Severity.ERROR).build();
+
+            TableBlock.HeaderConfig header1 = TableBlock.HeaderConfig.builder().required(false).pattern("test")
+                    .severity(Severity.INFO).build();
+
+            TableBlock.HeaderConfig header2 = TableBlock.HeaderConfig.builder().required(false).pattern("test")
+                    .severity(Severity.INFO).build();
+
+            TableBlock.CaptionConfig caption1 = TableBlock.CaptionConfig.builder().required(true).pattern("^Table.*")
+                    .minLength(10).maxLength(100).severity(Severity.WARN).build();
+
+            TableBlock.CaptionConfig caption2 = TableBlock.CaptionConfig.builder().required(true).pattern("^Table.*")
+                    .minLength(10).maxLength(100).severity(Severity.WARN).build();
+
+            TableBlock.FormatConfig format1 = TableBlock.FormatConfig.builder().style("grid").borders(true)
+                    .severity(Severity.INFO).build();
+
+            TableBlock.FormatConfig format2 = TableBlock.FormatConfig.builder().style("grid").borders(true)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertEquals(dim1, dim2);
             assertEquals(dim1.hashCode(), dim2.hashCode());
-            
+
             assertEquals(header1, header2);
             assertEquals(header1.hashCode(), header2.hashCode());
-            
+
             assertEquals(caption1, caption2);
             assertEquals(caption1.hashCode(), caption2.hashCode());
-            
+
             assertEquals(format1, format2);
             assertEquals(format1.hashCode(), format2.hashCode());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlockTest.java
@@ -14,59 +14,47 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("UlistBlock")
 class UlistBlockTest {
-    
+
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build UlistBlock with all attributes")
         void shouldBuildUlistBlockWithAllAttributes() {
             // Given
-            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder()
-                    .min(2)
-                    .max(10)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            UlistBlock.NestingLevelConfig nestingConfig = UlistBlock.NestingLevelConfig.builder()
-                    .max(3)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder().min(2).max(10)
+                    .severity(Severity.ERROR).build();
+
+            UlistBlock.NestingLevelConfig nestingConfig = UlistBlock.NestingLevelConfig.builder().max(3)
+                    .severity(Severity.WARN).build();
+
             // When
-            UlistBlock ulist = UlistBlock.builder()
-                    .name("requirements-list")
-                    .severity(Severity.ERROR)
-                    .items(itemsConfig)
-                    .nestingLevel(nestingConfig)
-                    .markerStyle("*")
-                    .build();
-            
+            UlistBlock ulist = UlistBlock.builder().name("requirements-list").severity(Severity.ERROR)
+                    .items(itemsConfig).nestingLevel(nestingConfig).markerStyle("*").build();
+
             // Then
             assertEquals("requirements-list", ulist.getName());
             assertEquals(Severity.ERROR, ulist.getSeverity());
-            
+
             assertNotNull(ulist.getItems());
             assertEquals(2, ulist.getItems().getMin());
             assertEquals(10, ulist.getItems().getMax());
             assertEquals(Severity.ERROR, ulist.getItems().getSeverity());
-            
+
             assertNotNull(ulist.getNestingLevel());
             assertEquals(3, ulist.getNestingLevel().getMax());
             assertEquals(Severity.WARN, ulist.getNestingLevel().getSeverity());
-            
+
             assertEquals("*", ulist.getMarkerStyle());
         }
-        
+
         @Test
         @DisplayName("should build UlistBlock with minimal attributes")
         void shouldBuildUlistBlockWithMinimalAttributes() {
             // When
-            UlistBlock ulist = UlistBlock.builder()
-                    .severity(Severity.WARN)
-                    .build();
-            
+            UlistBlock ulist = UlistBlock.builder().severity(Severity.WARN).build();
+
             // Then
             assertNull(ulist.getName());
             assertEquals(Severity.WARN, ulist.getSeverity());
@@ -74,7 +62,7 @@ class UlistBlockTest {
             assertNull(ulist.getNestingLevel());
             assertNull(ulist.getMarkerStyle());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldRequireSeverity() {
@@ -84,195 +72,146 @@ class UlistBlockTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("ItemsConfig Tests")
     class ItemsConfigTests {
-        
+
         @Test
         @DisplayName("should create ItemsConfig with min and max")
         void shouldCreateItemsConfigWithMinAndMax() {
             // When
-            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder()
-                    .min(1)
-                    .max(5)
-                    .severity(Severity.ERROR)
+            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder().min(1).max(5).severity(Severity.ERROR)
                     .build();
-            
+
             // Then
             assertEquals(1, itemsConfig.getMin());
             assertEquals(5, itemsConfig.getMax());
             assertEquals(Severity.ERROR, itemsConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create ItemsConfig with only min")
         void shouldCreateItemsConfigWithOnlyMin() {
             // When
-            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder()
-                    .min(3)
-                    .build();
-            
+            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder().min(3).build();
+
             // Then
             assertEquals(3, itemsConfig.getMin());
             assertNull(itemsConfig.getMax());
             assertNull(itemsConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create ItemsConfig with only max")
         void shouldCreateItemsConfigWithOnlyMax() {
             // When
-            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder()
-                    .max(10)
-                    .build();
-            
+            UlistBlock.ItemsConfig itemsConfig = UlistBlock.ItemsConfig.builder().max(10).build();
+
             // Then
             assertNull(itemsConfig.getMin());
             assertEquals(10, itemsConfig.getMax());
             assertNull(itemsConfig.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("NestingLevelConfig Tests")
     class NestingLevelConfigTests {
-        
+
         @Test
         @DisplayName("should create NestingLevelConfig with max")
         void shouldCreateNestingLevelConfigWithMax() {
             // When
-            UlistBlock.NestingLevelConfig nestingConfig = UlistBlock.NestingLevelConfig.builder()
-                    .max(2)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            UlistBlock.NestingLevelConfig nestingConfig = UlistBlock.NestingLevelConfig.builder().max(2)
+                    .severity(Severity.WARN).build();
+
             // Then
             assertEquals(2, nestingConfig.getMax());
             assertEquals(Severity.WARN, nestingConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should create NestingLevelConfig without severity")
         void shouldCreateNestingLevelConfigWithoutSeverity() {
             // When
-            UlistBlock.NestingLevelConfig nestingConfig = UlistBlock.NestingLevelConfig.builder()
-                    .max(4)
-                    .build();
-            
+            UlistBlock.NestingLevelConfig nestingConfig = UlistBlock.NestingLevelConfig.builder().max(4).build();
+
             // Then
             assertEquals(4, nestingConfig.getMax());
             assertNull(nestingConfig.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should correctly implement equals and hashCode")
         void shouldCorrectlyImplementEqualsAndHashCode() {
             // Given
-            UlistBlock.ItemsConfig items1 = UlistBlock.ItemsConfig.builder()
-                    .min(1)
-                    .max(5)
-                    .severity(Severity.ERROR)
+            UlistBlock.ItemsConfig items1 = UlistBlock.ItemsConfig.builder().min(1).max(5).severity(Severity.ERROR)
                     .build();
-                    
-            UlistBlock.ItemsConfig items2 = UlistBlock.ItemsConfig.builder()
-                    .min(1)
-                    .max(5)
-                    .severity(Severity.ERROR)
+
+            UlistBlock.ItemsConfig items2 = UlistBlock.ItemsConfig.builder().min(1).max(5).severity(Severity.ERROR)
                     .build();
-                    
-            UlistBlock.NestingLevelConfig nesting1 = UlistBlock.NestingLevelConfig.builder()
-                    .max(2)
-                    .severity(Severity.WARN)
-                    .build();
-                    
-            UlistBlock.NestingLevelConfig nesting2 = UlistBlock.NestingLevelConfig.builder()
-                    .max(2)
-                    .severity(Severity.WARN)
-                    .build();
-                    
+
+            UlistBlock.NestingLevelConfig nesting1 = UlistBlock.NestingLevelConfig.builder().max(2)
+                    .severity(Severity.WARN).build();
+
+            UlistBlock.NestingLevelConfig nesting2 = UlistBlock.NestingLevelConfig.builder().max(2)
+                    .severity(Severity.WARN).build();
+
             // When
-            UlistBlock ulist1 = UlistBlock.builder()
-                    .severity(Severity.ERROR)
-                    .items(items1)
-                    .nestingLevel(nesting1)
-                    .markerStyle("*")
-                    .build();
-                    
-            UlistBlock ulist2 = UlistBlock.builder()
-                    .severity(Severity.ERROR)
-                    .items(items2)
-                    .nestingLevel(nesting2)
-                    .markerStyle("*")
-                    .build();
-                    
-            UlistBlock ulist3 = UlistBlock.builder()
-                    .severity(Severity.WARN)
-                    .items(items1)
-                    .nestingLevel(nesting1)
-                    .markerStyle("*")
-                    .build();
-            
+            UlistBlock ulist1 = UlistBlock.builder().severity(Severity.ERROR).items(items1).nestingLevel(nesting1)
+                    .markerStyle("*").build();
+
+            UlistBlock ulist2 = UlistBlock.builder().severity(Severity.ERROR).items(items2).nestingLevel(nesting2)
+                    .markerStyle("*").build();
+
+            UlistBlock ulist3 = UlistBlock.builder().severity(Severity.WARN).items(items1).nestingLevel(nesting1)
+                    .markerStyle("*").build();
+
             // Then
             assertEquals(ulist1, ulist2);
             assertNotEquals(ulist1, ulist3);
             assertEquals(ulist1.hashCode(), ulist2.hashCode());
             assertNotEquals(ulist1.hashCode(), ulist3.hashCode());
         }
-        
+
         @Test
         @DisplayName("should test inner class equals and hashCode")
         void shouldTestInnerClassEqualsAndHashCode() {
             // Given
-            UlistBlock.ItemsConfig items1 = UlistBlock.ItemsConfig.builder()
-                    .min(2)
-                    .max(8)
-                    .severity(Severity.ERROR)
+            UlistBlock.ItemsConfig items1 = UlistBlock.ItemsConfig.builder().min(2).max(8).severity(Severity.ERROR)
                     .build();
-                    
-            UlistBlock.ItemsConfig items2 = UlistBlock.ItemsConfig.builder()
-                    .min(2)
-                    .max(8)
-                    .severity(Severity.ERROR)
+
+            UlistBlock.ItemsConfig items2 = UlistBlock.ItemsConfig.builder().min(2).max(8).severity(Severity.ERROR)
                     .build();
-                    
-            UlistBlock.NestingLevelConfig nesting1 = UlistBlock.NestingLevelConfig.builder()
-                    .max(3)
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            UlistBlock.NestingLevelConfig nesting2 = UlistBlock.NestingLevelConfig.builder()
-                    .max(3)
-                    .severity(Severity.INFO)
-                    .build();
-            
+
+            UlistBlock.NestingLevelConfig nesting1 = UlistBlock.NestingLevelConfig.builder().max(3)
+                    .severity(Severity.INFO).build();
+
+            UlistBlock.NestingLevelConfig nesting2 = UlistBlock.NestingLevelConfig.builder().max(3)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertEquals(items1, items2);
             assertEquals(items1.hashCode(), items2.hashCode());
-            
+
             assertEquals(nesting1, nesting2);
             assertEquals(nesting1.hashCode(), nesting2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should handle different marker styles")
         void shouldHandleDifferentMarkerStyles() {
             // Given
-            UlistBlock ulist1 = UlistBlock.builder()
-                    .severity(Severity.ERROR)
-                    .markerStyle("*")
-                    .build();
-                    
-            UlistBlock ulist2 = UlistBlock.builder()
-                    .severity(Severity.ERROR)
-                    .markerStyle("-")
-                    .build();
-            
+            UlistBlock ulist1 = UlistBlock.builder().severity(Severity.ERROR).markerStyle("*").build();
+
+            UlistBlock ulist2 = UlistBlock.builder().severity(Severity.ERROR).markerStyle("-").build();
+
             // Then
             assertNotEquals(ulist1, ulist2);
             assertNotEquals(ulist1.hashCode(), ulist2.hashCode());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlockTest.java
@@ -15,202 +15,128 @@ import org.junit.jupiter.api.Test;
 import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 class VerseBlockTest {
-    
+
     @Test
     void testBuilder() {
-        VerseBlock.AuthorConfig authorRule = VerseBlock.AuthorConfig.builder()
-                .defaultValue("Carl Sandburg")
-                .required(true)
-                .minLength(3)
-                .maxLength(50)
-                .pattern("^[A-Z][a-zA-Z\\s\\.]+$")
-                .build();
-                
-        VerseBlock.AttributionConfig attributionRule = VerseBlock.AttributionConfig.builder()
-                .defaultValue("Fog")
-                .required(false)
-                .minLength(5)
-                .maxLength(100)
-                .pattern("^[A-Za-z0-9\\s,\\.]+$")
-                .build();
-                
-        VerseBlock.ContentConfig contentRule = VerseBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(20)
-                .maxLength(500)
-                .pattern(".*\\n.*")
-                .build();
-        
-        VerseBlock verse = VerseBlock.builder()
-                .severity(Severity.WARN)
-                .author(authorRule)
-                .attribution(attributionRule)
-                .content(contentRule)
-                .build();
-        
+        VerseBlock.AuthorConfig authorRule = VerseBlock.AuthorConfig.builder().defaultValue("Carl Sandburg")
+                .required(true).minLength(3).maxLength(50).pattern("^[A-Z][a-zA-Z\\s\\.]+$").build();
+
+        VerseBlock.AttributionConfig attributionRule = VerseBlock.AttributionConfig.builder().defaultValue("Fog")
+                .required(false).minLength(5).maxLength(100).pattern("^[A-Za-z0-9\\s,\\.]+$").build();
+
+        VerseBlock.ContentConfig contentRule = VerseBlock.ContentConfig.builder().required(true).minLength(20)
+                .maxLength(500).pattern(".*\\n.*").build();
+
+        VerseBlock verse = VerseBlock.builder().severity(Severity.WARN).author(authorRule).attribution(attributionRule)
+                .content(contentRule).build();
+
         assertEquals(Severity.WARN, verse.getSeverity());
-        
+
         assertNotNull(verse.getAuthor());
         assertEquals("Carl Sandburg", verse.getAuthor().getDefaultValue());
         assertTrue(verse.getAuthor().isRequired());
         assertEquals(3, verse.getAuthor().getMinLength());
         assertEquals(50, verse.getAuthor().getMaxLength());
         assertNotNull(verse.getAuthor().getPattern());
-        
+
         assertNotNull(verse.getAttribution());
         assertEquals("Fog", verse.getAttribution().getDefaultValue());
         assertFalse(verse.getAttribution().isRequired());
         assertEquals(5, verse.getAttribution().getMinLength());
         assertEquals(100, verse.getAttribution().getMaxLength());
         assertNotNull(verse.getAttribution().getPattern());
-        
+
         assertNotNull(verse.getContent());
         assertTrue(verse.getContent().isRequired());
         assertEquals(20, verse.getContent().getMinLength());
         assertEquals(500, verse.getContent().getMaxLength());
         assertNotNull(verse.getContent().getPattern());
     }
-    
+
     @Test
     void testPatternStringConstructor() {
-        VerseBlock.AuthorConfig authorRule = VerseBlock.AuthorConfig.builder()
-                .pattern("^[A-Z].*")
-                .build();
-                
+        VerseBlock.AuthorConfig authorRule = VerseBlock.AuthorConfig.builder().pattern("^[A-Z].*").build();
+
         VerseBlock.AttributionConfig attributionRule = VerseBlock.AttributionConfig.builder()
-                .pattern(Pattern.compile("[0-9]+"))
+                .pattern(Pattern.compile("[0-9]+")).build();
+
+        VerseBlock verse = VerseBlock.builder().severity(Severity.ERROR).author(authorRule).attribution(attributionRule)
                 .build();
-        
-        VerseBlock verse = VerseBlock.builder()
-                .severity(Severity.ERROR)
-                .author(authorRule)
-                .attribution(attributionRule)
-                .build();
-        
+
         assertNotNull(verse.getAuthor().getPattern());
         assertEquals("^[A-Z].*", verse.getAuthor().getPattern().pattern());
         assertNotNull(verse.getAttribution().getPattern());
         assertEquals("[0-9]+", verse.getAttribution().getPattern().pattern());
     }
-    
+
     @Test
     void testNullPatterns() {
-        VerseBlock.AuthorConfig authorRule = VerseBlock.AuthorConfig.builder()
-                .pattern((String) null)
+        VerseBlock.AuthorConfig authorRule = VerseBlock.AuthorConfig.builder().pattern((String) null).build();
+
+        VerseBlock.AttributionConfig attributionRule = VerseBlock.AttributionConfig.builder().pattern((Pattern) null)
                 .build();
-                
-        VerseBlock.AttributionConfig attributionRule = VerseBlock.AttributionConfig.builder()
-                .pattern((Pattern) null)
+
+        VerseBlock verse = VerseBlock.builder().severity(Severity.INFO).author(authorRule).attribution(attributionRule)
                 .build();
-        
-        VerseBlock verse = VerseBlock.builder()
-                .severity(Severity.INFO)
-                .author(authorRule)
-                .attribution(attributionRule)
-                .build();
-        
+
         assertNull(verse.getAuthor().getPattern());
         assertNull(verse.getAttribution().getPattern());
     }
-    
+
     @Test
     void testEqualsAndHashCode() {
-        VerseBlock.AuthorConfig authorRule1 = VerseBlock.AuthorConfig.builder()
-                .defaultValue("Author1")
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*")
-                .build();
-                
-        VerseBlock.AuthorConfig authorRule2 = VerseBlock.AuthorConfig.builder()
-                .defaultValue("Author1")
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*")
-                .build();
-                
-        VerseBlock.AuthorConfig authorRule3 = VerseBlock.AuthorConfig.builder()
-                .defaultValue("Author2")
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*")
-                .build();
-        
-        VerseBlock verse1 = VerseBlock.builder()
-                .severity(Severity.WARN)
-                .author(authorRule1)
-                .build();
-        
-        VerseBlock verse2 = VerseBlock.builder()
-                .severity(Severity.WARN)
-                .author(authorRule2)
-                .build();
-        
-        VerseBlock verse3 = VerseBlock.builder()
-                .severity(Severity.WARN)
-                .author(authorRule3)
-                .build();
-        
+        VerseBlock.AuthorConfig authorRule1 = VerseBlock.AuthorConfig.builder().defaultValue("Author1").required(true)
+                .minLength(5).maxLength(50).pattern("^[A-Z].*").build();
+
+        VerseBlock.AuthorConfig authorRule2 = VerseBlock.AuthorConfig.builder().defaultValue("Author1").required(true)
+                .minLength(5).maxLength(50).pattern("^[A-Z].*").build();
+
+        VerseBlock.AuthorConfig authorRule3 = VerseBlock.AuthorConfig.builder().defaultValue("Author2").required(true)
+                .minLength(5).maxLength(50).pattern("^[A-Z].*").build();
+
+        VerseBlock verse1 = VerseBlock.builder().severity(Severity.WARN).author(authorRule1).build();
+
+        VerseBlock verse2 = VerseBlock.builder().severity(Severity.WARN).author(authorRule2).build();
+
+        VerseBlock verse3 = VerseBlock.builder().severity(Severity.WARN).author(authorRule3).build();
+
         assertEquals(verse1, verse2);
         assertNotEquals(verse1, verse3);
         assertEquals(verse1.hashCode(), verse2.hashCode());
         assertNotEquals(verse1.hashCode(), verse3.hashCode());
     }
-    
+
     @Test
     void testRequiredSeverity() {
         assertThrows(NullPointerException.class, () -> {
             VerseBlock.builder().build();
         });
     }
-    
+
     @Test
     void testInnerClassEqualsAndHashCode() {
-        VerseBlock.AuthorConfig author1 = VerseBlock.AuthorConfig.builder()
-                .defaultValue("Test")
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*")
-                .build();
-                
-        VerseBlock.AuthorConfig author2 = VerseBlock.AuthorConfig.builder()
-                .defaultValue("Test")
-                .required(true)
-                .minLength(5)
-                .maxLength(50)
-                .pattern("^[A-Z].*")
-                .build();
-                
-        VerseBlock.AttributionConfig attr1 = VerseBlock.AttributionConfig.builder()
-                .defaultValue("Source")
-                .required(false)
-                .build();
-                
-        VerseBlock.AttributionConfig attr2 = VerseBlock.AttributionConfig.builder()
-                .defaultValue("Source")
-                .required(false)
-                .build();
-                
-        VerseBlock.ContentConfig content1 = VerseBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(10)
-                .build();
-                
-        VerseBlock.ContentConfig content2 = VerseBlock.ContentConfig.builder()
-                .required(true)
-                .minLength(10)
-                .build();
-        
+        VerseBlock.AuthorConfig author1 = VerseBlock.AuthorConfig.builder().defaultValue("Test").required(true)
+                .minLength(5).maxLength(50).pattern("^[A-Z].*").build();
+
+        VerseBlock.AuthorConfig author2 = VerseBlock.AuthorConfig.builder().defaultValue("Test").required(true)
+                .minLength(5).maxLength(50).pattern("^[A-Z].*").build();
+
+        VerseBlock.AttributionConfig attr1 = VerseBlock.AttributionConfig.builder().defaultValue("Source")
+                .required(false).build();
+
+        VerseBlock.AttributionConfig attr2 = VerseBlock.AttributionConfig.builder().defaultValue("Source")
+                .required(false).build();
+
+        VerseBlock.ContentConfig content1 = VerseBlock.ContentConfig.builder().required(true).minLength(10).build();
+
+        VerseBlock.ContentConfig content2 = VerseBlock.ContentConfig.builder().required(true).minLength(10).build();
+
         assertEquals(author1, author2);
         assertEquals(author1.hashCode(), author2.hashCode());
-        
+
         assertEquals(attr1, attr2);
         assertEquals(attr1.hashCode(), attr2.hashCode());
-        
+
         assertEquals(content1, content2);
         assertEquals(content1.hashCode(), content2.hashCode());
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlockTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlockTest.java
@@ -23,15 +23,12 @@ class VideoBlockTest {
     @Nested
     @DisplayName("Builder Tests")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should build with minimal required fields")
         void shouldBuildWithMinimalRequiredFields() {
-            VideoBlock block = VideoBlock.builder()
-                    .name("test-video")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            VideoBlock block = VideoBlock.builder().name("test-video").severity(Severity.WARN).build();
+
             assertNotNull(block);
             assertEquals("test-video", block.getName());
             assertEquals(Severity.WARN, block.getSeverity());
@@ -42,49 +39,27 @@ class VideoBlockTest {
             assertNull(block.getOptions());
             assertNull(block.getCaption());
         }
-        
+
         @Test
         @DisplayName("should build with all fields")
         void shouldBuildWithAllFields() {
-            VideoBlock block = VideoBlock.builder()
-                    .name("full-video")
-                    .severity(Severity.ERROR)
-                    .occurrence(OccurrenceConfig.builder()
-                            .min(1)
-                            .max(3)
+            VideoBlock block = VideoBlock.builder().name("full-video").severity(Severity.ERROR)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(3).build())
+                    .url(VideoBlock.UrlConfig.builder().required(true).pattern("^https?://.*\\.(mp4|webm)$")
+                            .severity(Severity.ERROR).build())
+                    .width(VideoBlock.DimensionConfig.builder().minValue(320).maxValue(1920).severity(Severity.INFO)
                             .build())
-                    .url(VideoBlock.UrlConfig.builder()
-                            .required(true)
-                            .pattern("^https?://.*\\.(mp4|webm)$")
-                            .severity(Severity.ERROR)
-                            .build())
-                    .width(VideoBlock.DimensionConfig.builder()
-                            .minValue(320)
-                            .maxValue(1920)
-                            .severity(Severity.INFO)
-                            .build())
-                    .height(VideoBlock.DimensionConfig.builder()
-                            .minValue(180)
-                            .maxValue(1080)
-                            .severity(Severity.INFO)
-                            .build())
-                    .poster(VideoBlock.PosterConfig.builder()
-                            .pattern(".*\\.(jpg|jpeg|png)$")
-                            .build())
+                    .height(VideoBlock.DimensionConfig
+                            .builder().minValue(180).maxValue(1080).severity(Severity.INFO).build())
+                    .poster(VideoBlock.PosterConfig.builder().pattern(".*\\.(jpg|jpeg|png)$").build())
                     .options(VideoBlock.OptionsConfig.builder()
-                            .controls(VideoBlock.ControlsConfig.builder()
-                                    .required(true)
-                                    .severity(Severity.ERROR)
-                                    .build())
+                            .controls(
+                                    VideoBlock.ControlsConfig.builder().required(true).severity(Severity.ERROR).build())
                             .build())
-                    .caption(VideoBlock.CaptionConfig.builder()
-                            .required(true)
-                            .minLength(15)
-                            .maxLength(200)
-                            .severity(Severity.WARN)
-                            .build())
+                    .caption(VideoBlock.CaptionConfig.builder().required(true).minLength(15).maxLength(200)
+                            .severity(Severity.WARN).build())
                     .build();
-            
+
             assertNotNull(block);
             assertNotNull(block.getUrl());
             assertNotNull(block.getWidth());
@@ -93,182 +68,136 @@ class VideoBlockTest {
             assertNotNull(block.getOptions());
             assertNotNull(block.getCaption());
         }
-        
+
         @Test
         @DisplayName("should build successfully without name")
         void shouldBuildSuccessfullyWithoutName() {
-            VideoBlock block = VideoBlock.builder()
-                    .severity(Severity.WARN)
-                    .build();
-            
+            VideoBlock block = VideoBlock.builder().severity(Severity.WARN).build();
+
             assertNull(block.getName());
             assertEquals(Severity.WARN, block.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should throw when severity is null")
         void shouldThrowWhenSeverityIsNull() {
-            assertThrows(NullPointerException.class, () ->
-                    VideoBlock.builder()
-                            .name("test")
-                            .build());
+            assertThrows(NullPointerException.class, () -> VideoBlock.builder().name("test").build());
         }
     }
-    
+
     @Nested
     @DisplayName("UrlConfig Tests")
     class UrlConfigTests {
-        
+
         @Test
         @DisplayName("should build url config with all fields")
         void shouldBuildUrlConfigWithAllFields() {
-            VideoBlock.UrlConfig config = VideoBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern("^https?://.*\\.(mp4|webm)$")
-                    .severity(Severity.ERROR)
-                    .build();
-            
+            VideoBlock.UrlConfig config = VideoBlock.UrlConfig.builder().required(true)
+                    .pattern("^https?://.*\\.(mp4|webm)$").severity(Severity.ERROR).build();
+
             assertTrue(config.getRequired());
             assertNotNull(config.getPattern());
             assertEquals("^https?://.*\\.(mp4|webm)$", config.getPattern().pattern());
             assertEquals(Severity.ERROR, config.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should build with Pattern object")
         void shouldBuildWithPatternObject() {
             Pattern pattern = Pattern.compile("test.*");
-            VideoBlock.UrlConfig config = VideoBlock.UrlConfig.builder()
-                    .pattern(pattern)
-                    .build();
-            
+            VideoBlock.UrlConfig config = VideoBlock.UrlConfig.builder().pattern(pattern).build();
+
             assertEquals(pattern, config.getPattern());
         }
-        
+
         @Test
         @DisplayName("should handle null pattern string")
         void shouldHandleNullPatternString() {
-            VideoBlock.UrlConfig config = VideoBlock.UrlConfig.builder()
-                    .pattern((String) null)
-                    .build();
-            
+            VideoBlock.UrlConfig config = VideoBlock.UrlConfig.builder().pattern((String) null).build();
+
             assertNull(config.getPattern());
         }
     }
-    
+
     @Nested
     @DisplayName("DimensionConfig Tests")
     class DimensionConfigTests {
-        
+
         @Test
         @DisplayName("should build dimension config with all fields")
         void shouldBuildDimensionConfigWithAllFields() {
-            VideoBlock.DimensionConfig config = VideoBlock.DimensionConfig.builder()
-                    .required(false)
-                    .minValue(320)
-                    .maxValue(1920)
-                    .severity(Severity.INFO)
-                    .build();
-            
+            VideoBlock.DimensionConfig config = VideoBlock.DimensionConfig.builder().required(false).minValue(320)
+                    .maxValue(1920).severity(Severity.INFO).build();
+
             assertFalse(config.getRequired());
             assertEquals(320, config.getMinValue());
             assertEquals(1920, config.getMaxValue());
             assertEquals(Severity.INFO, config.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("CaptionConfig Tests")
     class CaptionConfigTests {
-        
+
         @Test
         @DisplayName("should build caption config with all fields")
         void shouldBuildCaptionConfigWithAllFields() {
-            VideoBlock.CaptionConfig config = VideoBlock.CaptionConfig.builder()
-                    .required(true)
-                    .minLength(15)
-                    .maxLength(200)
-                    .severity(Severity.WARN)
-                    .build();
-            
+            VideoBlock.CaptionConfig config = VideoBlock.CaptionConfig.builder().required(true).minLength(15)
+                    .maxLength(200).severity(Severity.WARN).build();
+
             assertTrue(config.getRequired());
             assertEquals(15, config.getMinLength());
             assertEquals(200, config.getMaxLength());
             assertEquals(Severity.WARN, config.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should be equal for same values")
         void shouldBeEqualForSameValues() {
-            VideoBlock block1 = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .url(VideoBlock.UrlConfig.builder()
-                            .required(true)
-                            .pattern("test.*")
-                            .build())
-                    .build();
-            
-            VideoBlock block2 = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .url(VideoBlock.UrlConfig.builder()
-                            .required(true)
-                            .pattern("test.*")
-                            .build())
-                    .build();
-            
+            VideoBlock block1 = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .url(VideoBlock.UrlConfig.builder().required(true).pattern("test.*").build()).build();
+
+            VideoBlock block2 = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .url(VideoBlock.UrlConfig.builder().required(true).pattern("test.*").build()).build();
+
             assertEquals(block1, block2);
             assertEquals(block1.hashCode(), block2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should not be equal for different values")
         void shouldNotBeEqualForDifferentValues() {
-            VideoBlock block1 = VideoBlock.builder()
-                    .name("test1")
-                    .severity(Severity.WARN)
-                    .build();
-            
-            VideoBlock block2 = VideoBlock.builder()
-                    .name("test2")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            VideoBlock block1 = VideoBlock.builder().name("test1").severity(Severity.WARN).build();
+
+            VideoBlock block2 = VideoBlock.builder().name("test2").severity(Severity.WARN).build();
+
             assertNotEquals(block1, block2);
         }
-        
+
         @Test
         @DisplayName("should handle pattern equality correctly")
         void shouldHandlePatternEqualityCorrectly() {
-            VideoBlock.UrlConfig config1 = VideoBlock.UrlConfig.builder()
-                    .pattern("test.*")
-                    .build();
-            
-            VideoBlock.UrlConfig config2 = VideoBlock.UrlConfig.builder()
-                    .pattern("test.*")
-                    .build();
-            
+            VideoBlock.UrlConfig config1 = VideoBlock.UrlConfig.builder().pattern("test.*").build();
+
+            VideoBlock.UrlConfig config2 = VideoBlock.UrlConfig.builder().pattern("test.*").build();
+
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should handle null patterns in equals")
         void shouldHandleNullPatternsInEquals() {
-            VideoBlock.UrlConfig config1 = VideoBlock.UrlConfig.builder()
-                    .pattern((Pattern) null)
-                    .build();
-            
-            VideoBlock.UrlConfig config2 = VideoBlock.UrlConfig.builder()
-                    .pattern((Pattern) null)
-                    .build();
-            
+            VideoBlock.UrlConfig config1 = VideoBlock.UrlConfig.builder().pattern((Pattern) null).build();
+
+            VideoBlock.UrlConfig config2 = VideoBlock.UrlConfig.builder().pattern((Pattern) null).build();
+
             assertEquals(config1, config2);
         }
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoaderSchemaTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoaderSchemaTest.java
@@ -18,141 +18,135 @@ import com.dataliquid.asciidoc.linter.config.LinterConfiguration;
 
 @DisplayName("ConfigurationLoader with Schema Validation")
 class ConfigurationLoaderSchemaTest {
-    
+
     @Nested
     @DisplayName("With Schema Validation Enabled")
     class WithSchemaValidation {
-        
+
         private ConfigurationLoader loader;
-        
+
         @BeforeEach
         void setUp() {
             loader = new ConfigurationLoader(); // Schema validation enabled by default
         }
-        
+
         @Test
         @DisplayName("should load valid configuration")
         void shouldLoadValidConfiguration(@TempDir Path tempDir) throws Exception {
             Path configFile = tempDir.resolve("valid-config.yaml");
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: error
-                      - name: author
-                        required: true
-                        severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
+                            severity: error
+                          - name: author
+                            required: true
+                            severity: error
+                    """;
+
             Files.writeString(configFile, yaml);
-            
+
             LinterConfiguration config = loader.loadConfiguration(configFile);
-            
+
             assertNotNull(config);
             assertNotNull(config.document());
             assertNotNull(config.document().metadata());
             assertEquals(2, config.document().metadata().attributes().size());
         }
-        
+
         @Test
         @DisplayName("should reject configuration with invalid severity")
         void shouldRejectInvalidSeverity(@TempDir Path tempDir) throws Exception {
             Path configFile = tempDir.resolve("invalid-config.yaml");
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: CRITICAL  # Invalid!
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
+                            severity: CRITICAL  # Invalid!
+                    """;
+
             Files.writeString(configFile, yaml);
-            
-            ConfigurationException ex = assertThrows(
-                ConfigurationException.class,
-                () -> loader.loadConfiguration(configFile)
-            );
-            
+
+            ConfigurationException ex = assertThrows(ConfigurationException.class,
+                    () -> loader.loadConfiguration(configFile));
+
             assertTrue(ex.getMessage().contains("does not match schema"));
             assertTrue(ex.getMessage().contains("severity"));
         }
-        
+
         @Test
         @DisplayName("should reject configuration with missing required field")
         void shouldRejectMissingRequiredField(@TempDir Path tempDir) throws Exception {
             Path configFile = tempDir.resolve("invalid-config.yaml");
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        # severity is required but missing
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            # severity is required but missing
+                    """;
+
             Files.writeString(configFile, yaml);
-            
-            ConfigurationException ex = assertThrows(
-                ConfigurationException.class,
-                () -> loader.loadConfiguration(configFile)
-            );
-            
+
+            ConfigurationException ex = assertThrows(ConfigurationException.class,
+                    () -> loader.loadConfiguration(configFile));
+
             assertTrue(ex.getMessage().contains("does not match schema"));
             assertTrue(ex.getMessage().contains("severity"));
             assertTrue(ex.getMessage().contains("required"));
         }
-        
+
         @Test
         @DisplayName("should reject configuration with invalid section level")
         void shouldRejectInvalidSectionLevel(@TempDir Path tempDir) throws Exception {
             Path configFile = tempDir.resolve("invalid-config.yaml");
             String yaml = """
-                document:
-                  sections:
-                    - name: intro
-                      level: -1  # Must be >= 0
-                """;
-            
+                    document:
+                      sections:
+                        - name: intro
+                          level: -1  # Must be >= 0
+                    """;
+
             Files.writeString(configFile, yaml);
-            
-            ConfigurationException ex = assertThrows(
-                ConfigurationException.class,
-                () -> loader.loadConfiguration(configFile)
-            );
-            
+
+            ConfigurationException ex = assertThrows(ConfigurationException.class,
+                    () -> loader.loadConfiguration(configFile));
+
             assertTrue(ex.getMessage().contains("does not match schema"));
             assertTrue(ex.getMessage().contains("level"));
         }
     }
-    
+
     @Nested
     @DisplayName("With Schema Validation Disabled")
     class WithoutSchemaValidation {
-        
+
         private ConfigurationLoader loader;
-        
+
         @BeforeEach
         void setUp() {
             loader = new ConfigurationLoader(true); // Skip schema validation
         }
-        
+
         @Test
         @DisplayName("should still fail on invalid severity even when schema validation is disabled")
         void shouldFailOnInvalidSeverity(@TempDir Path tempDir) throws Exception {
             Path configFile = tempDir.resolve("invalid-config.yaml");
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: CRITICAL  # Invalid severity
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
+                            severity: CRITICAL  # Invalid severity
+                    """;
+
             Files.writeString(configFile, yaml);
-            
+
             // ConfigurationLoader still validates severity values internally
             assertThrows(ConfigurationException.class, () -> {
                 loader.loadConfiguration(configFile);

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoaderTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoaderTest.java
@@ -33,74 +33,74 @@ import com.dataliquid.asciidoc.linter.config.blocks.VerseBlock;
 
 @DisplayName("ConfigurationLoader")
 class ConfigurationLoaderTest {
-    
+
     private ConfigurationLoader loader;
-    
+
     @BeforeEach
     void setUp() {
         loader = new ConfigurationLoader(true); // Skip schema validation for existing tests
     }
-    
+
     @Nested
     @DisplayName("Common Loading Scenarios")
     class CommonTest {
-        
+
         @Test
         @DisplayName("should load full configuration with metadata and sections")
         void shouldLoadFullConfigurationWithMetadataAndSections() throws IOException {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: description
-                        order: 1
-                        required: true
-                        minLength: 5
-                        maxLength: 100
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      - name: author
-                        required: false
-                        severity: warn
-                  sections:
-                    - name: introduction
-                      order: 1
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^(Introduction|Einführung)$"
-                      allowedBlocks:
-                        - paragraph:
-                            name: intro-paragraph
+                    document:
+                      metadata:
+                        attributes:
+                          - name: description
+                            order: 1
+                            required: true
+                            minLength: 5
+                            maxLength: 100
+                            pattern: "^[A-Z].*"
+                            severity: error
+                          - name: author
+                            required: false
                             severity: warn
-                            occurrence:
-                              min: 1
-                              max: 3
-                              severity: error
-                            lines:
-                              max: 15
-                        - image:
-                            severity: info
-                            occurrence:
-                              min: 0
-                              max: 1
-                """;
-            
+                      sections:
+                        - name: introduction
+                          order: 1
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^(Introduction|Einführung)$"
+                          allowedBlocks:
+                            - paragraph:
+                                name: intro-paragraph
+                                severity: warn
+                                occurrence:
+                                  min: 1
+                                  max: 3
+                                  severity: error
+                                lines:
+                                  max: 15
+                            - image:
+                                severity: info
+                                occurrence:
+                                  min: 0
+                                  max: 1
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Configuration structure
             assertNotNull(config);
             assertNotNull(config.document());
             assertNotNull(config.document().metadata());
-            
+
             // Then - Metadata attributes
             var attributes = config.document().metadata().attributes();
             assertEquals(2, attributes.size());
-            
+
             var titleAttr = attributes.get(0);
             assertEquals("description", titleAttr.name());
             assertEquals(1, titleAttr.order());
@@ -109,11 +109,11 @@ class ConfigurationLoaderTest {
             assertEquals(100, titleAttr.maxLength());
             assertEquals("^[A-Z].*", titleAttr.pattern());
             assertEquals(Severity.ERROR, titleAttr.severity());
-            
+
             // Then - Sections
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var introSection = sections.get(0);
             assertEquals("introduction", introSection.name());
             assertEquals(1, introSection.order());
@@ -121,15 +121,15 @@ class ConfigurationLoaderTest {
             assertNotNull(introSection.occurrence());
             assertEquals(1, introSection.occurrence().min());
             assertEquals(1, introSection.occurrence().max());
-            
+
             // Then - Title pattern
             assertNotNull(introSection.title());
             assertEquals("^(Introduction|Einführung)$", introSection.title().pattern());
-            
+
             // Then - Allowed blocks
             var allowedBlocks = introSection.allowedBlocks();
             assertEquals(2, allowedBlocks.size());
-            
+
             var abstractBlock = allowedBlocks.get(0);
             assertTrue(abstractBlock instanceof ParagraphBlock);
             ParagraphBlock paragraphBlock = (ParagraphBlock) abstractBlock;
@@ -143,230 +143,223 @@ class ConfigurationLoaderTest {
             assertNotNull(paragraphBlock.getLines());
             assertEquals(15, paragraphBlock.getLines().max());
         }
-        
+
         @Test
         @DisplayName("should load configuration from file")
         void shouldLoadConfigurationFromFile(@TempDir Path tempDir) throws IOException {
             // Given
             Path configFile = tempDir.resolve("test-config.yaml");
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: version
-                        required: true
-                        pattern: "^\\\\d+\\\\.\\\\d+$"
-                        severity: error
-                  sections: []
-                """;
+                    document:
+                      metadata:
+                        attributes:
+                          - name: version
+                            required: true
+                            pattern: "^\\\\d+\\\\.\\\\d+$"
+                            severity: error
+                      sections: []
+                    """;
             Files.writeString(configFile, yaml);
-            
+
             // When
             LinterConfiguration config = loader.loadConfiguration(configFile);
-            
+
             // Then
             assertNotNull(config);
             assertEquals(1, config.document().metadata().attributes().size());
         }
-        
+
         @Test
         @DisplayName("should throw exception when configuration is empty")
         void shouldThrowExceptionWhenConfigurationIsEmpty() {
             // Given
             String yaml = "";
-            
+
             // When & Then
-            assertThrows(ConfigurationException.class, () -> 
-                loader.loadConfiguration(yaml)
-            );
+            assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(yaml));
         }
-        
+
         @Test
         @DisplayName("should throw exception when document section is missing")
         void shouldThrowExceptionWhenDocumentSectionIsMissing() {
             // Given
             String yaml = """
-                someOtherKey:
-                  value: test
-                """;
-            
+                    someOtherKey:
+                      value: test
+                    """;
+
             // When
-            ConfigurationException exception = assertThrows(ConfigurationException.class, () -> 
-                loader.loadConfiguration(yaml)
-            );
-            
+            ConfigurationException exception = assertThrows(ConfigurationException.class,
+                    () -> loader.loadConfiguration(yaml));
+
             // Then
             // Jackson throws UnrecognizedPropertyException when encountering unknown fields
             assertTrue(exception.getMessage().contains("Unrecognized field"));
             assertTrue(exception.getMessage().contains("someOtherKey"));
             assertTrue(exception.getMessage().contains("one known property: \"document\""));
         }
-        
+
         @Test
         @DisplayName("should throw exception when severity is invalid")
         void shouldThrowExceptionWhenSeverityIsInvalid() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: test
-                        severity: invalid
-                  sections: []
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: test
+                            severity: invalid
+                      sections: []
+                    """;
+
             // When & Then
-            assertThrows(ConfigurationException.class, () -> 
-                loader.loadConfiguration(yaml)
-            );
+            assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(yaml));
         }
-        
+
         @Test
         @DisplayName("should throw exception when block type is invalid")
         void shouldThrowExceptionWhenBlockTypeIsInvalid() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - level: 1
-                      allowedBlocks:
-                        - unknownblock:
-                            severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - level: 1
+                          allowedBlocks:
+                            - unknownblock:
+                                severity: error
+                    """;
+
             // When & Then
-            assertThrows(ConfigurationException.class, () -> 
-                loader.loadConfiguration(yaml)
-            );
+            assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(yaml));
         }
-        
+
         @Test
         @DisplayName("should load nested sections with multiple levels")
         void shouldLoadNestedSectionsWithMultipleLevels() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: main
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      subsections:
-                        - name: sub1
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: main
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 2
+                            min: 1
+                            max: 1
                           subsections:
-                            - level: 3
+                            - name: sub1
+                              level: 2
                               occurrence:
                                 min: 0
-                                max: 5
-                """;
-            
+                                max: 2
+                              subsections:
+                                - level: 3
+                                  occurrence:
+                                    min: 0
+                                    max: 5
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Main section
             var mainSection = config.document().sections().get(0);
             assertEquals(1, mainSection.subsections().size());
-            
+
             // Then - Sub section
             var subSection = mainSection.subsections().get(0);
             assertEquals("sub1", subSection.name());
             assertEquals(2, subSection.level());
             assertEquals(1, subSection.subsections().size());
-            
+
             // Then - Sub-sub section
             var subSubSection = subSection.subsections().get(0);
             assertEquals(3, subSubSection.level());
             assertNotNull(subSubSection.occurrence());
             assertEquals(5, subSubSection.occurrence().max());
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("Sections Loading")
     class SectionsTest {
-        
+
         @Test
         @DisplayName("should load two sections with all attributes and subsections")
         void shouldLoadTwoSectionsWithAllAttributesAndSubsections() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: introduction
-                      order: 1
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^(Introduction|Einführung)$"
-                      subsections:
-                        - name: motivation
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: introduction
                           order: 1
-                          level: 2
-                          occurrence:
-                            min: 0
-                            max: 1
-                          title:
-                            pattern: "^Motivation$"
-                        - name: goals
-                          order: 2
-                          level: 2
-                          occurrence:
-                            min: 0
-                            max: 1
-                          title:
-                            pattern: "^(Goals|Ziele)$"
-                    - name: mainContent
-                      order: 2
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 5
-                      title:
-                        pattern: "^Chapter.*"
-                      subsections:
-                        - name: details
-                          order: 1
-                          level: 2
+                          level: 1
                           occurrence:
                             min: 1
-                            max: 3
+                            max: 1
                           title:
-                            pattern: "^Details.*"
-                        - name: examples
+                            pattern: "^(Introduction|Einführung)$"
+                          subsections:
+                            - name: motivation
+                              order: 1
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 1
+                              title:
+                                pattern: "^Motivation$"
+                            - name: goals
+                              order: 2
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 1
+                              title:
+                                pattern: "^(Goals|Ziele)$"
+                        - name: mainContent
                           order: 2
-                          level: 2
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 10
+                            min: 1
+                            max: 5
                           title:
-                            pattern: "^Example.*"
-                """;
-            
+                            pattern: "^Chapter.*"
+                          subsections:
+                            - name: details
+                              order: 1
+                              level: 2
+                              occurrence:
+                                min: 1
+                                max: 3
+                              title:
+                                pattern: "^Details.*"
+                            - name: examples
+                              order: 2
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 10
+                              title:
+                                pattern: "^Example.*"
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Basic structure
             assertNotNull(config);
             assertNotNull(config.document());
             assertNotNull(config.document().sections());
-            
+
             var sections = config.document().sections();
             assertEquals(2, sections.size());
-            
+
             // Then - First section (introduction)
             var introSection = sections.get(0);
             assertEquals("introduction", introSection.name());
@@ -377,11 +370,11 @@ class ConfigurationLoaderTest {
             assertEquals(1, introSection.occurrence().max());
             assertNotNull(introSection.title());
             assertEquals("^(Introduction|Einführung)$", introSection.title().pattern());
-            
+
             // Then - Introduction subsections
             var introSubsections = introSection.subsections();
             assertEquals(2, introSubsections.size());
-            
+
             var motivationSection = introSubsections.get(0);
             assertEquals("motivation", motivationSection.name());
             assertEquals(1, motivationSection.order());
@@ -390,7 +383,7 @@ class ConfigurationLoaderTest {
             assertEquals(0, motivationSection.occurrence().min());
             assertEquals(1, motivationSection.occurrence().max());
             assertEquals("^Motivation$", motivationSection.title().pattern());
-            
+
             var goalsSection = introSubsections.get(1);
             assertEquals("goals", goalsSection.name());
             assertEquals(2, goalsSection.order());
@@ -399,7 +392,7 @@ class ConfigurationLoaderTest {
             assertEquals(0, goalsSection.occurrence().min());
             assertEquals(1, goalsSection.occurrence().max());
             assertEquals("^(Goals|Ziele)$", goalsSection.title().pattern());
-            
+
             // Then - Second section (mainContent)
             var mainSection = sections.get(1);
             assertEquals("mainContent", mainSection.name());
@@ -410,11 +403,11 @@ class ConfigurationLoaderTest {
             assertEquals(5, mainSection.occurrence().max());
             assertNotNull(mainSection.title());
             assertEquals("^Chapter.*", mainSection.title().pattern());
-            
+
             // Then - Main content subsections
             var mainSubsections = mainSection.subsections();
             assertEquals(2, mainSubsections.size());
-            
+
             var detailsSection = mainSubsections.get(0);
             assertEquals("details", detailsSection.name());
             assertEquals(1, detailsSection.order());
@@ -423,7 +416,7 @@ class ConfigurationLoaderTest {
             assertEquals(1, detailsSection.occurrence().min());
             assertEquals(3, detailsSection.occurrence().max());
             assertEquals("^Details.*", detailsSection.title().pattern());
-            
+
             var examplesSection = mainSubsections.get(1);
             assertEquals("examples", examplesSection.name());
             assertEquals(2, examplesSection.order());
@@ -434,47 +427,47 @@ class ConfigurationLoaderTest {
             assertEquals("^Example.*", examplesSection.title().pattern());
         }
     }
-    
+
     @Nested
     @DisplayName("Metadata Attributes Loading")
     class MetadataAttributesTest {
-        
+
         @Test
         @DisplayName("should load two metadata attributes with all properties")
         void shouldLoadTwoMetadataAttributesWithAllProperties() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: description
-                        order: 1
-                        required: true
-                        minLength: 5
-                        maxLength: 100
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      - name: author
-                        order: 2
-                        required: false
-                        minLength: 3
-                        maxLength: 50
-                        pattern: "^[A-Za-z][a-zA-Z\\\\s\\\\.]+$"
-                        severity: warn
-                  sections: []
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: description
+                            order: 1
+                            required: true
+                            minLength: 5
+                            maxLength: 100
+                            pattern: "^[A-Z].*"
+                            severity: error
+                          - name: author
+                            order: 2
+                            required: false
+                            minLength: 3
+                            maxLength: 50
+                            pattern: "^[A-Za-z][a-zA-Z\\\\s\\\\.]+$"
+                            severity: warn
+                      sections: []
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Basic structure
             assertNotNull(config);
             assertNotNull(config.document());
             assertNotNull(config.document().metadata());
-            
+
             var attributes = config.document().metadata().attributes();
             assertEquals(2, attributes.size());
-            
+
             // Then - First attribute (title)
             var titleAttr = attributes.get(0);
             assertEquals("description", titleAttr.name());
@@ -484,7 +477,7 @@ class ConfigurationLoaderTest {
             assertEquals(100, titleAttr.maxLength());
             assertEquals("^[A-Z].*", titleAttr.pattern());
             assertEquals(Severity.ERROR, titleAttr.severity());
-            
+
             // Then - Second attribute (author)
             var authorAttr = attributes.get(1);
             assertEquals("author", authorAttr.name());
@@ -496,122 +489,122 @@ class ConfigurationLoaderTest {
             assertEquals(Severity.WARN, authorAttr.severity());
         }
     }
-    
+
     @Nested
     @DisplayName("ImageBlock Loading")
     class ImageBlockTest {
-        
+
         @Test
         @DisplayName("should load ImageBlock in section and subsection")
         void shouldLoadImageBlockInSectionAndSubsection() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: main-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - image:
-                            name: section-image
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 3
-                            url:
-                              required: true
-                              pattern: "^https?://.*\\\\.(jpg|jpeg|png|gif|svg)$"
-                            height:
-                              required: false
-                              minValue: 100
-                              maxValue: 2000
-                            width:
-                              required: false
-                              minValue: 100
-                              maxValue: 3000
-                            alt:
-                              required: true
-                              minLength: 10
-                              maxLength: 200
-                      subsections:
-                        - name: sub-section
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: main-section
+                          level: 1
                           occurrence:
                             min: 1
-                            max: 2
+                            max: 1
                           allowedBlocks:
                             - image:
-                                name: subsection-image
-                                severity: info
+                                name: section-image
+                                severity: warn
                                 occurrence:
-                                  min: 1
-                                  max: 5
+                                  min: 0
+                                  max: 3
                                 url:
                                   required: true
-                                  pattern: ".*\\\\.(jpg|png)$"
+                                  pattern: "^https?://.*\\\\.(jpg|jpeg|png|gif|svg)$"
+                                height:
+                                  required: false
+                                  minValue: 100
+                                  maxValue: 2000
+                                width:
+                                  required: false
+                                  minValue: 100
+                                  maxValue: 3000
                                 alt:
                                   required: true
-                                  minLength: 5
-                                  maxLength: 100
-                """;
-            
+                                  minLength: 10
+                                  maxLength: 200
+                          subsections:
+                            - name: sub-section
+                              level: 2
+                              occurrence:
+                                min: 1
+                                max: 2
+                              allowedBlocks:
+                                - image:
+                                    name: subsection-image
+                                    severity: info
+                                    occurrence:
+                                      min: 1
+                                      max: 5
+                                    url:
+                                      required: true
+                                      pattern: ".*\\\\.(jpg|png)$"
+                                    alt:
+                                      required: true
+                                      minLength: 5
+                                      maxLength: 100
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level image block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var mainSection = sections.get(0);
             assertEquals("main-section", mainSection.name());
             assertEquals(1, mainSection.allowedBlocks().size());
-            
+
             var sectionImage = (ImageBlock) mainSection.allowedBlocks().get(0);
             assertEquals("section-image", sectionImage.getName());
             assertEquals(Severity.WARN, sectionImage.getSeverity());
             assertEquals(0, sectionImage.getOccurrence().min());
             assertEquals(3, sectionImage.getOccurrence().max());
-            
+
             // URL validation
             assertNotNull(sectionImage.getUrl());
             assertTrue(sectionImage.getUrl().isRequired());
             assertEquals("^https?://.*\\.(jpg|jpeg|png|gif|svg)$", sectionImage.getUrl().getPattern().pattern());
-            
+
             // Dimension validation
             assertNotNull(sectionImage.getHeight());
             assertFalse(sectionImage.getHeight().isRequired());
             assertEquals(100, sectionImage.getHeight().getMinValue());
             assertEquals(2000, sectionImage.getHeight().getMaxValue());
-            
+
             assertNotNull(sectionImage.getWidth());
             assertFalse(sectionImage.getWidth().isRequired());
             assertEquals(100, sectionImage.getWidth().getMinValue());
             assertEquals(3000, sectionImage.getWidth().getMaxValue());
-            
+
             // Alt text validation
             assertNotNull(sectionImage.getAlt());
             assertTrue(sectionImage.getAlt().isRequired());
             assertEquals(10, sectionImage.getAlt().getMinLength());
             assertEquals(200, sectionImage.getAlt().getMaxLength());
-            
+
             // Then - Subsection level image block
             var subsections = mainSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var subSection = subsections.get(0);
             assertEquals("sub-section", subSection.name());
             assertEquals(1, subSection.allowedBlocks().size());
-            
+
             var subsectionImage = (ImageBlock) subSection.allowedBlocks().get(0);
             assertEquals("subsection-image", subsectionImage.getName());
             assertEquals(Severity.INFO, subsectionImage.getSeverity());
             assertEquals(1, subsectionImage.getOccurrence().min());
             assertEquals(5, subsectionImage.getOccurrence().max());
-            
+
             // Subsection image validation rules
             assertTrue(subsectionImage.getUrl().isRequired());
             assertEquals(".*\\.(jpg|png)$", subsectionImage.getUrl().getPattern().pattern());
@@ -620,93 +613,93 @@ class ConfigurationLoaderTest {
             assertEquals(100, subsectionImage.getAlt().getMaxLength());
         }
     }
-    
+
     @Nested
     @DisplayName("ListingBlock Loading")
     class ListingBlockTest {
-        
+
         @Test
         @DisplayName("should load ListingBlock in section and subsection")
         void shouldLoadListingBlockInSectionAndSubsection() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: code-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - listing:
-                            name: main-code
-                            severity: error
-                            occurrence:
-                              min: 1
-                              max: 10
-                            language:
-                              required: true
-                              allowed: ["java", "python", "javascript"]
-                              severity: error
-                            lines:
-                              min: 5
-                              max: 200
-                            title:
-                              required: true
-                              pattern: "^Listing \\\\d+:.*"
-                              severity: warn
-                            callouts:
-                              allowed: true
-                              max: 15
-                              severity: info
-                      subsections:
-                        - name: examples
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: code-section
+                          level: 1
                           occurrence:
                             min: 1
-                            max: 3
+                            max: 1
                           allowedBlocks:
                             - listing:
-                                name: example-code
-                                severity: warn
+                                name: main-code
+                                severity: error
                                 occurrence:
                                   min: 1
-                                  max: 5
+                                  max: 10
                                 language:
-                                  required: false
-                                  allowed: ["yaml", "json", "xml"]
-                                  severity: warn
-                                lines:
-                                  min: 1
-                                  max: 50
-                                title:
-                                  required: false
-                                  pattern: "^Example.*"
-                                  severity: info
-                                callouts:
-                                  allowed: false
+                                  required: true
+                                  allowed: ["java", "python", "javascript"]
                                   severity: error
-                """;
-            
+                                lines:
+                                  min: 5
+                                  max: 200
+                                title:
+                                  required: true
+                                  pattern: "^Listing \\\\d+:.*"
+                                  severity: warn
+                                callouts:
+                                  allowed: true
+                                  max: 15
+                                  severity: info
+                          subsections:
+                            - name: examples
+                              level: 2
+                              occurrence:
+                                min: 1
+                                max: 3
+                              allowedBlocks:
+                                - listing:
+                                    name: example-code
+                                    severity: warn
+                                    occurrence:
+                                      min: 1
+                                      max: 5
+                                    language:
+                                      required: false
+                                      allowed: ["yaml", "json", "xml"]
+                                      severity: warn
+                                    lines:
+                                      min: 1
+                                      max: 50
+                                    title:
+                                      required: false
+                                      pattern: "^Example.*"
+                                      severity: info
+                                    callouts:
+                                      allowed: false
+                                      severity: error
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level listing block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var codeSection = sections.get(0);
             assertEquals("code-section", codeSection.name());
             assertEquals(1, codeSection.allowedBlocks().size());
-            
+
             var mainListing = (ListingBlock) codeSection.allowedBlocks().get(0);
             assertEquals("main-code", mainListing.getName());
             assertEquals(Severity.ERROR, mainListing.getSeverity());
             assertEquals(1, mainListing.getOccurrence().min());
             assertEquals(10, mainListing.getOccurrence().max());
-            
+
             // Language validation
             assertNotNull(mainListing.getLanguage());
             assertTrue(mainListing.getLanguage().isRequired());
@@ -715,36 +708,36 @@ class ConfigurationLoaderTest {
             assertTrue(mainListing.getLanguage().getAllowed().contains("python"));
             assertTrue(mainListing.getLanguage().getAllowed().contains("javascript"));
             assertEquals(Severity.ERROR, mainListing.getLanguage().getSeverity());
-            
+
             // Lines validation
             assertNotNull(mainListing.getLines());
             assertEquals(5, mainListing.getLines().min());
             assertEquals(200, mainListing.getLines().max());
-            
+
             // Title validation
             assertNotNull(mainListing.getTitle());
             assertTrue(mainListing.getTitle().isRequired());
             assertEquals("^Listing \\d+:.*", mainListing.getTitle().getPattern().pattern());
             assertEquals(Severity.WARN, mainListing.getTitle().getSeverity());
-            
+
             // Callouts validation
             assertNotNull(mainListing.getCallouts());
             assertTrue(mainListing.getCallouts().isAllowed());
             assertEquals(15, mainListing.getCallouts().getMax());
             assertEquals(Severity.INFO, mainListing.getCallouts().getSeverity());
-            
+
             // Then - Subsection level listing block
             var subsections = codeSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var examplesSection = subsections.get(0);
             assertEquals("examples", examplesSection.name());
             assertEquals(1, examplesSection.allowedBlocks().size());
-            
+
             var exampleListing = (ListingBlock) examplesSection.allowedBlocks().get(0);
             assertEquals("example-code", exampleListing.getName());
             assertEquals(Severity.WARN, exampleListing.getSeverity());
-            
+
             // Subsection listing validation rules
             assertFalse(exampleListing.getLanguage().isRequired());
             assertEquals(3, exampleListing.getLanguage().getAllowed().size());
@@ -755,215 +748,215 @@ class ConfigurationLoaderTest {
             assertFalse(exampleListing.getCallouts().isAllowed());
         }
     }
-    
+
     @Nested
     @DisplayName("ParagraphBlock Loading")
     class ParagraphBlockTest {
-        
+
         @Test
         @DisplayName("should load ParagraphBlock in section and subsection")
         void shouldLoadParagraphBlockInSectionAndSubsection() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: intro-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - paragraph:
-                            name: intro-paragraph
-                            severity: warn
-                            occurrence:
-                              min: 1
-                              max: 5
-                              severity: error
-                            lines:
-                              min: 3
-                              max: 20
-                      subsections:
-                        - name: details
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: intro-section
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 3
+                            min: 1
+                            max: 1
                           allowedBlocks:
                             - paragraph:
-                                name: detail-paragraph
-                                severity: info
+                                name: intro-paragraph
+                                severity: warn
                                 occurrence:
                                   min: 1
-                                  max: 10
+                                  max: 5
+                                  severity: error
                                 lines:
-                                  min: 1
-                                  max: 15
-                """;
-            
+                                  min: 3
+                                  max: 20
+                          subsections:
+                            - name: details
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 3
+                              allowedBlocks:
+                                - paragraph:
+                                    name: detail-paragraph
+                                    severity: info
+                                    occurrence:
+                                      min: 1
+                                      max: 10
+                                    lines:
+                                      min: 1
+                                      max: 15
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level paragraph block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var introSection = sections.get(0);
             assertEquals("intro-section", introSection.name());
             assertEquals(1, introSection.allowedBlocks().size());
-            
+
             var introParagraph = (ParagraphBlock) introSection.allowedBlocks().get(0);
             assertEquals("intro-paragraph", introParagraph.getName());
             assertEquals(Severity.WARN, introParagraph.getSeverity());
             assertEquals(1, introParagraph.getOccurrence().min());
             assertEquals(5, introParagraph.getOccurrence().max());
             assertEquals(Severity.ERROR, introParagraph.getOccurrence().severity());
-            
+
             // Lines validation
             assertNotNull(introParagraph.getLines());
             assertEquals(3, introParagraph.getLines().min());
             assertEquals(20, introParagraph.getLines().max());
-            
+
             // Then - Subsection level paragraph block
             var subsections = introSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var detailsSection = subsections.get(0);
             assertEquals("details", detailsSection.name());
             assertEquals(1, detailsSection.allowedBlocks().size());
-            
+
             var detailParagraph = (ParagraphBlock) detailsSection.allowedBlocks().get(0);
             assertEquals("detail-paragraph", detailParagraph.getName());
             assertEquals(Severity.INFO, detailParagraph.getSeverity());
             assertEquals(1, detailParagraph.getOccurrence().min());
             assertEquals(10, detailParagraph.getOccurrence().max());
-            
+
             // Subsection paragraph lines validation
             assertEquals(1, detailParagraph.getLines().min());
             assertEquals(15, detailParagraph.getLines().max());
         }
     }
-    
+
     @Nested
     @DisplayName("TableBlock Loading")
     class TableBlockTest {
-        
+
         @Test
         @DisplayName("should load TableBlock in section and subsection")
         void shouldLoadTableBlockInSectionAndSubsection() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: data-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - table:
-                            name: main-table
-                            severity: error
-                            occurrence:
-                              min: 1
-                              max: 3
-                            columns:
-                              min: 2
-                              max: 10
-                              severity: error
-                            rows:
-                              min: 1
-                              max: 100
-                              severity: warn
-                            header:
-                              required: true
-                              pattern: "^[A-Z].*"
-                              severity: error
-                            caption:
-                              required: true
-                              pattern: "^Table \\\\d+:.*"
-                              minLength: 10
-                              maxLength: 200
-                              severity: warn
-                            format:
-                              style: "grid"
-                              borders: true
-                              severity: info
-                      subsections:
-                        - name: summary
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: data-section
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 2
+                            min: 1
+                            max: 1
                           allowedBlocks:
                             - table:
-                                name: summary-table
-                                severity: warn
+                                name: main-table
+                                severity: error
                                 occurrence:
-                                  min: 0
-                                  max: 5
+                                  min: 1
+                                  max: 3
                                 columns:
                                   min: 2
-                                  max: 5
-                                  severity: warn
+                                  max: 10
+                                  severity: error
                                 rows:
                                   min: 1
-                                  max: 50
-                                  severity: info
+                                  max: 100
+                                  severity: warn
                                 header:
-                                  required: false
-                                  pattern: ".*"
-                                  severity: info
+                                  required: true
+                                  pattern: "^[A-Z].*"
+                                  severity: error
                                 caption:
-                                  required: false
-                                  minLength: 5
-                                  maxLength: 100
-                                  severity: info
+                                  required: true
+                                  pattern: "^Table \\\\d+:.*"
+                                  minLength: 10
+                                  maxLength: 200
+                                  severity: warn
                                 format:
-                                  style: "simple"
-                                  borders: false
+                                  style: "grid"
+                                  borders: true
                                   severity: info
-                """;
-            
+                          subsections:
+                            - name: summary
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 2
+                              allowedBlocks:
+                                - table:
+                                    name: summary-table
+                                    severity: warn
+                                    occurrence:
+                                      min: 0
+                                      max: 5
+                                    columns:
+                                      min: 2
+                                      max: 5
+                                      severity: warn
+                                    rows:
+                                      min: 1
+                                      max: 50
+                                      severity: info
+                                    header:
+                                      required: false
+                                      pattern: ".*"
+                                      severity: info
+                                    caption:
+                                      required: false
+                                      minLength: 5
+                                      maxLength: 100
+                                      severity: info
+                                    format:
+                                      style: "simple"
+                                      borders: false
+                                      severity: info
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level table block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var dataSection = sections.get(0);
             assertEquals("data-section", dataSection.name());
             assertEquals(1, dataSection.allowedBlocks().size());
-            
+
             var mainTable = (TableBlock) dataSection.allowedBlocks().get(0);
             assertEquals("main-table", mainTable.getName());
             assertEquals(Severity.ERROR, mainTable.getSeverity());
             assertEquals(1, mainTable.getOccurrence().min());
             assertEquals(3, mainTable.getOccurrence().max());
-            
+
             // Columns validation
             assertNotNull(mainTable.getColumns());
             assertEquals(2, mainTable.getColumns().getMin());
             assertEquals(10, mainTable.getColumns().getMax());
             assertEquals(Severity.ERROR, mainTable.getColumns().getSeverity());
-            
+
             // Rows validation
             assertNotNull(mainTable.getRows());
             assertEquals(1, mainTable.getRows().getMin());
             assertEquals(100, mainTable.getRows().getMax());
             assertEquals(Severity.WARN, mainTable.getRows().getSeverity());
-            
+
             // Header validation
             assertNotNull(mainTable.getHeader());
             assertTrue(mainTable.getHeader().isRequired());
             assertEquals("^[A-Z].*", mainTable.getHeader().getPattern().pattern());
             assertEquals(Severity.ERROR, mainTable.getHeader().getSeverity());
-            
+
             // Caption validation
             assertNotNull(mainTable.getCaption());
             assertTrue(mainTable.getCaption().isRequired());
@@ -971,25 +964,25 @@ class ConfigurationLoaderTest {
             assertEquals(10, mainTable.getCaption().getMinLength());
             assertEquals(200, mainTable.getCaption().getMaxLength());
             assertEquals(Severity.WARN, mainTable.getCaption().getSeverity());
-            
+
             // Format validation
             assertNotNull(mainTable.getFormat());
             assertEquals("grid", mainTable.getFormat().getStyle());
             assertTrue(mainTable.getFormat().getBorders());
             assertEquals(Severity.INFO, mainTable.getFormat().getSeverity());
-            
+
             // Then - Subsection level table block
             var subsections = dataSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var summarySection = subsections.get(0);
             assertEquals("summary", summarySection.name());
             assertEquals(1, summarySection.allowedBlocks().size());
-            
+
             var summaryTable = (TableBlock) summarySection.allowedBlocks().get(0);
             assertEquals("summary-table", summaryTable.getName());
             assertEquals(Severity.WARN, summaryTable.getSeverity());
-            
+
             // Subsection table validation rules
             assertEquals(2, summaryTable.getColumns().getMin());
             assertEquals(5, summaryTable.getColumns().getMax());
@@ -1000,71 +993,71 @@ class ConfigurationLoaderTest {
             assertFalse(summaryTable.getFormat().getBorders());
         }
     }
-    
+
     @Nested
     @DisplayName("PassBlock Loading")
     class PassBlockTest {
-        
+
         @Test
         @DisplayName("should load PassBlock with all configurations")
         void shouldLoadPassBlockWithAllConfigurations() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: main-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - pass:
-                            name: html-widget
-                            severity: error
-                            occurrence:
-                              min: 0
-                              max: 1
-                              severity: error
-                            type:
-                              required: true
-                              allowed: [html, xml, svg]
-                              severity: error
-                            content:
-                              required: true
-                              maxLength: 1000
-                              pattern: "^<[^>]+>.*</[^>]+>$"
-                              severity: error
-                            reason:
-                              required: true
-                              minLength: 20
-                              maxLength: 200
-                              severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: main-section
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - pass:
+                                name: html-widget
+                                severity: error
+                                occurrence:
+                                  min: 0
+                                  max: 1
+                                  severity: error
+                                type:
+                                  required: true
+                                  allowed: [html, xml, svg]
+                                  severity: error
+                                content:
+                                  required: true
+                                  maxLength: 1000
+                                  pattern: "^<[^>]+>.*</[^>]+>$"
+                                  severity: error
+                                reason:
+                                  required: true
+                                  minLength: 20
+                                  maxLength: 200
+                                  severity: error
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var mainSection = sections.get(0);
             assertEquals("main-section", mainSection.name());
             assertEquals(1, mainSection.allowedBlocks().size());
-            
+
             var passBlock = (PassBlock) mainSection.allowedBlocks().get(0);
             assertEquals("html-widget", passBlock.getName());
             assertEquals(Severity.ERROR, passBlock.getSeverity());
-            
+
             // Then - Occurrence
             var occurrence = passBlock.getOccurrence();
             assertNotNull(occurrence);
             assertEquals(0, occurrence.min());
             assertEquals(1, occurrence.max());
             assertEquals(Severity.ERROR, occurrence.severity());
-            
+
             // Then - Type config
             var typeConfig = passBlock.getTypeConfig();
             assertNotNull(typeConfig);
@@ -1072,7 +1065,7 @@ class ConfigurationLoaderTest {
             assertEquals(3, typeConfig.getAllowed().size());
             assertTrue(typeConfig.getAllowed().containsAll(Arrays.asList("html", "xml", "svg")));
             assertEquals(Severity.ERROR, typeConfig.getSeverity());
-            
+
             // Then - Content config
             var contentConfig = passBlock.getContent();
             assertNotNull(contentConfig);
@@ -1080,7 +1073,7 @@ class ConfigurationLoaderTest {
             assertEquals(1000, contentConfig.getMaxLength());
             assertEquals("^<[^>]+>.*</[^>]+>$", contentConfig.getPattern().pattern());
             assertEquals(Severity.ERROR, contentConfig.getSeverity());
-            
+
             // Then - Reason config
             var reasonConfig = passBlock.getReason();
             assertNotNull(reasonConfig);
@@ -1089,36 +1082,36 @@ class ConfigurationLoaderTest {
             assertEquals(200, reasonConfig.getMaxLength());
             assertEquals(Severity.ERROR, reasonConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should load PassBlock with minimal configuration")
         void shouldLoadPassBlockWithMinimalConfiguration() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - pass:
-                            severity: warn
-                """;
-            
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: section
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - pass:
+                                severity: warn
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var section = sections.get(0);
             assertEquals(1, section.allowedBlocks().size());
-            
+
             var passBlock = (PassBlock) section.allowedBlocks().get(0);
             assertEquals(Severity.WARN, passBlock.getSeverity());
             assertNull(passBlock.getName());
@@ -1128,93 +1121,93 @@ class ConfigurationLoaderTest {
             assertNull(passBlock.getReason());
         }
     }
-    
+
     @Nested
     @DisplayName("VerseBlock Loading")
     class VerseBlockTest {
-        
+
         @Test
         @DisplayName("should load VerseBlock in section and subsection")
         void shouldLoadVerseBlockInSectionAndSubsection() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: quotes-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - verse:
-                            name: main-verse
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 3
-                            author:
-                              defaultValue: "Unknown"
-                              minLength: 3
-                              maxLength: 50
-                              pattern: "^[A-Z][a-zA-Z\\\\s\\\\.]+$"
-                              required: true
-                            attribution:
-                              defaultValue: "Source Unknown"
-                              minLength: 5
-                              maxLength: 100
-                              pattern: "^[A-Za-z0-9\\\\s,\\\\.]+$"
-                              required: false
-                            content:
-                              minLength: 20
-                              maxLength: 500
-                              pattern: ".*\\\\n.*"
-                              required: true
-                      subsections:
-                        - name: poetry
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: quotes-section
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 5
+                            min: 1
+                            max: 1
                           allowedBlocks:
                             - verse:
-                                name: poetry-verse
-                                severity: info
+                                name: main-verse
+                                severity: warn
                                 occurrence:
-                                  min: 1
-                                  max: 10
+                                  min: 0
+                                  max: 3
                                 author:
-                                  minLength: 2
-                                  maxLength: 40
-                                  required: false
-                                attribution:
+                                  defaultValue: "Unknown"
                                   minLength: 3
-                                  maxLength: 80
+                                  maxLength: 50
+                                  pattern: "^[A-Z][a-zA-Z\\\\s\\\\.]+$"
+                                  required: true
+                                attribution:
+                                  defaultValue: "Source Unknown"
+                                  minLength: 5
+                                  maxLength: 100
+                                  pattern: "^[A-Za-z0-9\\\\s,\\\\.]+$"
                                   required: false
                                 content:
-                                  minLength: 10
-                                  maxLength: 300
+                                  minLength: 20
+                                  maxLength: 500
+                                  pattern: ".*\\\\n.*"
                                   required: true
-                """;
-            
+                          subsections:
+                            - name: poetry
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 5
+                              allowedBlocks:
+                                - verse:
+                                    name: poetry-verse
+                                    severity: info
+                                    occurrence:
+                                      min: 1
+                                      max: 10
+                                    author:
+                                      minLength: 2
+                                      maxLength: 40
+                                      required: false
+                                    attribution:
+                                      minLength: 3
+                                      maxLength: 80
+                                      required: false
+                                    content:
+                                      minLength: 10
+                                      maxLength: 300
+                                      required: true
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level verse block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var quotesSection = sections.get(0);
             assertEquals("quotes-section", quotesSection.name());
             assertEquals(1, quotesSection.allowedBlocks().size());
-            
+
             var mainVerse = (VerseBlock) quotesSection.allowedBlocks().get(0);
             assertEquals("main-verse", mainVerse.getName());
             assertEquals(Severity.WARN, mainVerse.getSeverity());
             assertEquals(0, mainVerse.getOccurrence().min());
             assertEquals(3, mainVerse.getOccurrence().max());
-            
+
             // Author validation
             assertNotNull(mainVerse.getAuthor());
             assertEquals("Unknown", mainVerse.getAuthor().getDefaultValue());
@@ -1222,7 +1215,7 @@ class ConfigurationLoaderTest {
             assertEquals(50, mainVerse.getAuthor().getMaxLength());
             assertEquals("^[A-Z][a-zA-Z\\s\\.]+$", mainVerse.getAuthor().getPattern().pattern());
             assertTrue(mainVerse.getAuthor().isRequired());
-            
+
             // Attribution validation
             assertNotNull(mainVerse.getAttribution());
             assertEquals("Source Unknown", mainVerse.getAttribution().getDefaultValue());
@@ -1230,28 +1223,28 @@ class ConfigurationLoaderTest {
             assertEquals(100, mainVerse.getAttribution().getMaxLength());
             assertEquals("^[A-Za-z0-9\\s,\\.]+$", mainVerse.getAttribution().getPattern().pattern());
             assertFalse(mainVerse.getAttribution().isRequired());
-            
+
             // Content validation
             assertNotNull(mainVerse.getContent());
             assertEquals(20, mainVerse.getContent().getMinLength());
             assertEquals(500, mainVerse.getContent().getMaxLength());
             assertEquals(".*\\n.*", mainVerse.getContent().getPattern().pattern());
             assertTrue(mainVerse.getContent().isRequired());
-            
+
             // Then - Subsection level verse block
             var subsections = quotesSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var poetrySection = subsections.get(0);
             assertEquals("poetry", poetrySection.name());
             assertEquals(1, poetrySection.allowedBlocks().size());
-            
+
             var poetryVerse = (VerseBlock) poetrySection.allowedBlocks().get(0);
             assertEquals("poetry-verse", poetryVerse.getName());
             assertEquals(Severity.INFO, poetryVerse.getSeverity());
             assertEquals(1, poetryVerse.getOccurrence().min());
             assertEquals(10, poetryVerse.getOccurrence().max());
-            
+
             // Subsection verse validation rules
             assertEquals(2, poetryVerse.getAuthor().getMinLength());
             assertEquals(40, poetryVerse.getAuthor().getMaxLength());
@@ -1259,71 +1252,71 @@ class ConfigurationLoaderTest {
             assertEquals(10, poetryVerse.getContent().getMinLength());
             assertEquals(300, poetryVerse.getContent().getMaxLength());
         }
-        
+
         @Test
         @DisplayName("should load paragraph block with sentence validation")
         void shouldLoadParagraphBlockWithSentenceValidation() throws IOException {
             // Given
             String yaml = """
-                document:
-                  sections:
-                    - name: conclusion
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - paragraph:
-                            name: conclusion-paragraph
-                            severity: error
-                            occurrence:
-                              min: 1
-                              max: 3
-                            lines:
-                              min: 3
-                              max: 20
-                              severity: warn
-                            sentence:
-                              occurrence:
-                                min: 3
-                                max: 10
-                                severity: warn
-                              words:
-                                min: 8
-                                max: 25
-                                severity: info
-                """;
-            
+                    document:
+                      sections:
+                        - name: conclusion
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - paragraph:
+                                name: conclusion-paragraph
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  max: 3
+                                lines:
+                                  min: 3
+                                  max: 20
+                                  severity: warn
+                                sentence:
+                                  occurrence:
+                                    min: 3
+                                    max: 10
+                                    severity: warn
+                                  words:
+                                    min: 8
+                                    max: 25
+                                    severity: info
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var conclusionSection = sections.get(0);
             assertEquals("conclusion", conclusionSection.name());
             assertEquals(1, conclusionSection.allowedBlocks().size());
-            
+
             var paragraphBlock = (ParagraphBlock) conclusionSection.allowedBlocks().get(0);
             assertEquals("conclusion-paragraph", paragraphBlock.getName());
             assertEquals(Severity.ERROR, paragraphBlock.getSeverity());
-            
+
             // Lines validation
             assertNotNull(paragraphBlock.getLines());
             assertEquals(3, paragraphBlock.getLines().min());
             assertEquals(20, paragraphBlock.getLines().max());
             assertEquals(Severity.WARN, paragraphBlock.getLines().severity());
-            
+
             // Sentence validation
             assertNotNull(paragraphBlock.getSentence());
-            
+
             // Sentence occurrence
             assertNotNull(paragraphBlock.getSentence().getOccurrence());
             assertEquals(3, paragraphBlock.getSentence().getOccurrence().min());
             assertEquals(10, paragraphBlock.getSentence().getOccurrence().max());
             assertEquals(Severity.WARN, paragraphBlock.getSentence().getOccurrence().severity());
-            
+
             // Words per sentence
             assertNotNull(paragraphBlock.getSentence().getWords());
             assertEquals(8, paragraphBlock.getSentence().getWords().getMin());
@@ -1331,72 +1324,72 @@ class ConfigurationLoaderTest {
             assertEquals(Severity.INFO, paragraphBlock.getSentence().getWords().getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("AdmonitionBlock Loading")
     class AdmonitionBlockTest {
-        
+
         @Test
         @DisplayName("should load AdmonitionBlock with type validation and nested rules")
         void shouldLoadAdmonitionBlockWithTypeValidation() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: notes-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - admonition:
-                            name: content-notes
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 10
-                            type:
-                              required: true
-                              allowed: ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]
-                              severity: error
-                            title:
-                              required: true
-                              pattern: "^[A-Z][A-Za-z\\\\s]{2,49}$"
-                              minLength: 3
-                              maxLength: 50
-                              severity: error
-                            content:
-                              required: false
-                              minLength: 10
-                              maxLength: 500
-                              severity: warn
-                              lines:
-                                min: 1
-                                max: 10
-                                severity: info
-                            icon:
-                              required: true
-                              pattern: "^(info|warning|caution|tip|note)$"
-                              severity: info
-                """;
-            
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: notes-section
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - admonition:
+                                name: content-notes
+                                severity: warn
+                                occurrence:
+                                  min: 0
+                                  max: 10
+                                type:
+                                  required: true
+                                  allowed: ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]
+                                  severity: error
+                                title:
+                                  required: true
+                                  pattern: "^[A-Z][A-Za-z\\\\s]{2,49}$"
+                                  minLength: 3
+                                  maxLength: 50
+                                  severity: error
+                                content:
+                                  required: false
+                                  minLength: 10
+                                  maxLength: 500
+                                  severity: warn
+                                  lines:
+                                    min: 1
+                                    max: 10
+                                    severity: info
+                                icon:
+                                  required: true
+                                  pattern: "^(info|warning|caution|tip|note)$"
+                                  severity: info
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var notesSection = sections.get(0);
             assertEquals("notes-section", notesSection.name());
             assertEquals(1, notesSection.allowedBlocks().size());
-            
+
             var admonitionBlock = (AdmonitionBlock) notesSection.allowedBlocks().get(0);
             assertEquals("content-notes", admonitionBlock.getName());
             assertEquals(Severity.WARN, admonitionBlock.getSeverity());
-            
+
             // Type validation
             assertNotNull(admonitionBlock.getTypeConfig());
             assertTrue(admonitionBlock.getTypeConfig().isRequired());
@@ -1404,7 +1397,7 @@ class ConfigurationLoaderTest {
             assertTrue(admonitionBlock.getTypeConfig().getAllowed().contains("NOTE"));
             assertTrue(admonitionBlock.getTypeConfig().getAllowed().contains("TIP"));
             assertEquals(Severity.ERROR, admonitionBlock.getTypeConfig().getSeverity());
-            
+
             // Title validation
             assertNotNull(admonitionBlock.getTitle());
             assertTrue(admonitionBlock.getTitle().isRequired());
@@ -1412,20 +1405,20 @@ class ConfigurationLoaderTest {
             assertEquals(3, admonitionBlock.getTitle().getMinLength());
             assertEquals(50, admonitionBlock.getTitle().getMaxLength());
             assertEquals(Severity.ERROR, admonitionBlock.getTitle().getSeverity());
-            
+
             // Content validation with nested lines
             assertNotNull(admonitionBlock.getContent());
             assertFalse(admonitionBlock.getContent().isRequired());
             assertEquals(10, admonitionBlock.getContent().getMinLength());
             assertEquals(500, admonitionBlock.getContent().getMaxLength());
             assertEquals(Severity.WARN, admonitionBlock.getContent().getSeverity());
-            
+
             // Lines validation (nested in content)
             assertNotNull(admonitionBlock.getContent().getLines());
             assertEquals(1, admonitionBlock.getContent().getLines().min());
             assertEquals(10, admonitionBlock.getContent().getLines().max());
             assertEquals(Severity.INFO, admonitionBlock.getContent().getLines().severity());
-            
+
             // Icon validation
             assertNotNull(admonitionBlock.getIcon());
             assertTrue(admonitionBlock.getIcon().isRequired());
@@ -1433,73 +1426,73 @@ class ConfigurationLoaderTest {
             assertEquals(Severity.INFO, admonitionBlock.getIcon().getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("LiteralBlock Loading")
     class LiteralBlockTest {
-        
+
         @Test
         @DisplayName("should load LiteralBlock with all configurations")
         void shouldLoadLiteralBlockWithAllConfigurations() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: configuration-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - literal:
-                            name: config-literal
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 3
-                              severity: error
-                            title:
-                              required: false
-                              minLength: 5
-                              maxLength: 50
-                              severity: info
-                            lines:
-                              min: 3
-                              max: 100
-                              severity: warn
-                            indentation:
-                              required: false
-                              consistent: true
-                              minSpaces: 2
-                              maxSpaces: 8
-                              severity: warn
-                """;
-            
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: configuration-section
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - literal:
+                                name: config-literal
+                                severity: warn
+                                occurrence:
+                                  min: 0
+                                  max: 3
+                                  severity: error
+                                title:
+                                  required: false
+                                  minLength: 5
+                                  maxLength: 50
+                                  severity: info
+                                lines:
+                                  min: 3
+                                  max: 100
+                                  severity: warn
+                                indentation:
+                                  required: false
+                                  consistent: true
+                                  minSpaces: 2
+                                  maxSpaces: 8
+                                  severity: warn
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var configSection = sections.get(0);
             assertEquals("configuration-section", configSection.name());
             assertEquals(1, configSection.allowedBlocks().size());
-            
+
             var literalBlock = (LiteralBlock) configSection.allowedBlocks().get(0);
             assertEquals("config-literal", literalBlock.getName());
             assertEquals(Severity.WARN, literalBlock.getSeverity());
             assertEquals(BlockType.LITERAL, literalBlock.getType());
-            
+
             // Then - Occurrence
             var occurrence = literalBlock.getOccurrence();
             assertNotNull(occurrence);
             assertEquals(0, occurrence.min());
             assertEquals(3, occurrence.max());
             assertEquals(Severity.ERROR, occurrence.severity());
-            
+
             // Then - Title config
             var titleConfig = literalBlock.getTitle();
             assertNotNull(titleConfig);
@@ -1507,14 +1500,14 @@ class ConfigurationLoaderTest {
             assertEquals(5, titleConfig.getMinLength());
             assertEquals(50, titleConfig.getMaxLength());
             assertEquals(Severity.INFO, titleConfig.getSeverity());
-            
+
             // Then - Lines config
             var linesConfig = literalBlock.getLines();
             assertNotNull(linesConfig);
             assertEquals(3, linesConfig.getMin());
             assertEquals(100, linesConfig.getMax());
             assertEquals(Severity.WARN, linesConfig.getSeverity());
-            
+
             // Then - Indentation config
             var indentationConfig = literalBlock.getIndentation();
             assertNotNull(indentationConfig);
@@ -1524,36 +1517,36 @@ class ConfigurationLoaderTest {
             assertEquals(8, indentationConfig.getMaxSpaces());
             assertEquals(Severity.WARN, indentationConfig.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should load LiteralBlock with minimal configuration")
         void shouldLoadLiteralBlockWithMinimalConfiguration() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - literal:
-                            severity: info
-                """;
-            
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: section
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - literal:
+                                severity: info
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var section = sections.get(0);
             assertEquals(1, section.allowedBlocks().size());
-            
+
             var literalBlock = (LiteralBlock) section.allowedBlocks().get(0);
             assertEquals(Severity.INFO, literalBlock.getSeverity());
             assertEquals(BlockType.LITERAL, literalBlock.getType());
@@ -1563,99 +1556,99 @@ class ConfigurationLoaderTest {
             assertNull(literalBlock.getLines());
             assertNull(literalBlock.getIndentation());
         }
-        
+
         @Test
         @DisplayName("should load LiteralBlock in section and subsection")
         void shouldLoadLiteralBlockInSectionAndSubsection() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: examples-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - literal:
-                            name: main-literal
-                            severity: error
-                            occurrence:
-                              min: 1
-                              max: 5
-                            title:
-                              required: true
-                              minLength: 10
-                              maxLength: 100
-                              severity: error
-                            lines:
-                              min: 5
-                              max: 200
-                            indentation:
-                              required: true
-                              consistent: true
-                              minSpaces: 4
-                              maxSpaces: 4
-                              severity: error
-                      subsections:
-                        - name: code-examples
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: examples-section
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 3
+                            min: 1
+                            max: 1
                           allowedBlocks:
                             - literal:
-                                name: code-literal
-                                severity: warn
+                                name: main-literal
+                                severity: error
                                 occurrence:
-                                  min: 0
-                                  max: 10
-                                title:
-                                  required: false
-                                  minLength: 5
-                                  maxLength: 50
-                                lines:
                                   min: 1
-                                  max: 50
-                                  severity: info
+                                  max: 5
+                                title:
+                                  required: true
+                                  minLength: 10
+                                  maxLength: 100
+                                  severity: error
+                                lines:
+                                  min: 5
+                                  max: 200
                                 indentation:
-                                  required: false
-                                  consistent: false
-                                  minSpaces: 0
-                                  maxSpaces: 12
-                """;
-            
+                                  required: true
+                                  consistent: true
+                                  minSpaces: 4
+                                  maxSpaces: 4
+                                  severity: error
+                          subsections:
+                            - name: code-examples
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 3
+                              allowedBlocks:
+                                - literal:
+                                    name: code-literal
+                                    severity: warn
+                                    occurrence:
+                                      min: 0
+                                      max: 10
+                                    title:
+                                      required: false
+                                      minLength: 5
+                                      maxLength: 50
+                                    lines:
+                                      min: 1
+                                      max: 50
+                                      severity: info
+                                    indentation:
+                                      required: false
+                                      consistent: false
+                                      minSpaces: 0
+                                      maxSpaces: 12
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level literal block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var examplesSection = sections.get(0);
             assertEquals("examples-section", examplesSection.name());
             assertEquals(1, examplesSection.allowedBlocks().size());
-            
+
             var mainLiteral = (LiteralBlock) examplesSection.allowedBlocks().get(0);
             assertEquals("main-literal", mainLiteral.getName());
             assertEquals(Severity.ERROR, mainLiteral.getSeverity());
             assertEquals(1, mainLiteral.getOccurrence().min());
             assertEquals(5, mainLiteral.getOccurrence().max());
-            
+
             // Title validation
             assertNotNull(mainLiteral.getTitle());
             assertTrue(mainLiteral.getTitle().isRequired());
             assertEquals(10, mainLiteral.getTitle().getMinLength());
             assertEquals(100, mainLiteral.getTitle().getMaxLength());
             assertEquals(Severity.ERROR, mainLiteral.getTitle().getSeverity());
-            
+
             // Lines validation
             assertNotNull(mainLiteral.getLines());
             assertEquals(5, mainLiteral.getLines().getMin());
             assertEquals(200, mainLiteral.getLines().getMax());
-            
+
             // Indentation validation
             assertNotNull(mainLiteral.getIndentation());
             assertTrue(mainLiteral.getIndentation().isRequired());
@@ -1663,19 +1656,19 @@ class ConfigurationLoaderTest {
             assertEquals(4, mainLiteral.getIndentation().getMinSpaces());
             assertEquals(4, mainLiteral.getIndentation().getMaxSpaces());
             assertEquals(Severity.ERROR, mainLiteral.getIndentation().getSeverity());
-            
+
             // Then - Subsection level literal block
             var subsections = examplesSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var codeExamplesSection = subsections.get(0);
             assertEquals("code-examples", codeExamplesSection.name());
             assertEquals(1, codeExamplesSection.allowedBlocks().size());
-            
+
             var codeLiteral = (LiteralBlock) codeExamplesSection.allowedBlocks().get(0);
             assertEquals("code-literal", codeLiteral.getName());
             assertEquals(Severity.WARN, codeLiteral.getSeverity());
-            
+
             // Subsection literal validation rules
             assertFalse(codeLiteral.getTitle().isRequired());
             assertEquals(5, codeLiteral.getTitle().getMinLength());
@@ -1686,147 +1679,147 @@ class ConfigurationLoaderTest {
             assertEquals(12, codeLiteral.getIndentation().getMaxSpaces());
         }
     }
-    
+
     @Nested
     @DisplayName("AudioBlock Loading")
     class AudioBlockTest {
-        
+
         @Test
         @DisplayName("should load AudioBlock with all configurations")
         void shouldLoadAudioBlockWithAllConfigurations() {
             // Given
             String yaml = """
-                document:
-                  metadata:
-                    attributes: []
-                  sections:
-                    - name: media-section
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - audio:
-                            name: main-audio
-                            severity: info
-                            occurrence:
-                              min: 0
-                              max: 3
-                            url:
-                              required: true
-                              pattern: "^(https?://|\\\\./|/).*\\\\.(mp3|ogg|wav|m4a)$"
-                              severity: error
-                            options:
-                              autoplay:
-                                allowed: false
-                                severity: error
-                              controls:
-                                required: true
-                                severity: error
-                              loop:
-                                allowed: true
-                                severity: info
-                            title:
-                              required: true
-                              minLength: 10
-                              maxLength: 100
-                              severity: warn
-                      subsections:
-                        - name: examples
-                          level: 2
+                    document:
+                      metadata:
+                        attributes: []
+                      sections:
+                        - name: media-section
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 2
+                            min: 1
+                            max: 1
                           allowedBlocks:
                             - audio:
-                                name: example-audio
-                                severity: warn
+                                name: main-audio
+                                severity: info
+                                occurrence:
+                                  min: 0
+                                  max: 3
                                 url:
-                                  required: false
-                                  pattern: "^https?://.*$"
+                                  required: true
+                                  pattern: "^(https?://|\\\\./|/).*\\\\.(mp3|ogg|wav|m4a)$"
+                                  severity: error
                                 options:
                                   autoplay:
-                                    allowed: true
-                                  controls:
-                                    required: false
-                                  loop:
                                     allowed: false
+                                    severity: error
+                                  controls:
+                                    required: true
+                                    severity: error
+                                  loop:
+                                    allowed: true
+                                    severity: info
                                 title:
-                                  required: false
-                                  minLength: 5
-                                  maxLength: 50
-                """;
-            
+                                  required: true
+                                  minLength: 10
+                                  maxLength: 100
+                                  severity: warn
+                          subsections:
+                            - name: examples
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 2
+                              allowedBlocks:
+                                - audio:
+                                    name: example-audio
+                                    severity: warn
+                                    url:
+                                      required: false
+                                      pattern: "^https?://.*$"
+                                    options:
+                                      autoplay:
+                                        allowed: true
+                                      controls:
+                                        required: false
+                                      loop:
+                                        allowed: false
+                                    title:
+                                      required: false
+                                      minLength: 5
+                                      maxLength: 50
+                    """;
+
             // When
             LinterConfiguration config = loader.loadConfiguration(yaml);
-            
+
             // Then - Section level audio block
             var sections = config.document().sections();
             assertEquals(1, sections.size());
-            
+
             var mediaSection = sections.get(0);
             assertEquals("media-section", mediaSection.name());
             assertEquals(1, mediaSection.allowedBlocks().size());
-            
+
             var mainAudio = (AudioBlock) mediaSection.allowedBlocks().get(0);
             assertEquals("main-audio", mainAudio.getName());
             assertEquals(Severity.INFO, mainAudio.getSeverity());
             assertEquals(0, mainAudio.getOccurrence().min());
             assertEquals(3, mainAudio.getOccurrence().max());
-            
+
             // URL validation
             assertNotNull(mainAudio.getUrl());
             assertTrue(mainAudio.getUrl().isRequired());
             assertEquals("^(https?://|\\./|/).*\\.(mp3|ogg|wav|m4a)$", mainAudio.getUrl().getPattern().pattern());
             assertEquals(Severity.ERROR, mainAudio.getUrl().getSeverity());
-            
+
             // Options validation
             assertNotNull(mainAudio.getOptions());
             assertNotNull(mainAudio.getOptions().getAutoplay());
             assertFalse(mainAudio.getOptions().getAutoplay().isAllowed());
             assertEquals(Severity.ERROR, mainAudio.getOptions().getAutoplay().getSeverity());
-            
+
             assertNotNull(mainAudio.getOptions().getControls());
             assertTrue(mainAudio.getOptions().getControls().isRequired());
             assertEquals(Severity.ERROR, mainAudio.getOptions().getControls().getSeverity());
-            
+
             assertNotNull(mainAudio.getOptions().getLoop());
             assertTrue(mainAudio.getOptions().getLoop().isAllowed());
             assertEquals(Severity.INFO, mainAudio.getOptions().getLoop().getSeverity());
-            
+
             // Title validation
             assertNotNull(mainAudio.getTitle());
             assertTrue(mainAudio.getTitle().isRequired());
             assertEquals(10, mainAudio.getTitle().getMinLength());
             assertEquals(100, mainAudio.getTitle().getMaxLength());
             assertEquals(Severity.WARN, mainAudio.getTitle().getSeverity());
-            
+
             // Then - Subsection level audio block
             var subsections = mediaSection.subsections();
             assertEquals(1, subsections.size());
-            
+
             var examplesSection = subsections.get(0);
             assertEquals("examples", examplesSection.name());
             assertEquals(1, examplesSection.allowedBlocks().size());
-            
+
             var exampleAudio = (AudioBlock) examplesSection.allowedBlocks().get(0);
             assertEquals("example-audio", exampleAudio.getName());
             assertEquals(Severity.WARN, exampleAudio.getSeverity());
-            
+
             // Subsection audio validation rules
             assertFalse(exampleAudio.getUrl().isRequired());
             assertEquals("^https?://.*$", exampleAudio.getUrl().getPattern().pattern());
             assertNull(exampleAudio.getUrl().getSeverity());
-            
+
             assertTrue(exampleAudio.getOptions().getAutoplay().isAllowed());
             assertNull(exampleAudio.getOptions().getAutoplay().getSeverity());
-            
+
             assertFalse(exampleAudio.getOptions().getControls().isRequired());
             assertNull(exampleAudio.getOptions().getControls().getSeverity());
-            
+
             assertFalse(exampleAudio.getOptions().getLoop().isAllowed());
             assertNull(exampleAudio.getOptions().getLoop().getSeverity());
-            
+
             assertFalse(exampleAudio.getTitle().isRequired());
             assertEquals(5, exampleAudio.getTitle().getMinLength());
             assertEquals(50, exampleAudio.getTitle().getMaxLength());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ExampleBlockYamlTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ExampleBlockYamlTest.java
@@ -22,87 +22,87 @@ import com.dataliquid.asciidoc.linter.config.blocks.ExampleBlock;
 
 @DisplayName("ExampleBlock YAML Loading")
 class ExampleBlockYamlTest {
-    
+
     private ConfigurationLoader loader;
-    
+
     @BeforeEach
     void setUp() {
         loader = new ConfigurationLoader(true); // Skip schema validation for tests
     }
-    
+
     @Test
     @DisplayName("should load example block with minimal configuration")
     void shouldLoadExampleBlockWithMinimalConfiguration() throws Exception {
         // Given
         String yaml = """
-            document:
-              sections:
-                - name: test-section
-                  occurrence:
-                    min: 1
-                    max: 1
-                  allowedBlocks:
-                    - example:
-                        name: minimal-example
-                        severity: warn
-            """;
-        
+                document:
+                  sections:
+                    - name: test-section
+                      occurrence:
+                        min: 1
+                        max: 1
+                      allowedBlocks:
+                        - example:
+                            name: minimal-example
+                            severity: warn
+                """;
+
         InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-        
+
         // When
         LinterConfiguration config = loader.loadConfiguration(stream);
-        
+
         // Then
         var section = config.document().sections().get(0);
         var block = section.allowedBlocks().get(0);
-        
+
         assertInstanceOf(ExampleBlock.class, block);
         ExampleBlock exampleBlock = (ExampleBlock) block;
-        
+
         assertEquals("minimal-example", exampleBlock.getName());
         assertEquals(Severity.WARN, exampleBlock.getSeverity());
         assertNull(exampleBlock.getCaption());
         assertNull(exampleBlock.getCollapsible());
     }
-    
+
     @Test
     @DisplayName("should load example block with caption configuration")
     void shouldLoadExampleBlockWithCaptionConfiguration() throws Exception {
         // Given
         String yaml = """
-            document:
-              sections:
-                - name: test-section
-                  occurrence:
-                    min: 1
-                    max: 1
-                  allowedBlocks:
-                    - example:
-                        name: example-with-caption
-                        severity: warn
-                        caption:
-                          required: true
-                          pattern: "^(Example|Beispiel)\\\\s+\\\\d+\\\\.\\\\d*:.*"
-                          minLength: 15
-                          maxLength: 100
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - name: test-section
+                      occurrence:
+                        min: 1
+                        max: 1
+                      allowedBlocks:
+                        - example:
+                            name: example-with-caption
+                            severity: warn
+                            caption:
+                              required: true
+                              pattern: "^(Example|Beispiel)\\\\s+\\\\d+\\\\.\\\\d*:.*"
+                              minLength: 15
+                              maxLength: 100
+                              severity: error
+                """;
+
         InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-        
+
         // When
         LinterConfiguration config = loader.loadConfiguration(stream);
-        
+
         // Then
         var section = config.document().sections().get(0);
         var block = section.allowedBlocks().get(0);
-        
+
         assertInstanceOf(ExampleBlock.class, block);
         ExampleBlock exampleBlock = (ExampleBlock) block;
-        
+
         assertNotNull(exampleBlock.getCaption());
         var caption = exampleBlock.getCaption();
-        
+
         assertTrue(caption.isRequired());
         assertNotNull(caption.getPattern());
         assertEquals("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*", caption.getPattern().pattern());
@@ -110,100 +110,100 @@ class ExampleBlockYamlTest {
         assertEquals(100, caption.getMaxLength());
         assertEquals(Severity.ERROR, caption.getSeverity());
     }
-    
+
     @Test
     @DisplayName("should load example block with collapsible configuration")
     void shouldLoadExampleBlockWithCollapsibleConfiguration() throws Exception {
         // Given
         String yaml = """
-            document:
-              sections:
-                - name: test-section
-                  occurrence:
-                    min: 1
-                    max: 1
-                  allowedBlocks:
-                    - example:
-                        name: example-with-collapsible
-                        severity: warn
-                        collapsible:
-                          required: false
-                          allowed: [true, false]
-                          severity: info
-            """;
-        
+                document:
+                  sections:
+                    - name: test-section
+                      occurrence:
+                        min: 1
+                        max: 1
+                      allowedBlocks:
+                        - example:
+                            name: example-with-collapsible
+                            severity: warn
+                            collapsible:
+                              required: false
+                              allowed: [true, false]
+                              severity: info
+                """;
+
         InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-        
+
         // When
         LinterConfiguration config = loader.loadConfiguration(stream);
-        
+
         // Then
         var section = config.document().sections().get(0);
         var block = section.allowedBlocks().get(0);
-        
+
         assertInstanceOf(ExampleBlock.class, block);
         ExampleBlock exampleBlock = (ExampleBlock) block;
-        
+
         assertNotNull(exampleBlock.getCollapsible());
         var collapsible = exampleBlock.getCollapsible();
-        
+
         assertFalse(collapsible.isRequired());
         assertEquals(Arrays.asList(true, false), collapsible.getAllowed());
         assertEquals(Severity.INFO, collapsible.getSeverity());
     }
-    
+
     @Test
     @DisplayName("should load example block with full configuration")
     void shouldLoadExampleBlockWithFullConfiguration() throws Exception {
         // Given
         String yaml = """
-            document:
-              sections:
-                - name: test-section
-                  occurrence:
-                    min: 1
-                    max: 1
-                  allowedBlocks:
-                    - example:
-                        name: full-example
-                        severity: warn
-                        occurrence:
-                          min: 0
-                          max: 10
-                        caption:
-                          required: true
-                          pattern: "^Example \\\\d+:.*"
-                          minLength: 10
-                          maxLength: 50
-                          severity: error
-                        collapsible:
-                          required: false
-                          allowed: [true, false]
-                          severity: info
-            """;
-        
+                document:
+                  sections:
+                    - name: test-section
+                      occurrence:
+                        min: 1
+                        max: 1
+                      allowedBlocks:
+                        - example:
+                            name: full-example
+                            severity: warn
+                            occurrence:
+                              min: 0
+                              max: 10
+                            caption:
+                              required: true
+                              pattern: "^Example \\\\d+:.*"
+                              minLength: 10
+                              maxLength: 50
+                              severity: error
+                            collapsible:
+                              required: false
+                              allowed: [true, false]
+                              severity: info
+                """;
+
         InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-        
+
         // When
         LinterConfiguration config = loader.loadConfiguration(stream);
-        
+
         // Then
         var section = config.document().sections().get(0);
         var block = section.allowedBlocks().get(0);
-        
+
         assertInstanceOf(ExampleBlock.class, block);
         ExampleBlock exampleBlock = (ExampleBlock) block;
-        
+
         assertEquals("full-example", exampleBlock.getName());
         assertEquals(Severity.WARN, exampleBlock.getSeverity());
-        
+
         assertNotNull(exampleBlock.getOccurrence());
         assertEquals(0, exampleBlock.getOccurrence().min());
         assertEquals(10, exampleBlock.getOccurrence().max());
-        
+
         assertNotNull(exampleBlock.getCaption());
         assertTrue(exampleBlock.getCaption().isRequired());
-        
+
         assertNotNull(exampleBlock.getCollapsible());
         assertFalse(exampleBlock.getCollapsible().isRequired());
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/loader/QuoteBlockYamlTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/loader/QuoteBlockYamlTest.java
@@ -22,14 +22,14 @@ import com.dataliquid.asciidoc.linter.config.blocks.QuoteBlock;
 
 @DisplayName("QuoteBlock YAML Loading Tests")
 class QuoteBlockYamlTest {
-    
+
     private ConfigurationLoader loader;
-    
+
     @BeforeEach
     void setUp() {
         loader = new ConfigurationLoader(true); // Skip schema validation for tests
     }
-    
+
     @Test
     @DisplayName("should load quote block from YAML with all configurations")
     void shouldLoadQuoteBlockFromYaml() throws Exception {
@@ -70,33 +70,33 @@ class QuoteBlockYamlTest {
                                 max: 20
                                 severity: info
                 """;
-        
+
         InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
         LinterConfiguration config = loader.loadConfiguration(stream);
-        
+
         assertNotNull(config);
         assertNotNull(config.document());
         assertNotNull(config.document().sections());
         assertEquals(1, config.document().sections().size());
-        
+
         var section = config.document().sections().get(0);
         assertNotNull(section.allowedBlocks());
         assertEquals(1, section.allowedBlocks().size());
-        
+
         var block = section.allowedBlocks().get(0);
         assertInstanceOf(QuoteBlock.class, block);
-        
+
         QuoteBlock quoteBlock = (QuoteBlock) block;
         assertEquals("important-quote", quoteBlock.getName());
         assertEquals(Severity.INFO, quoteBlock.getSeverity());
         assertEquals(BlockType.QUOTE, quoteBlock.getType());
-        
+
         // Verify occurrence
         assertNotNull(quoteBlock.getOccurrence());
         assertEquals(0, quoteBlock.getOccurrence().min());
         assertEquals(3, quoteBlock.getOccurrence().max());
         assertEquals(Severity.WARN, quoteBlock.getOccurrence().severity());
-        
+
         // Verify attribution config
         assertNotNull(quoteBlock.getAttribution());
         assertTrue(quoteBlock.getAttribution().isRequired());
@@ -104,7 +104,7 @@ class QuoteBlockYamlTest {
         assertEquals(100, quoteBlock.getAttribution().getMaxLength());
         assertEquals("^[A-Z][a-zA-Z\\s\\.\\-,]+$", quoteBlock.getAttribution().getPattern().pattern());
         assertEquals(Severity.ERROR, quoteBlock.getAttribution().getSeverity());
-        
+
         // Verify citation config
         assertNotNull(quoteBlock.getCitation());
         assertFalse(quoteBlock.getCitation().isRequired());
@@ -112,20 +112,20 @@ class QuoteBlockYamlTest {
         assertEquals(200, quoteBlock.getCitation().getMaxLength());
         assertEquals("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$", quoteBlock.getCitation().getPattern().pattern());
         assertEquals(Severity.WARN, quoteBlock.getCitation().getSeverity());
-        
+
         // Verify content config
         assertNotNull(quoteBlock.getContent());
         assertTrue(quoteBlock.getContent().isRequired());
         assertEquals(20, quoteBlock.getContent().getMinLength());
         assertEquals(1000, quoteBlock.getContent().getMaxLength());
-        
+
         // Verify lines config
         assertNotNull(quoteBlock.getContent().getLines());
         assertEquals(1, quoteBlock.getContent().getLines().getMin());
         assertEquals(20, quoteBlock.getContent().getLines().getMax());
         assertEquals(Severity.INFO, quoteBlock.getContent().getLines().getSeverity());
     }
-    
+
     @Test
     @DisplayName("should load quote block with minimal configuration")
     void shouldLoadQuoteBlockWithMinimalConfig() throws Exception {
@@ -141,13 +141,13 @@ class QuoteBlockYamlTest {
                         - quote:
                             severity: info
                 """;
-        
+
         InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
         LinterConfiguration config = loader.loadConfiguration(stream);
-        
+
         var block = config.document().sections().get(0).allowedBlocks().get(0);
         assertInstanceOf(QuoteBlock.class, block);
-        
+
         QuoteBlock quoteBlock = (QuoteBlock) block;
         assertEquals(Severity.INFO, quoteBlock.getSeverity());
         assertNull(quoteBlock.getName());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/loader/SidebarBlockYamlTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/loader/SidebarBlockYamlTest.java
@@ -24,75 +24,75 @@ import com.dataliquid.asciidoc.linter.config.rule.SectionConfig;
  */
 @DisplayName("SidebarBlock YAML parsing")
 class SidebarBlockYamlTest {
-    
+
     @Test
     @DisplayName("should parse sidebar block with all configurations")
     void shouldParseSidebarBlockWithAllConfigurations() throws Exception {
         // Given
         String yaml = """
-            document:
-              sections:
-                - level: 1
-                  title:
-                    pattern: "Introduction"
-                  allowedBlocks:
-                    - sidebar:
-                        name: "additional-info"
-                        severity: info
-                        occurrence:
-                          min: 0
-                          max: 2
-                          severity: warn
-                        title:
-                          required: false
-                          minLength: 5
-                          maxLength: 50
-                          pattern: "^[A-Z].*$"
-                          severity: info
-                        content:
-                          required: true
-                          minLength: 50
-                          maxLength: 800
-                          lines:
-                            min: 3
-                            max: 30
+                document:
+                  sections:
+                    - level: 1
+                      title:
+                        pattern: "Introduction"
+                      allowedBlocks:
+                        - sidebar:
+                            name: "additional-info"
                             severity: info
-                        position:
-                          required: false
-                          allowed: ["left", "right", "float"]
-                          severity: info
-            """;
-        
+                            occurrence:
+                              min: 0
+                              max: 2
+                              severity: warn
+                            title:
+                              required: false
+                              minLength: 5
+                              maxLength: 50
+                              pattern: "^[A-Z].*$"
+                              severity: info
+                            content:
+                              required: true
+                              minLength: 50
+                              maxLength: 800
+                              lines:
+                                min: 3
+                                max: 30
+                                severity: info
+                            position:
+                              required: false
+                              allowed: ["left", "right", "float"]
+                              severity: info
+                """;
+
         ConfigurationLoader loader = new ConfigurationLoader(true); // Skip schema validation
-        
+
         // When
         LinterConfiguration config = loader.loadConfiguration(yaml);
-        
+
         // Then
         assertNotNull(config);
         assertNotNull(config.document());
-        
+
         DocumentConfiguration doc = config.document();
         assertNotNull(doc.sections());
         assertEquals(1, doc.sections().size());
-        
+
         SectionConfig section = doc.sections().get(0);
         assertNotNull(section.allowedBlocks());
         assertEquals(1, section.allowedBlocks().size());
-        
+
         Block block = section.allowedBlocks().get(0);
         assertInstanceOf(SidebarBlock.class, block);
-        
+
         SidebarBlock sidebar = (SidebarBlock) block;
         assertEquals("additional-info", sidebar.getName());
         assertEquals(Severity.INFO, sidebar.getSeverity());
-        
+
         // Validate occurrence
         assertNotNull(sidebar.getOccurrence());
         assertEquals(0, sidebar.getOccurrence().min());
         assertEquals(2, sidebar.getOccurrence().max());
         assertEquals(Severity.WARN, sidebar.getOccurrence().severity());
-        
+
         // Validate title config
         assertNotNull(sidebar.getTitle());
         assertFalse(sidebar.getTitle().isRequired());
@@ -100,51 +100,51 @@ class SidebarBlockYamlTest {
         assertEquals(50, sidebar.getTitle().getMaxLength());
         assertEquals("^[A-Z].*$", sidebar.getTitle().getPattern().pattern());
         assertEquals(Severity.INFO, sidebar.getTitle().getSeverity());
-        
+
         // Validate content config
         assertNotNull(sidebar.getContent());
         assertTrue(sidebar.getContent().isRequired());
         assertEquals(50, sidebar.getContent().getMinLength());
         assertEquals(800, sidebar.getContent().getMaxLength());
-        
+
         // Validate lines config
         assertNotNull(sidebar.getContent().getLines());
         assertEquals(3, sidebar.getContent().getLines().getMin());
         assertEquals(30, sidebar.getContent().getLines().getMax());
         assertEquals(Severity.INFO, sidebar.getContent().getLines().getSeverity());
-        
+
         // Validate position config
         assertNotNull(sidebar.getPosition());
         assertFalse(sidebar.getPosition().isRequired());
         assertEquals(List.of("left", "right", "float"), sidebar.getPosition().getAllowed());
         assertEquals(Severity.INFO, sidebar.getPosition().getSeverity());
     }
-    
+
     @Test
     @DisplayName("should parse sidebar block with minimal configuration")
     void shouldParseSidebarBlockWithMinimalConfiguration() throws Exception {
         // Given
         String yaml = """
-            document:
-              sections:
-                - level: 1
-                  title:
-                    pattern: "Section"
-                  allowedBlocks:
-                    - sidebar:
-                        name: "simple-sidebar"
-                        severity: warn
-            """;
-        
+                document:
+                  sections:
+                    - level: 1
+                      title:
+                        pattern: "Section"
+                      allowedBlocks:
+                        - sidebar:
+                            name: "simple-sidebar"
+                            severity: warn
+                """;
+
         ConfigurationLoader loader = new ConfigurationLoader(true);
-        
+
         // When
         LinterConfiguration config = loader.loadConfiguration(yaml);
-        
+
         // Then
         Block block = config.document().sections().get(0).allowedBlocks().get(0);
         assertInstanceOf(SidebarBlock.class, block);
-        
+
         SidebarBlock sidebar = (SidebarBlock) block;
         assertEquals("simple-sidebar", sidebar.getName());
         assertEquals(Severity.WARN, sidebar.getSeverity());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationLoaderTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationLoaderTest.java
@@ -24,43 +24,43 @@ import org.junit.jupiter.api.io.TempDir;
  */
 @DisplayName("OutputConfigurationLoader Tests")
 class OutputConfigurationLoaderTest {
-    
+
     private OutputConfigurationLoader loader;
     private OutputConfigurationLoader loaderWithoutValidation;
-    
+
     @BeforeEach
     void setUp() {
         loader = new OutputConfigurationLoader();
         loaderWithoutValidation = new OutputConfigurationLoader(true);
     }
-    
+
     @Nested
     @DisplayName("File Loading Tests")
     class FileLoadingTests {
-        
+
         @TempDir
         Path tempDir;
-        
+
         @Test
         @DisplayName("should load valid configuration from file")
         void shouldLoadValidConfigurationFromFile() throws IOException {
             // Given
             String yaml = """
-                output:
-                  format: enhanced
-                  display:
-                    useColors: true
-                    contextLines: 3
-                    showLineNumbers: true
-                    highlightStyle: underline
-                """;
-            
+                    output:
+                      format: enhanced
+                      display:
+                        useColors: true
+                        contextLines: 3
+                        showLineNumbers: true
+                        highlightStyle: underline
+                    """;
+
             Path configFile = tempDir.resolve("output.yaml");
             Files.writeString(configFile, yaml);
-            
+
             // When
             OutputConfiguration config = loaderWithoutValidation.loadConfiguration(configFile.toString());
-            
+
             // Then
             assertEquals(OutputFormat.ENHANCED, config.getFormat());
             assertTrue(config.getDisplay().isUseColors());
@@ -68,17 +68,15 @@ class OutputConfigurationLoaderTest {
             assertTrue(config.getDisplay().isShowLineNumbers());
             assertEquals(HighlightStyle.UNDERLINE, config.getDisplay().getHighlightStyle());
         }
-        
+
         @Test
         @DisplayName("should throw exception for non-existent file")
         void shouldThrowExceptionForNonExistentFile() {
             // When/Then
-            assertThrows(IOException.class, () -> 
-                loader.loadConfiguration("/non/existent/file.yaml")
-            );
+            assertThrows(IOException.class, () -> loader.loadConfiguration("/non/existent/file.yaml"));
         }
     }
-    
+
     @Nested
     @DisplayName("Stream Loading Tests")
     class StreamLoadingTests {
@@ -87,44 +85,44 @@ class OutputConfigurationLoaderTest {
         void shouldLoadMinimalConfiguration() throws IOException {
             // Given
             String yaml = """
-                output:
-                  format: simple
-                """;
-            
+                    output:
+                      format: simple
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When
             OutputConfiguration config = loaderWithoutValidation.loadConfiguration(input);
-            
+
             // Then
             assertEquals(OutputFormat.SIMPLE, config.getFormat());
             assertNotNull(config.getDisplay());
             assertNotNull(config.getErrorGrouping());
             assertNotNull(config.getSummary());
         }
-        
+
         @Test
         @DisplayName("should load compact configuration")
         void shouldLoadCompactConfiguration() throws IOException {
             // Given
             String yaml = """
-                output:
-                  format: compact
-                  display:
-                    useColors: false
-                    contextLines: 0
-                    highlightStyle: none
-                  errorGrouping:
-                    enabled: false
-                  summary:
-                    enabled: false
-                """;
-            
+                    output:
+                      format: compact
+                      display:
+                        useColors: false
+                        contextLines: 0
+                        highlightStyle: none
+                      errorGrouping:
+                        enabled: false
+                      summary:
+                        enabled: false
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When
             OutputConfiguration config = loaderWithoutValidation.loadConfiguration(input);
-            
+
             // Then
             assertEquals(OutputFormat.COMPACT, config.getFormat());
             assertFalse(config.getDisplay().isUseColors());
@@ -134,85 +132,79 @@ class OutputConfigurationLoaderTest {
             assertFalse(config.getSummary().isEnabled());
         }
     }
-    
+
     @Nested
     @DisplayName("Predefined Configuration Tests")
     class PredefinedConfigurationTests {
-        
+
         @Test
         @DisplayName("should load predefined enhanced configuration")
         void shouldLoadPredefinedEnhancedConfiguration() throws IOException {
             // When
             OutputConfiguration config = loader.loadPredefinedConfiguration(OutputFormat.ENHANCED);
-            
+
             // Then
             assertEquals(OutputFormat.ENHANCED, config.getFormat());
             assertTrue(config.getDisplay().isUseColors());
             assertTrue(config.getDisplay().isShowLineNumbers());
             assertTrue(config.getSummary().isEnabled());
         }
-        
+
         @Test
         @DisplayName("should load predefined simple configuration")
         void shouldLoadPredefinedSimpleConfiguration() throws IOException {
             // When
             OutputConfiguration config = loader.loadPredefinedConfiguration(OutputFormat.SIMPLE);
-            
+
             // Then
             assertEquals(OutputFormat.SIMPLE, config.getFormat());
             assertTrue(config.getDisplay().isUseColors());
             assertTrue(config.getDisplay().isShowLineNumbers());
             assertTrue(config.getSummary().isEnabled());
         }
-        
+
         @Test
         @DisplayName("should load predefined compact configuration")
         void shouldLoadPredefinedCompactConfiguration() throws IOException {
             // When
             OutputConfiguration config = loader.loadPredefinedConfiguration(OutputFormat.COMPACT);
-            
+
             // Then
             assertEquals(OutputFormat.COMPACT, config.getFormat());
             assertFalse(config.getDisplay().isUseColors());
             assertFalse(config.getDisplay().isShowLineNumbers());
             assertFalse(config.getSummary().isEnabled());
         }
-        
+
         @Test
         @DisplayName("should throw exception for non-existent predefined configuration")
         void shouldThrowExceptionForNonExistentPredefinedConfiguration() {
             // When/Then
             // Test with an invalid format string using reflection or a non-enum value
-            assertThrows(IllegalArgumentException.class, () ->
-                OutputFormat.fromValue("non-existent")
-            );
+            assertThrows(IllegalArgumentException.class, () -> OutputFormat.fromValue("non-existent"));
         }
     }
-    
-    
+
     @Nested
     @DisplayName("Validation Tests")
     class ValidationTests {
-        
-        
+
         @Test
         @DisplayName("should fail validation for invalid context lines")
         void shouldFailValidationForInvalidContextLines() {
             // Given
             String yaml = """
-                output:
-                  format: enhanced
-                  display:
-                    contextLines: 20
-                """;
-            
+                    output:
+                      format: enhanced
+                      display:
+                        contextLines: 20
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When/Then
-            assertThrows(OutputConfigurationException.class, () ->
-                loader.loadConfiguration(input)
-            );
+            assertThrows(OutputConfigurationException.class, () -> loader.loadConfiguration(input));
         }
-        
+
     }
 }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/rule/OrderConfigTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/rule/OrderConfigTest.java
@@ -16,106 +16,92 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("OrderConfig")
 class OrderConfigTest {
-    
+
     @Nested
     @DisplayName("builder")
     class Builder {
-        
+
         @Test
         @DisplayName("should build with fixed order")
         void shouldBuildWithFixedOrder() {
             // Given
             List<String> fixedOrder = Arrays.asList("intro", "body", "conclusion");
-            
+
             // When
-            OrderConfig config = OrderConfig.builder()
-                .fixedOrder(fixedOrder)
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig config = OrderConfig.builder().fixedOrder(fixedOrder).severity(Severity.ERROR).build();
+
             // Then
             assertEquals(fixedOrder, config.fixedOrder());
             assertEquals(Severity.ERROR, config.severity());
         }
-        
+
         @Test
         @DisplayName("should build with empty lists by default")
         void shouldBuildWithEmptyListsByDefault() {
             // Given/When
-            OrderConfig config = OrderConfig.builder()
-                .severity(Severity.WARN)
-                .build();
-            
+            OrderConfig config = OrderConfig.builder().severity(Severity.WARN).build();
+
             // Then
             assertTrue(config.fixedOrder().isEmpty());
             assertTrue(config.before().isEmpty());
             assertTrue(config.after().isEmpty());
             assertEquals(Severity.WARN, config.severity());
         }
-        
+
         @Test
         @DisplayName("should add individual fixed order items")
         void shouldAddIndividualFixedOrderItems() {
             // Given/When
-            OrderConfig config = OrderConfig.builder()
-                .addFixedOrder("first")
-                .addFixedOrder("second")
-                .addFixedOrder("third")
-                .severity(Severity.INFO)
-                .build();
-            
+            OrderConfig config = OrderConfig.builder().addFixedOrder("first").addFixedOrder("second")
+                    .addFixedOrder("third").severity(Severity.INFO).build();
+
             // Then
             assertEquals(Arrays.asList("first", "second", "third"), config.fixedOrder());
         }
-        
+
         @Test
         @DisplayName("should add before constraints")
         void shouldAddBeforeConstraints() {
             // Given/When
-            OrderConfig config = OrderConfig.builder()
-                .addBefore("intro", "body", Severity.ERROR)
-                .addBefore("body", "conclusion", Severity.WARN)
-                .severity(Severity.INFO)
-                .build();
-            
+            OrderConfig config = OrderConfig.builder().addBefore("intro", "body", Severity.ERROR)
+                    .addBefore("body", "conclusion", Severity.WARN).severity(Severity.INFO).build();
+
             // Then
             assertEquals(2, config.before().size());
             assertEquals("intro", config.before().get(0).first());
             assertEquals("body", config.before().get(0).second());
             assertEquals(Severity.ERROR, config.before().get(0).severity());
         }
-        
+
         @Test
         @DisplayName("should add after constraints")
         void shouldAddAfterConstraints() {
             // Given/When
-            OrderConfig config = OrderConfig.builder()
-                .addAfter("conclusion", "body", Severity.ERROR)
-                .severity(Severity.INFO)
-                .build();
-            
+            OrderConfig config = OrderConfig.builder().addAfter("conclusion", "body", Severity.ERROR)
+                    .severity(Severity.INFO).build();
+
             // Then
             assertEquals(1, config.after().size());
             assertEquals("conclusion", config.after().get(0).first());
             assertEquals("body", config.after().get(0).second());
             assertEquals(Severity.ERROR, config.after().get(0).severity());
         }
-        
+
         @Test
         @DisplayName("should default to ERROR severity")
         void shouldDefaultToErrorSeverity() {
             // Given/When
             OrderConfig config = OrderConfig.builder().build();
-            
+
             // Then
             assertEquals(Severity.ERROR, config.severity());
         }
     }
-    
+
     @Nested
     @DisplayName("OrderConstraint")
     class OrderConstraintTest {
-        
+
         @Test
         @DisplayName("should create constraint with required fields")
         void shouldCreateConstraintWithRequiredFields() {
@@ -123,17 +109,16 @@ class OrderConfigTest {
             String first = "intro";
             String second = "body";
             Severity severity = Severity.ERROR;
-            
+
             // When
-            OrderConfig.OrderConstraint constraint = 
-                OrderConfig.OrderConstraint.of(first, second, severity);
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(first, second, severity);
+
             // Then
             assertEquals(first, constraint.first());
             assertEquals(second, constraint.second());
             assertEquals(severity, constraint.severity());
         }
-        
+
         @Test
         @DisplayName("should require non-null first")
         void shouldRequireNonNullFirst() {
@@ -141,12 +126,11 @@ class OrderConfigTest {
             String first = null;
             String second = "body";
             Severity severity = Severity.ERROR;
-            
+
             // When/Then
-            assertThrows(NullPointerException.class,
-                () -> OrderConfig.OrderConstraint.of(first, second, severity));
+            assertThrows(NullPointerException.class, () -> OrderConfig.OrderConstraint.of(first, second, severity));
         }
-        
+
         @Test
         @DisplayName("should require non-null second")
         void shouldRequireNonNullSecond() {
@@ -154,12 +138,11 @@ class OrderConfigTest {
             String first = "intro";
             String second = null;
             Severity severity = Severity.ERROR;
-            
+
             // When/Then
-            assertThrows(NullPointerException.class,
-                () -> OrderConfig.OrderConstraint.of(first, second, severity));
+            assertThrows(NullPointerException.class, () -> OrderConfig.OrderConstraint.of(first, second, severity));
         }
-        
+
         @Test
         @DisplayName("should require non-null severity")
         void shouldRequireNonNullSeverity() {
@@ -167,65 +150,50 @@ class OrderConfigTest {
             String first = "intro";
             String second = "body";
             Severity severity = null;
-            
+
             // When/Then
-            assertThrows(NullPointerException.class,
-                () -> OrderConfig.OrderConstraint.of(first, second, severity));
+            assertThrows(NullPointerException.class, () -> OrderConfig.OrderConstraint.of(first, second, severity));
         }
     }
-    
+
     @Nested
     @DisplayName("equals and hashCode")
     class EqualsAndHashCode {
-        
+
         @Test
         @DisplayName("should be equal for same values")
         void shouldBeEqualForSameValues() {
             // Given
-            OrderConfig config1 = OrderConfig.builder()
-                .addFixedOrder("intro")
-                .addBefore("intro", "body", Severity.ERROR)
-                .severity(Severity.WARN)
-                .build();
-                
-            OrderConfig config2 = OrderConfig.builder()
-                .addFixedOrder("intro")
-                .addBefore("intro", "body", Severity.ERROR)
-                .severity(Severity.WARN)
-                .build();
-            
+            OrderConfig config1 = OrderConfig.builder().addFixedOrder("intro")
+                    .addBefore("intro", "body", Severity.ERROR).severity(Severity.WARN).build();
+
+            OrderConfig config2 = OrderConfig.builder().addFixedOrder("intro")
+                    .addBefore("intro", "body", Severity.ERROR).severity(Severity.WARN).build();
+
             // When/Then
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should not be equal for different fixed order")
         void shouldNotBeEqualForDifferentFixedOrder() {
             // Given
-            OrderConfig config1 = OrderConfig.builder()
-                .addFixedOrder("intro")
-                .severity(Severity.ERROR)
-                .build();
-                
-            OrderConfig config2 = OrderConfig.builder()
-                .addFixedOrder("body")
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig config1 = OrderConfig.builder().addFixedOrder("intro").severity(Severity.ERROR).build();
+
+            OrderConfig config2 = OrderConfig.builder().addFixedOrder("body").severity(Severity.ERROR).build();
+
             // When/Then
             assertNotEquals(config1, config2);
         }
-        
+
         @Test
         @DisplayName("should be equal for constraint with same values")
         void shouldBeEqualForConstraintWithSameValues() {
             // Given
-            OrderConfig.OrderConstraint constraint1 = 
-                OrderConfig.OrderConstraint.of("intro", "body", Severity.ERROR);
-            OrderConfig.OrderConstraint constraint2 = 
-                OrderConfig.OrderConstraint.of("intro", "body", Severity.ERROR);
-            
+            OrderConfig.OrderConstraint constraint1 = OrderConfig.OrderConstraint.of("intro", "body", Severity.ERROR);
+            OrderConfig.OrderConstraint constraint2 = OrderConfig.OrderConstraint.of("intro", "body", Severity.ERROR);
+
             // When/Then
             assertEquals(constraint1, constraint2);
             assertEquals(constraint1.hashCode(), constraint2.hashCode());

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/validation/ComprehensiveSchemaValidationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/validation/ComprehensiveSchemaValidationTest.java
@@ -20,461 +20,461 @@ import com.dataliquid.asciidoc.linter.config.loader.ConfigurationException;
 import com.dataliquid.asciidoc.linter.config.loader.ConfigurationLoader;
 
 /**
- * Comprehensive schema validation tests for all block types.
- * These tests ensure that schema validation is working correctly and catching errors.
- * 
- * IMPORTANT: This test class uses ConfigurationLoader() with schema validation ENABLED.
- * This is different from most other test classes which skip validation for performance.
+ * Comprehensive schema validation tests for all block types. These tests ensure that schema validation is working
+ * correctly and catching errors.
+ *
+ * IMPORTANT: This test class uses ConfigurationLoader() with schema validation ENABLED. This is different from most
+ * other test classes which skip validation for performance.
  */
 @DisplayName("Comprehensive Schema Validation Tests")
 class ComprehensiveSchemaValidationTest {
-    
+
     private ConfigurationLoader loader;
-    
+
     @BeforeEach
     void setUp() {
         // IMPORTANT: Schema validation is ENABLED (not using ConfigurationLoader(true))
         loader = new ConfigurationLoader();
     }
-    
+
     @Nested
     @DisplayName("All Block Types Validation")
     class AllBlockTypesValidation {
-        
+
         @Test
         @DisplayName("should validate configuration with all block types")
         void shouldValidateConfigurationWithAllBlockTypes() throws IOException {
             // Given - configuration with all supported block types
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: error
-                  sections:
-                    - name: "comprehensive"
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - paragraph:
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
                             severity: error
-                            occurrence:
-                              min: 0
-                              max: 10
-                        - listing:
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 5
-                            language:
-                              required: true
-                              allowed: ["java", "python"]
-                        - table:
-                            severity: info
-                            occurrence:
-                              min: 0
-                              max: 3
-                            columns:
-                              min: 2
-                              max: 10
-                        - image:
-                            severity: error
-                            occurrence:
-                              min: 0
-                              max: 5
-                            url:
-                              required: true
-                              pattern: ".*\\\\.(jpg|png|gif)$"
-                        - verse:
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 2
-                            author:
-                              required: false
-                        - admonition:
-                            severity: info
-                            occurrence:
-                              min: 0
-                              max: 10
-                            type:
-                              required: true
-                              allowed: ["NOTE", "TIP", "WARNING"]
-                        - pass:
-                            severity: error
-                            occurrence:
-                              min: 0
-                              max: 1
-                            type:
-                              required: true
-                              allowed: ["html", "xml"]
-                        - literal:
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 5
-                            lines:
-                              min: 1
-                              max: 100
-                        - quote:
-                            severity: info
-                            occurrence:
-                              min: 0
-                              max: 3
-                            attribution:
-                              required: false
-                        - sidebar:
-                            severity: error
-                            occurrence:
-                              min: 0
-                              max: 2
-                            title:
-                              required: false
-                        - example:
-                            severity: warn
-                            occurrence:
-                              min: 0
-                              max: 5
-                            caption:
-                              required: false
-                        - audio:
-                            severity: info
-                            occurrence:
-                              min: 0
-                              max: 3
-                            url:
-                              required: true
-                        - video:
-                            severity: error
-                            occurrence:
-                              min: 0
-                              max: 3
-                            url:
-                              required: true
-                """;
-            
+                      sections:
+                        - name: "comprehensive"
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 0
+                                  max: 10
+                            - listing:
+                                severity: warn
+                                occurrence:
+                                  min: 0
+                                  max: 5
+                                language:
+                                  required: true
+                                  allowed: ["java", "python"]
+                            - table:
+                                severity: info
+                                occurrence:
+                                  min: 0
+                                  max: 3
+                                columns:
+                                  min: 2
+                                  max: 10
+                            - image:
+                                severity: error
+                                occurrence:
+                                  min: 0
+                                  max: 5
+                                url:
+                                  required: true
+                                  pattern: ".*\\\\.(jpg|png|gif)$"
+                            - verse:
+                                severity: warn
+                                occurrence:
+                                  min: 0
+                                  max: 2
+                                author:
+                                  required: false
+                            - admonition:
+                                severity: info
+                                occurrence:
+                                  min: 0
+                                  max: 10
+                                type:
+                                  required: true
+                                  allowed: ["NOTE", "TIP", "WARNING"]
+                            - pass:
+                                severity: error
+                                occurrence:
+                                  min: 0
+                                  max: 1
+                                type:
+                                  required: true
+                                  allowed: ["html", "xml"]
+                            - literal:
+                                severity: warn
+                                occurrence:
+                                  min: 0
+                                  max: 5
+                                lines:
+                                  min: 1
+                                  max: 100
+                            - quote:
+                                severity: info
+                                occurrence:
+                                  min: 0
+                                  max: 3
+                                attribution:
+                                  required: false
+                            - sidebar:
+                                severity: error
+                                occurrence:
+                                  min: 0
+                                  max: 2
+                                title:
+                                  required: false
+                            - example:
+                                severity: warn
+                                occurrence:
+                                  min: 0
+                                  max: 5
+                                caption:
+                                  required: false
+                            - audio:
+                                severity: info
+                                occurrence:
+                                  min: 0
+                                  max: 3
+                                url:
+                                  required: true
+                            - video:
+                                severity: error
+                                occurrence:
+                                  min: 0
+                                  max: 3
+                                url:
+                                  required: true
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then - should load without schema validation errors
             LinterConfiguration config = assertDoesNotThrow(() -> loader.loadConfiguration(input));
-            
+
             // Verify configuration loaded correctly
             assertNotNull(config);
             assertNotNull(config.document());
             assertNotNull(config.document().sections());
             assertTrue(config.document().sections().size() > 0);
         }
-        
+
         @Test
         @DisplayName("should detect invalid block type in schema")
         void shouldDetectInvalidBlockType() {
             // Given - configuration with invalid block type
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - invalid_block_type:
-                            severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - invalid_block_type:
+                                severity: error
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then - should throw exception for invalid block type
             assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(input));
         }
-        
+
         @Test
         @DisplayName("should detect missing required severity in block")
         void shouldDetectMissingRequiredSeverity() {
             // Given - paragraph block without required severity
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - paragraph:
-                            occurrence:
-                              min: 1
-                              max: 5
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - paragraph:
+                                occurrence:
+                                  min: 1
+                                  max: 5
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then - should throw exception for missing severity
             assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(input));
         }
     }
-    
+
     @Nested
     @DisplayName("Individual Block Type Schema Validation")
     class IndividualBlockTypeValidation {
-        
+
         @Test
         @DisplayName("should validate paragraph block schema")
         void shouldValidateParagraphBlockSchema() throws IOException {
             // Given
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            lines:
-                              min: 1
-                              max: 50
-                            sentence:
-                              occurrence:
-                                min: 1
-                                max: 10
-                              words:
-                                min: 5
-                                max: 30
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                lines:
+                                  min: 1
+                                  max: 50
+                                sentence:
+                                  occurrence:
+                                    min: 1
+                                    max: 10
+                                  words:
+                                    min: 5
+                                    max: 30
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertDoesNotThrow(() -> loader.loadConfiguration(input));
         }
-        
+
         @Test
         @DisplayName("should validate listing block schema")
         void shouldValidateListingBlockSchema() throws IOException {
             // Given
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - listing:
-                            severity: warn
-                            language:
-                              required: true
-                              allowed: ["java", "python", "javascript"]
-                            title:
-                              required: false
-                              pattern: "^Listing \\\\d+:.*"
-                            callouts:
-                              allowed: true
-                              max: 20
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - listing:
+                                severity: warn
+                                language:
+                                  required: true
+                                  allowed: ["java", "python", "javascript"]
+                                title:
+                                  required: false
+                                  pattern: "^Listing \\\\d+:.*"
+                                callouts:
+                                  allowed: true
+                                  max: 20
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertDoesNotThrow(() -> loader.loadConfiguration(input));
         }
-        
+
         @Test
         @DisplayName("should validate admonition block schema")
         void shouldValidateAdmonitionBlockSchema() throws IOException {
             // Given
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - admonition:
-                            severity: info
-                            type:
-                              required: true
-                              allowed: ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]
-                            title:
-                              required: true
-                              minLength: 3
-                              maxLength: 50
-                            icon:
-                              required: true
-                              pattern: "^(info|warning|caution|tip|note)$"
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - admonition:
+                                severity: info
+                                type:
+                                  required: true
+                                  allowed: ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"]
+                                title:
+                                  required: true
+                                  minLength: 3
+                                  maxLength: 50
+                                icon:
+                                  required: true
+                                  pattern: "^(info|warning|caution|tip|note)$"
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertDoesNotThrow(() -> loader.loadConfiguration(input));
         }
-        
+
         @Test
         @DisplayName("should validate video block schema")
         void shouldValidateVideoBlockSchema() throws IOException {
             // Given
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - video:
-                            severity: error
-                            url:
-                              required: true
-                              pattern: ".*\\\\.(mp4|webm|ogg)$"
-                            width:
-                              required: false
-                              minValue: 100
-                              maxValue: 1920
-                            height:
-                              required: false
-                              minValue: 100
-                              maxValue: 1080
-                            poster:
-                              required: false
-                              pattern: ".*\\\\.(jpg|jpeg|png)$"
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - video:
+                                severity: error
+                                url:
+                                  required: true
+                                  pattern: ".*\\\\.(mp4|webm|ogg)$"
+                                width:
+                                  required: false
+                                  minValue: 100
+                                  maxValue: 1920
+                                height:
+                                  required: false
+                                  minValue: 100
+                                  maxValue: 1080
+                                poster:
+                                  required: false
+                                  pattern: ".*\\\\.(jpg|jpeg|png)$"
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertDoesNotThrow(() -> loader.loadConfiguration(input));
         }
     }
-    
+
     @Nested
     @DisplayName("Schema Error Detection")
     class SchemaErrorDetection {
-        
+
         @Test
         @DisplayName("should detect invalid enum value for severity")
         void shouldDetectInvalidEnumValueForSeverity() {
             // Given - invalid severity value
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - paragraph:
-                            severity: critical  # Invalid - should be error, warn, or info
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - paragraph:
+                                severity: critical  # Invalid - should be error, warn, or info
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(input));
         }
-        
+
         @Test
         @DisplayName("should detect invalid property in block configuration")
         void shouldDetectInvalidPropertyInBlockConfiguration() {
             // Given - invalid property for paragraph block
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            invalidProperty: true  # This property doesn't exist in schema
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                invalidProperty: true  # This property doesn't exist in schema
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(input));
         }
-        
+
         @Test
         @DisplayName("should detect type mismatch in configuration")
         void shouldDetectTypeMismatchInConfiguration() {
             // Given - string instead of integer
             String yaml = """
-                document:
-                  sections:
-                    - name: "test"
-                      allowedBlocks:
-                        - table:
-                            severity: error
-                            columns:
-                              min: "two"  # Should be integer, not string
-                              max: 10
-                """;
-            
+                    document:
+                      sections:
+                        - name: "test"
+                          allowedBlocks:
+                            - table:
+                                severity: error
+                                columns:
+                                  min: "two"  # Should be integer, not string
+                                  max: 10
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             assertThrows(ConfigurationException.class, () -> loader.loadConfiguration(input));
         }
     }
-    
+
     @Nested
     @DisplayName("Complex Configuration Validation")
     class ComplexConfigurationValidation {
-        
+
         @Test
         @DisplayName("should validate nested sections with multiple block types")
         void shouldValidateNestedSectionsWithMultipleBlockTypes() throws IOException {
             // Given - complex nested configuration
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: error
-                      - name: author
-                        required: true
-                        severity: error
-                  sections:
-                    - name: "introduction"
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - paragraph:
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
                             severity: error
-                            occurrence:
-                              min: 1
-                              max: 3
-                      subsections:
-                        - name: "overview"
-                          level: 2
+                          - name: author
+                            required: true
+                            severity: error
+                      sections:
+                        - name: "introduction"
+                          level: 1
                           occurrence:
-                            min: 0
+                            min: 1
                             max: 1
                           allowedBlocks:
                             - paragraph:
-                                severity: warn
-                            - image:
-                                severity: info
-                                url:
-                                  required: true
-                    - name: "main"
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 5
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                        - listing:
-                            severity: warn
-                            language:
-                              required: true
-                        - table:
-                            severity: info
-                      subsections:
-                        - level: 2
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  max: 3
+                          subsections:
+                            - name: "overview"
+                              level: 2
+                              occurrence:
+                                min: 0
+                                max: 1
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: warn
+                                - image:
+                                    severity: info
+                                    url:
+                                      required: true
+                        - name: "main"
+                          level: 1
                           occurrence:
-                            min: 0
-                            max: 10
+                            min: 1
+                            max: 5
                           allowedBlocks:
                             - paragraph:
+                                severity: error
+                            - listing:
                                 severity: warn
-                            - admonition:
-                                severity: info
-                                type:
+                                language:
                                   required: true
-                """;
-            
+                            - table:
+                                severity: info
+                          subsections:
+                            - level: 2
+                              occurrence:
+                                min: 0
+                                max: 10
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: warn
+                                - admonition:
+                                    severity: info
+                                    type:
+                                      required: true
+                    """;
+
             InputStream input = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-            
+
             // When & Then
             LinterConfiguration config = assertDoesNotThrow(() -> loader.loadConfiguration(input));
-            
+
             // Verify structure
             assertNotNull(config);
             assertTrue(config.document().sections().size() >= 2);

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/validation/RuleSchemaValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/validation/RuleSchemaValidatorTest.java
@@ -16,193 +16,177 @@ import org.junit.jupiter.api.io.TempDir;
 
 @DisplayName("RuleSchemaValidator")
 class RuleSchemaValidatorTest {
-    
+
     private RuleSchemaValidator validator;
-    
+
     @BeforeEach
     void setUp() {
         validator = new RuleSchemaValidator();
     }
-    
+
     @Nested
     @DisplayName("Valid Configurations")
     class ValidConfigurations {
-        
+
         @Test
         @DisplayName("should accept minimal valid configuration")
         void shouldAcceptMinimalValidConfiguration() {
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: error
-                """;
-            
-            assertDoesNotThrow(() -> 
-                validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
+                            severity: error
+                    """;
+
+            assertDoesNotThrow(() -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
         }
-        
+
         @Test
         @DisplayName("should accept configuration with sections")
         void shouldAcceptConfigurationWithSections() {
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: error
-                  sections:
-                    - name: introduction
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - paragraph:
-                            severity: warn
-                """;
-            
-            assertDoesNotThrow(() -> 
-                validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
+                            severity: error
+                      sections:
+                        - name: introduction
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: warn
+                    """;
+
+            assertDoesNotThrow(() -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
         }
-        
+
         @Test
         @DisplayName("should accept all severity values")
         void shouldAcceptAllSeverityValues() {
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: attr1
-                        severity: error
-                      - name: attr2
-                        severity: warn
-                      - name: attr3
-                        severity: info
-                """;
-            
-            assertDoesNotThrow(() -> 
-                validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
+                    document:
+                      metadata:
+                        attributes:
+                          - name: attr1
+                            severity: error
+                          - name: attr2
+                            severity: warn
+                          - name: attr3
+                            severity: info
+                    """;
+
+            assertDoesNotThrow(() -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
         }
     }
-    
+
     @Nested
     @DisplayName("Invalid Configurations")
     class InvalidConfigurations {
-        
+
         @Test
         @DisplayName("should reject invalid severity value")
         void shouldRejectInvalidSeverity() {
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        severity: CRITICAL
-                """;
-            
-            RuleValidationException ex = assertThrows(
-                RuleValidationException.class,
-                () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            severity: CRITICAL
+                    """;
+
+            RuleValidationException ex = assertThrows(RuleValidationException.class,
+                    () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
+
             assertTrue(ex.getMessage().contains("severity"));
             assertTrue(ex.getMessage().contains("error, warn, info"));
         }
-        
+
         @Test
         @DisplayName("should reject missing required fields")
         void shouldRejectMissingRequiredFields() {
             String yaml = """
-                document:
-                  sections:
-                    - name: intro
-                      # level is required but missing
-                """;
-            
-            RuleValidationException ex = assertThrows(
-                RuleValidationException.class,
-                () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
-            
+                    document:
+                      sections:
+                        - name: intro
+                          # level is required but missing
+                    """;
+
+            RuleValidationException ex = assertThrows(RuleValidationException.class,
+                    () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
+
             assertTrue(ex.getMessage().contains("level"));
             assertTrue(ex.getMessage().contains("required"));
         }
-        
+
         @Test
         @DisplayName("should reject invalid section level")
         void shouldRejectInvalidSectionLevel() {
             String yaml = """
-                document:
-                  sections:
-                    - name: intro
-                      level: -1  # Must be >= 0
-                """;
-            
-            RuleValidationException ex = assertThrows(
-                RuleValidationException.class,
-                () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
-            
+                    document:
+                      sections:
+                        - name: intro
+                          level: -1  # Must be >= 0
+                    """;
+
+            RuleValidationException ex = assertThrows(RuleValidationException.class,
+                    () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
+
             assertTrue(ex.getMessage().contains("level"));
             assertTrue(ex.getMessage().contains("minimum"));
         }
-        
+
         @Test
         @DisplayName("should reject empty document")
         void shouldRejectEmptyDocument() {
             String yaml = """
-                # Empty configuration
-                """;
-            
-            assertThrows(
-                RuleValidationException.class,
-                () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes()))
-            );
+                    # Empty configuration
+                    """;
+
+            assertThrows(RuleValidationException.class,
+                    () -> validator.validateUserConfig(new ByteArrayInputStream(yaml.getBytes())));
         }
     }
-    
+
     @Nested
     @DisplayName("File Validation")
     class FileValidation {
-        
+
         @Test
         @DisplayName("should validate configuration file")
         void shouldValidateConfigurationFile(@TempDir Path tempDir) throws Exception {
             Path configFile = tempDir.resolve("config.yaml");
             String yaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        required: true
-                        severity: error
-                      - name: author
-                        pattern: "^[A-Z].*"
-                        severity: warn
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            required: true
+                            severity: error
+                          - name: author
+                            pattern: "^[A-Z].*"
+                            severity: warn
+                    """;
+
             Files.writeString(configFile, yaml);
-            
+
             assertDoesNotThrow(() -> validator.validateUserConfig(configFile));
         }
-        
+
         @Test
         @DisplayName("should throw exception for non-existent file")
         void shouldThrowExceptionForNonExistentFile(@TempDir Path tempDir) {
             Path nonExistent = tempDir.resolve("non-existent.yaml");
-            
-            RuleValidationException ex = assertThrows(
-                RuleValidationException.class,
-                () -> validator.validateUserConfig(nonExistent)
-            );
-            
+
+            RuleValidationException ex = assertThrows(RuleValidationException.class,
+                    () -> validator.validateUserConfig(nonExistent));
+
             assertTrue(ex.getMessage().contains("not found"));
         }
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/validation/SectionSchemaValidationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/validation/SectionSchemaValidationTest.java
@@ -15,212 +15,209 @@ import com.dataliquid.asciidoc.linter.config.loader.ConfigurationLoader;
 
 @DisplayName("Section Schema Validation")
 class SectionSchemaValidationTest {
-    
+
     private ConfigurationLoader loader;
-    
+
     @BeforeEach
     void setUp() {
         loader = new ConfigurationLoader(); // Enable schema validation
     }
-    
+
     @Test
     @DisplayName("should validate configuration with all block types in sections")
     void shouldValidateConfigurationWithAllBlockTypes() throws IOException {
         // Given
         String yaml = """
-            document:
-              sections:
-                - name: comprehensive
-                  level: 1
-                  occurrence:
-                    min: 1
-                    max: 1
-                  allowedBlocks:
-                    - paragraph:
-                        severity: warn
-                        occurrence:
-                          min: 1
-                          max: 10
-                    - listing:
-                        severity: error
-                        language:
-                          required: true
-                          severity: error
-                    - image:
-                        severity: info
-                        url:
-                          required: true
-                    - table:
-                        severity: warn
-                        columns:
-                          min: 2
-                          max: 10
-                    - verse:
-                        severity: info
-                        author:
-                          required: false
-                    - sidebar:
-                        severity: info
-                        title:
-                          required: true
-                          severity: error
-                    - admonition:
-                        severity: warn
-                        type:
-                          required: true
-                          allowed: ["NOTE", "TIP", "WARNING"]
-                    - pass:
-                        severity: error
-                        type:
-                          required: true
-                          allowed: ["html", "xml"]
-                    - literal:
-                        severity: warn
-                        lines:
-                          min: 1
-                          max: 100
-                    - audio:
-                        severity: info
-                        url:
-                          required: true
-                    - quote:
-                        severity: info
-            """;
-        
+                document:
+                  sections:
+                    - name: comprehensive
+                      level: 1
+                      occurrence:
+                        min: 1
+                        max: 1
+                      allowedBlocks:
+                        - paragraph:
+                            severity: warn
+                            occurrence:
+                              min: 1
+                              max: 10
+                        - listing:
+                            severity: error
+                            language:
+                              required: true
+                              severity: error
+                        - image:
+                            severity: info
+                            url:
+                              required: true
+                        - table:
+                            severity: warn
+                            columns:
+                              min: 2
+                              max: 10
+                        - verse:
+                            severity: info
+                            author:
+                              required: false
+                        - sidebar:
+                            severity: info
+                            title:
+                              required: true
+                              severity: error
+                        - admonition:
+                            severity: warn
+                            type:
+                              required: true
+                              allowed: ["NOTE", "TIP", "WARNING"]
+                        - pass:
+                            severity: error
+                            type:
+                              required: true
+                              allowed: ["html", "xml"]
+                        - literal:
+                            severity: warn
+                            lines:
+                              min: 1
+                              max: 100
+                        - audio:
+                            severity: info
+                            url:
+                              required: true
+                        - quote:
+                            severity: info
+                """;
+
         // When & Then - should not throw any schema validation exceptions
         LinterConfiguration config = assertDoesNotThrow(() -> loader.loadConfiguration(yaml));
-        
+
         // Then - verify configuration was loaded
         assertNotNull(config);
         assertNotNull(config.document());
         assertNotNull(config.document().sections());
     }
-    
+
     @Test
     @DisplayName("should validate mixed block types in nested sections")
     void shouldValidateMixedBlockTypesInNestedSections() throws IOException {
         // Given
         String yaml = """
-            document:
-              sections:
-                - name: main
-                  level: 1
-                  occurrence:
-                    min: 1
-                    max: 5
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                    - listing:
-                        severity: warn
-                    - admonition:
-                        severity: info
-                        type:
-                          required: true
-                  subsections:
-                    - name: details
-                      level: 2
+                document:
+                  sections:
+                    - name: main
+                      level: 1
                       occurrence:
-                        min: 0
-                        max: 3
-                      allowedBlocks:
-                        - literal:
-                            severity: warn
-                        - quote:
-                            severity: info
-                        - sidebar:
-                            severity: info
-                    - level: 2
-                      occurrence:
-                        min: 0
+                        min: 1
                         max: 5
                       allowedBlocks:
-                        - audio:
-                            severity: info
-                        - pass:
+                        - paragraph:
                             severity: error
-            """;
-        
+                        - listing:
+                            severity: warn
+                        - admonition:
+                            severity: info
+                            type:
+                              required: true
+                      subsections:
+                        - name: details
+                          level: 2
+                          occurrence:
+                            min: 0
+                            max: 3
+                          allowedBlocks:
+                            - literal:
+                                severity: warn
+                            - quote:
+                                severity: info
+                            - sidebar:
+                                severity: info
+                        - level: 2
+                          occurrence:
+                            min: 0
+                            max: 5
+                          allowedBlocks:
+                            - audio:
+                                severity: info
+                            - pass:
+                                severity: error
+                """;
+
         // When & Then - should not throw any schema validation exceptions
         LinterConfiguration config = assertDoesNotThrow(() -> loader.loadConfiguration(yaml));
-        
+
         // Then - verify configuration was loaded
         assertNotNull(config);
         assertNotNull(config.document());
         assertNotNull(config.document().sections());
     }
-    
+
     @Test
     @DisplayName("should validate document title (level 0) with max = 1")
     void shouldValidateDocumentTitleWithMaxOne() throws IOException {
         // Given - valid configuration with level 0 and max = 1
         String yaml = """
-            document:
-              sections:
-                - name: documentTitle
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 1
-                  title:
-                    pattern: "^[A-Z].*"
-                    severity: error
-            """;
-        
+                document:
+                  sections:
+                    - name: documentTitle
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 1
+                      title:
+                        pattern: "^[A-Z].*"
+                        severity: error
+                """;
+
         // When & Then - should not throw any schema validation exceptions
         LinterConfiguration config = assertDoesNotThrow(() -> loader.loadConfiguration(yaml));
-        
+
         // Then - verify configuration was loaded
         assertNotNull(config);
         assertNotNull(config.document());
         assertNotNull(config.document().sections());
     }
-    
+
     @Test
     @DisplayName("should reject document title (level 0) with max > 1")
     void shouldRejectDocumentTitleWithMaxGreaterThanOne() {
         // Given - invalid configuration with level 0 and max = 2
         String yaml = """
-            document:
-              sections:
-                - name: documentTitle
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 2
-                  title:
-                    pattern: "^[A-Z].*"
-                    severity: error
-            """;
-        
+                document:
+                  sections:
+                    - name: documentTitle
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 2
+                      title:
+                        pattern: "^[A-Z].*"
+                        severity: error
+                """;
+
         // When & Then - should throw schema validation exception
-        assertThrows(
-            com.dataliquid.asciidoc.linter.config.loader.ConfigurationException.class,
-            () -> loader.loadConfiguration(yaml),
-            "Should reject level 0 section with max > 1"
-        );
+        assertThrows(com.dataliquid.asciidoc.linter.config.loader.ConfigurationException.class,
+                () -> loader.loadConfiguration(yaml), "Should reject level 0 section with max > 1");
     }
-    
+
     @Test
     @DisplayName("should accept non-document sections (level > 0) with max > 1")
     void shouldAcceptNonDocumentSectionsWithMaxGreaterThanOne() throws IOException {
         // Given - valid configuration with level 1 and max = 5
         String yaml = """
-            document:
-              sections:
-                - name: mainSection
-                  level: 1
-                  occurrence:
-                    min: 1
-                    max: 5
-                  title:
-                    pattern: "^Chapter.*"
-                    severity: error
-            """;
-        
+                document:
+                  sections:
+                    - name: mainSection
+                      level: 1
+                      occurrence:
+                        min: 1
+                        max: 5
+                      title:
+                        pattern: "^Chapter.*"
+                        severity: error
+                """;
+
         // When & Then - should not throw any schema validation exceptions
         LinterConfiguration config = assertDoesNotThrow(() -> loader.loadConfiguration(yaml));
-        
+
         // Then - verify configuration was loaded
         assertNotNull(config);
         assertNotNull(config.document());

--- a/src/test/java/com/dataliquid/asciidoc/linter/documentation/AsciiDocAuthorGuidelineGeneratorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/documentation/AsciiDocAuthorGuidelineGeneratorTest.java
@@ -26,110 +26,90 @@ import com.dataliquid.asciidoc.linter.config.rule.SectionConfig;
 
 @DisplayName("AsciiDocAuthorGuidelineGenerator")
 class AsciiDocAuthorGuidelineGeneratorTest {
-    
+
     private AsciiDocAuthorGuidelineGenerator generator;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
-    
+
     @BeforeEach
     void setUp() {
         generator = new AsciiDocAuthorGuidelineGenerator();
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
-    
+
     @Test
     @DisplayName("should return correct format")
     void shouldReturnCorrectFormat() {
         assertEquals(DocumentationFormat.ASCIIDOC, generator.getFormat());
     }
-    
+
     @Test
     @DisplayName("should return correct name")
     void shouldReturnCorrectName() {
         assertEquals("AsciiDoc Author Guideline Generator", generator.getName());
     }
-    
+
     @Nested
     @DisplayName("Generate Documentation")
     class GenerateDocumentation {
-        
+
         @Test
         @DisplayName("should require non-null configuration")
         void shouldRequireNonNullConfiguration() {
-            assertThrows(NullPointerException.class, () -> 
-                generator.generate(null, printWriter)
-            );
+            assertThrows(NullPointerException.class, () -> generator.generate(null, printWriter));
         }
-        
+
         @Test
         @DisplayName("should require non-null writer")
         void shouldRequireNonNullWriter() {
-            LinterConfiguration config = LinterConfiguration.builder()
-                .document(DocumentConfiguration.builder().build())
-                .build();
-            
-            assertThrows(NullPointerException.class, () -> 
-                generator.generate(config, null)
-            );
+            LinterConfiguration config = LinterConfiguration.builder().document(DocumentConfiguration.builder().build())
+                    .build();
+
+            assertThrows(NullPointerException.class, () -> generator.generate(config, null));
         }
-        
+
         @Test
         @DisplayName("should generate basic documentation structure")
         void shouldGenerateBasicDocumentationStructure() {
             // Given
-            LinterConfiguration config = LinterConfiguration.builder()
-                .document(DocumentConfiguration.builder().build())
-                .build();
-            
+            LinterConfiguration config = LinterConfiguration.builder().document(DocumentConfiguration.builder().build())
+                    .build();
+
             // When
             generator.generate(config, printWriter);
             printWriter.flush();
             String output = stringWriter.toString();
-            
+
             // Then
             assertTrue(output.contains("= AsciiDoc Author Guidelines"));
             assertTrue(output.contains(":toc: left"));
             assertTrue(output.contains("== Introduction"));
             assertTrue(output.contains("== Validation Levels"));
         }
-        
+
         @Test
         @DisplayName("should generate metadata documentation")
         void shouldGenerateMetadataDocumentation() {
             // Given
-            AttributeConfig titleAttr = AttributeConfig.builder()
-                .name("title")
-                .required(true)
-                .minLength(10)
-                .maxLength(100)
-                .severity(Severity.ERROR)
-                .build();
-            
-            AttributeConfig authorAttr = AttributeConfig.builder()
-                .name("author")
-                .required(false)
-                .pattern("^[A-Z].*")
-                .severity(Severity.WARN)
-                .build();
-            
-            MetadataConfiguration metadata = MetadataConfiguration.builder()
-                .attributes(List.of(titleAttr, authorAttr))
-                .build();
-            
-            DocumentConfiguration document = DocumentConfiguration.builder()
-                .metadata(metadata)
-                .build();
-            
-            LinterConfiguration config = LinterConfiguration.builder()
-                .document(document)
-                .build();
-            
+            AttributeConfig titleAttr = AttributeConfig.builder().name("title").required(true).minLength(10)
+                    .maxLength(100).severity(Severity.ERROR).build();
+
+            AttributeConfig authorAttr = AttributeConfig.builder().name("author").required(false).pattern("^[A-Z].*")
+                    .severity(Severity.WARN).build();
+
+            MetadataConfiguration metadata = MetadataConfiguration.builder().attributes(List.of(titleAttr, authorAttr))
+                    .build();
+
+            DocumentConfiguration document = DocumentConfiguration.builder().metadata(metadata).build();
+
+            LinterConfiguration config = LinterConfiguration.builder().document(document).build();
+
             // When
             generator.generate(config, printWriter);
             printWriter.flush();
             String output = stringWriter.toString();
-            
+
             // Then
             assertTrue(output.contains("== Document Metadata"));
             assertTrue(output.contains("=== Required Attributes"));
@@ -139,43 +119,27 @@ class AsciiDocAuthorGuidelineGeneratorTest {
             assertTrue(output.contains("Minimum length: 10 characters"));
             assertTrue(output.contains("Maximum length: 100 characters"));
         }
-        
+
         @Test
         @DisplayName("should generate section documentation")
         void shouldGenerateSectionDocumentation() {
             // Given
-            ParagraphBlock paragraph = ParagraphBlock.builder()
-                .severity(Severity.WARN)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(3)
-                    .build())
-                .build();
-            
-            SectionConfig section = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .order(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .allowedBlocks(List.of(paragraph))
-                .build();
-            
-            DocumentConfiguration document = DocumentConfiguration.builder()
-                .sections(List.of(section))
-                .build();
-            
-            LinterConfiguration config = LinterConfiguration.builder()
-                .document(document)
-                .build();
-            
+            ParagraphBlock paragraph = ParagraphBlock.builder().severity(Severity.WARN)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(3).build()).build();
+
+            SectionConfig section = SectionConfig.builder().name("introduction").level(1).order(1)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build()).allowedBlocks(List.of(paragraph))
+                    .build();
+
+            DocumentConfiguration document = DocumentConfiguration.builder().sections(List.of(section)).build();
+
+            LinterConfiguration config = LinterConfiguration.builder().document(document).build();
+
             // When
             generator.generate(config, printWriter);
             printWriter.flush();
             String output = stringWriter.toString();
-            
+
             // Then
             assertTrue(output.contains("== Document Structure"));
             assertTrue(output.contains("=== Section: introduction"));
@@ -183,67 +147,52 @@ class AsciiDocAuthorGuidelineGeneratorTest {
             assertTrue(output.contains("paragraph"));
         }
     }
-    
+
     @Nested
     @DisplayName("Visualization Styles")
     class VisualizationStyles {
-        
+
         @Test
         @DisplayName("should use default tree visualization")
         void shouldUseDefaultTreeVisualization() {
             // Given
-            SectionConfig section = SectionConfig.builder()
-                .name("test")
-                .level(1)
-                .build();
-            
-            DocumentConfiguration document = DocumentConfiguration.builder()
-                .sections(List.of(section))
-                .build();
-            
-            LinterConfiguration config = LinterConfiguration.builder()
-                .document(document)
-                .build();
-            
+            SectionConfig section = SectionConfig.builder().name("test").level(1).build();
+
+            DocumentConfiguration document = DocumentConfiguration.builder().sections(List.of(section)).build();
+
+            LinterConfiguration config = LinterConfiguration.builder().document(document).build();
+
             // When
             generator.generate(config, printWriter);
             printWriter.flush();
             String output = stringWriter.toString();
-            
+
             // Then
             assertTrue(output.contains("[literal]"));
             assertTrue(output.contains("document/"));
         }
-        
+
         @Test
         @DisplayName("should support multiple visualization styles")
         void shouldSupportMultipleVisualizationStyles() {
             // Given
             AsciiDocAuthorGuidelineGenerator multiStyleGenerator = new AsciiDocAuthorGuidelineGenerator(
-                Set.of(VisualizationStyle.TREE, VisualizationStyle.TABLE)
-            );
-            
-            SectionConfig section = SectionConfig.builder()
-                .name("test")
-                .level(1)
-                .build();
-            
-            DocumentConfiguration document = DocumentConfiguration.builder()
-                .sections(List.of(section))
-                .build();
-            
-            LinterConfiguration config = LinterConfiguration.builder()
-                .document(document)
-                .build();
-            
+                    Set.of(VisualizationStyle.TREE, VisualizationStyle.TABLE));
+
+            SectionConfig section = SectionConfig.builder().name("test").level(1).build();
+
+            DocumentConfiguration document = DocumentConfiguration.builder().sections(List.of(section)).build();
+
+            LinterConfiguration config = LinterConfiguration.builder().document(document).build();
+
             // When
             assertDoesNotThrow(() -> {
                 multiStyleGenerator.generate(config, printWriter);
                 printWriter.flush();
             });
-            
+
             String output = stringWriter.toString();
-            
+
             // Then
             assertTrue(output.contains("ASCII-art tree structure"));
             assertTrue(output.contains("Hierarchical table with indentation"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/documentation/PatternHumanizerTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/documentation/PatternHumanizerTest.java
@@ -11,46 +11,46 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("PatternHumanizer")
 class PatternHumanizerTest {
-    
+
     private PatternHumanizer humanizer;
-    
+
     @BeforeEach
     void setUp() {
         humanizer = new PatternHumanizer();
     }
-    
+
     @Nested
     @DisplayName("Known Patterns")
     class KnownPatterns {
-        
+
         @Test
         @DisplayName("should humanize uppercase start pattern")
         void shouldHumanizeUppercaseStartPattern() {
             String result = humanizer.humanize("^[A-Z].*");
             assertEquals("Must start with an uppercase letter", result);
         }
-        
+
         @Test
         @DisplayName("should humanize semantic versioning pattern")
         void shouldHumanizeSemanticVersioningPattern() {
             String result = humanizer.humanize("^\\d+\\.\\d+\\.\\d+$");
             assertEquals("Semantic Versioning Format (e.g. 1.0.0)", result);
         }
-        
+
         @Test
         @DisplayName("should humanize email pattern")
         void shouldHumanizeEmailPattern() {
             String result = humanizer.humanize("^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$");
             assertEquals("Valid email address", result);
         }
-        
+
         @Test
         @DisplayName("should humanize image file pattern")
         void shouldHumanizeImageFilePattern() {
             String result = humanizer.humanize(".*\\.(png|jpg|jpeg|gif|svg)$");
             assertEquals("Image file (PNG, JPG, JPEG, GIF or SVG)", result);
         }
-        
+
         @Test
         @DisplayName("should humanize audio file pattern")
         void shouldHumanizeAudioFilePattern() {
@@ -58,39 +58,39 @@ class PatternHumanizerTest {
             assertEquals("Audio file (MP3, OGG, WAV or M4A)", result);
         }
     }
-    
+
     @Nested
     @DisplayName("Generated Descriptions")
     class GeneratedDescriptions {
-        
+
         @Test
         @DisplayName("should generate description for simple starts-with pattern")
         void shouldGenerateStartsWithDescription() {
             String result = humanizer.humanize("^Chapter");
             assertEquals("Must start with 'Chapter'", result);
         }
-        
+
         @Test
         @DisplayName("should generate description for simple ends-with pattern")
         void shouldGenerateEndsWithDescription() {
             String result = humanizer.humanize("END$");
             assertEquals("Must end with 'END'", result);
         }
-        
+
         @Test
         @DisplayName("should generate description for exact match pattern")
         void shouldGenerateExactMatchDescription() {
             String result = humanizer.humanize("^EXACT$");
             assertEquals("Must be exactly 'EXACT'", result);
         }
-        
+
         @Test
         @DisplayName("should generate description for letters only pattern")
         void shouldGenerateLettersOnlyDescription() {
             String result = humanizer.humanize("^[A-Za-z]+$");
             assertEquals("Only letters allowed", result);
         }
-        
+
         @Test
         @DisplayName("should generate description for numbers only pattern")
         void shouldGenerateNumbersOnlyDescription() {
@@ -98,25 +98,25 @@ class PatternHumanizerTest {
             assertEquals("Only numbers allowed", result);
         }
     }
-    
+
     @Nested
     @DisplayName("Edge Cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should handle null pattern")
         void shouldHandleNullPattern() {
             String result = humanizer.humanize((Pattern) null);
             assertEquals("", result);
         }
-        
+
         @Test
         @DisplayName("should handle empty pattern string")
         void shouldHandleEmptyPatternString() {
             String result = humanizer.humanize("");
             assertEquals("", result);
         }
-        
+
         @Test
         @DisplayName("should show pattern for complex regex")
         void shouldShowPatternForComplexRegex() {
@@ -125,22 +125,22 @@ class PatternHumanizerTest {
             assertEquals("Must match pattern: " + complex, result);
         }
     }
-    
+
     @Nested
     @DisplayName("Custom Patterns")
     class CustomPatterns {
-        
+
         @Test
         @DisplayName("should use registered custom pattern")
         void shouldUseRegisteredCustomPattern() {
             // Given
             String pattern = "^CUSTOM-\\d{4}$";
             String description = "Must match format CUSTOM-XXXX (4 digits)";
-            
+
             // When
             humanizer.registerPattern(pattern, description);
             String result = humanizer.humanize(pattern);
-            
+
             // Then
             assertEquals(description, result);
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/highlight/PlaceholderHighlightIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/highlight/PlaceholderHighlightIntegrationTest.java
@@ -28,17 +28,17 @@ import com.dataliquid.asciidoc.linter.report.ConsoleFormatter;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 /**
- * Integration test for placeholder highlighting in console output.
- * Tests the enhanced error display with placeholders for missing values.
+ * Integration test for placeholder highlighting in console output. Tests the enhanced error display with placeholders
+ * for missing values.
  */
 @DisplayName("Placeholder Highlight Integration Test")
 class PlaceholderHighlightIntegrationTest {
-    
+
     private Linter linter;
     private ConfigurationLoader configLoader;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
-    
+
     @BeforeEach
     void setUp() {
         linter = new Linter();
@@ -46,2936 +46,3012 @@ class PlaceholderHighlightIntegrationTest {
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
-    
+
     @AfterEach
     void tearDown() {
         linter.close();
     }
-    
+
     /**
      * Creates the default output configuration for enhanced placeholder display.
      */
     private OutputConfiguration createDefaultOutputConfig() {
         return createDefaultOutputConfig(3);
     }
-    
+
     /**
      * Creates output configuration with specified context lines.
      */
     private OutputConfiguration createDefaultOutputConfig(int contextLines) {
-        return OutputConfiguration.builder()
-            .format(OutputFormat.ENHANCED)
-            .display(DisplayConfig.builder()
-                .contextLines(contextLines)
-                .useColors(false)  // No colors for easier testing
-                .showLineNumbers(true)
-                .showHeader(true)  // Enable header to match expected output
-                .highlightStyle(HighlightStyle.UNDERLINE)
-                .maxLineWidth(120)
-                .build())
-            .errorGrouping(ErrorGroupingConfig.builder()
-                .enabled(false)  // Disable grouping for tests to show each error individually
-                .build())
-            .suggestions(SuggestionsConfig.builder()
-                .enabled(false)
-                .build())
-            .summary(SummaryConfig.builder()
-                .enabled(false)
-                .build())
-            .build();
+        return OutputConfiguration.builder().format(OutputFormat.ENHANCED)
+                .display(DisplayConfig.builder().contextLines(contextLines).useColors(false) // No colors for easier
+                                                                                             // testing
+                        .showLineNumbers(true).showHeader(true) // Enable header to match expected output
+                        .highlightStyle(HighlightStyle.UNDERLINE).maxLineWidth(120).build())
+                .errorGrouping(ErrorGroupingConfig.builder().enabled(false) // Disable grouping for tests to show each
+                                                                            // error individually
+                        .build())
+                .suggestions(SuggestionsConfig.builder().enabled(false).build())
+                .summary(SummaryConfig.builder().enabled(false).build()).build();
     }
-    
+
     /**
      * Validates content and returns the formatted console output.
      */
     private String validateAndFormat(String rules, String adocContent, Path tempDir) throws IOException {
         return validateAndFormat(rules, adocContent, tempDir, createDefaultOutputConfig());
     }
-    
+
     /**
      * Validates content and returns the formatted console output with custom config.
      */
-    private String validateAndFormat(String rules, String adocContent, Path tempDir, OutputConfiguration outputConfig) throws IOException {
+    private String validateAndFormat(String rules, String adocContent, Path tempDir, OutputConfiguration outputConfig)
+            throws IOException {
         // Clear any previous output
         stringWriter.getBuffer().setLength(0);
-        
+
         // Create temporary file with content
         Path testFile = tempDir.resolve("test.adoc");
         Files.writeString(testFile, adocContent);
-        
+
         // Load configuration and validate
         LinterConfiguration config = configLoader.loadConfiguration(rules);
         ValidationResult result = linter.validateFile(testFile, config);
-        
+
         // Format output
         ConsoleFormatter formatter = new ConsoleFormatter(outputConfig);
         formatter.format(result, printWriter);
         printWriter.flush();
-        
+
         return stringWriter.toString();
     }
-    
-    
+
     @Test
     @DisplayName("should show placeholder for missing listing language")
     void shouldShowPlaceholderForMissingListingLanguage(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring language for listing blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - listing:
-                        severity: error
-                        language:
-                          required: true
-                          severity: error
-            """;
-        
-        // Given - AsciiDoc content with missing language  
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - listing:
+                            severity: error
+                            language:
+                              required: true
+                              severity: error
+                """;
+
+        // Given - AsciiDoc content with missing language
         String adocContent = """
-            = Test Document
-            
-            [source]
-            ----
-            public class Example {
-                // Some code here
-            }
-            ----
-            """;
-        
+                = Test Document
+
+                [source]
+                ----
+                public class Example {
+                    // Some code here
+                }
+                ----
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Listing language is required [listing.language.required]
-              File: %s:3:8
-              Actual: No language
-              Expected: Language required
-            
-               1 | = Test Document
-               2 |\s
-               3 | [source,«language»]
-               4 | ----
-               5 | public class Example {
-               6 |     // Some code here
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Listing language is required [listing.language.required]
+                          File: %s:3:8
+                          Actual: No language
+                          Expected: Language required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [source,«language»]
+                           4 | ----
+                           5 | public class Example {
+                           6 |     // Some code here
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     // TODO: Check later - Asciidoctor doesn't recognize image::[] as an image block when URL is empty
     // @Test
     @DisplayName("should show placeholder for missing image URL")
     void shouldShowPlaceholderForMissingImageUrl(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring URL for image blocks at document level
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - image:
-                        severity: error
-                        url:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - image:
+                            severity: error
+                            url:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing image URL
         String adocContent = """
-            = Test Document
-            
-            image::[]
-            """;
-        
+                = Test Document
+
+                image::[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Image must have a URL [image.url.required]
-              File: %s:3:8
-            
-               1 | = Test Document
-               2 | 
-               3 | image::«filename.png»[]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Image must have a URL [image.url.required]
+                          File: %s:3:8
+
+                           1 | = Test Document
+                           2 |
+                           3 | image::«filename.png»[]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing alt text")
     void shouldShowPlaceholderForMissingAltText(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring alt text for image blocks at document level
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - image:
-                        severity: error
-                        alt:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - image:
+                            severity: error
+                            alt:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing alt text
         String adocContent = """
-            = Test Document
-            
-            image::example.png[]
-            """;
-        
+                = Test Document
+
+                image::example.png[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Image must have alt text [image.alt.required]
-              File: %s:3:20
-              Actual: No alt text
-              Expected: Alt text required
-            
-               1 | = Test Document
-               2 |\s
-               3 | image::example.png[«Description of image»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Image must have alt text [image.alt.required]
+                          File: %s:3:20
+                          Actual: No alt text
+                          Expected: Alt text required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | image::example.png[«Description of image»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing width attribute")
     void shouldShowPlaceholderForMissingWidth(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring width for image blocks at document level
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - image:
-                        severity: error
-                        width:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - image:
+                            severity: error
+                            width:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing width attribute
         String adocContent = """
-            = Test Document
-            
-            image::example.png[alt="Example image"]
-            """;
-        
+                = Test Document
+
+                image::example.png[alt="Example image"]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Image must have width specified [image.width.required]
-              File: %s:3:39
-              Actual: No width
-              Expected: width required
-            
-               1 | = Test Document
-               2 |\s
-               3 | image::example.png[alt="Example image",width=«640»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Image must have width specified [image.width.required]
+                          File: %s:3:39
+                          Actual: No width
+                          Expected: width required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | image::example.png[alt="Example image",width=«640»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing height attribute")
     void shouldShowPlaceholderForMissingHeight(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring height for image blocks at document level
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - image:
-                        severity: error
-                        height:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - image:
+                            severity: error
+                            height:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing height attribute
         String adocContent = """
-            = Test Document
-            
-            image::example.png[alt="Example image",width=200]
-            """;
-        
+                = Test Document
+
+                image::example.png[alt="Example image",width=200]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Image must have height specified [image.height.required]
-              File: %s:3:49
-              Actual: No height
-              Expected: height required
-            
-               1 | = Test Document
-               2 |\s
-               3 | image::example.png[alt="Example image",width=200,height=«480»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Image must have height specified [image.height.required]
+                          File: %s:3:49
+                          Actual: No height
+                          Expected: height required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | image::example.png[alt="Example image",width=200,height=«480»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for paragraph with too few sentences")
     void shouldShowPlaceholderForParagraphWithTooFewSentences(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 3 sentences for paragraphs
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        sentence:
-                          occurrence:
-                            min: 3
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
                             severity: error
-            """;
-        
+                            sentence:
+                              occurrence:
+                                min: 3
+                                severity: error
+                """;
+
         // Given - AsciiDoc content with paragraph having only 2 sentences
         String adocContent = """
-            = Test Document
-            
-            This is the first sentence. This is the second sentence.
-            """;
-        
+                = Test Document
+
+                This is the first sentence. This is the second sentence.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Paragraph has too few sentences [paragraph.sentence.occurrence.min]
-              File: %s:3:57
-              Actual: 2
-              Expected: At least 3 sentences
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is the first sentence. This is the second sentence. «Add more sentences.»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Paragraph has too few sentences [paragraph.sentence.occurrence.min]
+                          File: %s:3:57
+                          Actual: 2
+                          Expected: At least 3 sentences
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | This is the first sentence. This is the second sentence. «Add more sentences.»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for paragraph with only one sentence when three required")
     void shouldShowPlaceholderForParagraphWithOneSentenceWhenThreeRequired(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 3 sentences for paragraphs
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: warn
-                        sentence:
-                          occurrence:
-                            min: 3
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
                             severity: warn
-            """;
-        
+                            sentence:
+                              occurrence:
+                                min: 3
+                                severity: warn
+                """;
+
         // Given - AsciiDoc content with paragraph having only 1 sentence
         String adocContent = """
-            = Test Document
-            
-            This is only one sentence.
-            """;
-        
+                = Test Document
+
+                This is only one sentence.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [WARN]: Paragraph has too few sentences [paragraph.sentence.occurrence.min]
-              File: %s:3:27
-              Actual: 1
-              Expected: At least 3 sentences
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is only one sentence. «Add more sentences.»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [WARN]: Paragraph has too few sentences [paragraph.sentence.occurrence.min]
+                          File: %s:3:27
+                          Actual: 1
+                          Expected: At least 3 sentences
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | This is only one sentence. «Add more sentences.»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for sentence with too few words")
     void shouldShowPlaceholderForSentenceWithTooFewWords(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 5 words per sentence
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        sentence:
-                          words:
-                            min: 5
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
                             severity: error
-            """;
-        
+                            sentence:
+                              words:
+                                min: 5
+                                severity: error
+                """;
+
         // Given - AsciiDoc content with sentence having only 3 words
         String adocContent = """
-            = Test Document
-            
-            This is short.
-            """;
-        
+                = Test Document
+
+                This is short.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder before punctuation
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Sentence 1 has too few words [paragraph.sentence.words.min]
-              File: %s:3:14
-              Actual: 3 words
-              Expected: At least 5 words
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is short «add more words».
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Sentence 1 has too few words [paragraph.sentence.words.min]
+                          File: %s:3:14
+                          Actual: 3 words
+                          Expected: At least 5 words
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | This is short «add more words».
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for sentence with question mark")
     void shouldShowPlaceholderForSentenceWithQuestionMark(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 4 words per sentence
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: warn
-                        sentence:
-                          words:
-                            min: 4
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
                             severity: warn
-            """;
-        
+                            sentence:
+                              words:
+                                min: 4
+                                severity: warn
+                """;
+
         // Given - AsciiDoc content with question having only 3 words
         String adocContent = """
-            = Test Document
-            
-            How are you?
-            """;
-        
+                = Test Document
+
+                How are you?
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder before question mark
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [WARN]: Sentence 1 has too few words [paragraph.sentence.words.min]
-              File: %s:3:12
-              Actual: 3 words
-              Expected: At least 4 words
-            
-               1 | = Test Document
-               2 |\s
-               3 | How are you «add more words»?
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [WARN]: Sentence 1 has too few words [paragraph.sentence.words.min]
+                          File: %s:3:12
+                          Actual: 3 words
+                          Expected: At least 4 words
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | How are you «add more words»?
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for sentence with exclamation mark")
     void shouldShowPlaceholderForSentenceWithExclamationMark(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 3 words per sentence
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        sentence:
-                          words:
-                            min: 3
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
                             severity: error
-            """;
-        
+                            sentence:
+                              words:
+                                min: 3
+                                severity: error
+                """;
+
         // Given - AsciiDoc content with exclamation having only 2 words
         String adocContent = """
-            = Test Document
-            
-            Too short!
-            """;
-        
+                = Test Document
+
+                Too short!
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder before exclamation mark
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Sentence 1 has too few words [paragraph.sentence.words.min]
-              File: %s:3:10
-              Actual: 2 words
-              Expected: At least 3 words
-            
-               1 | = Test Document
-               2 |\s
-               3 | Too short «add more words»!
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Sentence 1 has too few words [paragraph.sentence.words.min]
+                          File: %s:3:10
+                          Actual: 2 words
+                          Expected: At least 3 words
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | Too short «add more words»!
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for multiple sentences with too few words")
     void shouldShowPlaceholderForMultipleSentencesWithTooFewWords(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 5 words per sentence
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: warn
-                        sentence:
-                          words:
-                            min: 5
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
                             severity: warn
-            """;
-        
+                            sentence:
+                              words:
+                                min: 5
+                                severity: warn
+                """;
+
         // Given - AsciiDoc content with multiple short sentences
         String adocContent = """
-            = Test Document
-            
-            Too short. This sentence has exactly five words. Also short!
-            """;
-        
+                = Test Document
+
+                Too short. This sentence has exactly five words. Also short!
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholders for each short sentence
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [WARN]: Sentence 1 has too few words [paragraph.sentence.words.min]
-              File: %s:3:10
-              Actual: 2 words
-              Expected: At least 5 words
-            
-               1 | = Test Document
-               2 |\s
-               3 | Too short «add more words». This sentence has exactly five words. Also short!
-            
-            [WARN]: Sentence 3 has too few words [paragraph.sentence.words.min]
-              File: %s:3:60
-              Actual: 2 words
-              Expected: At least 5 words
-            
-               1 | = Test Document
-               2 |\s
-               3 | Too short. This sentence has exactly five words. Also short «add more words»!
-            
-            
-            """, testFile.toString(), testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [WARN]: Sentence 1 has too few words [paragraph.sentence.words.min]
+                          File: %s:3:10
+                          Actual: 2 words
+                          Expected: At least 5 words
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | Too short «add more words». This sentence has exactly five words. Also short!
+
+                        [WARN]: Sentence 3 has too few words [paragraph.sentence.words.min]
+                          File: %s:3:60
+                          Actual: 2 words
+                          Expected: At least 5 words
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | Too short. This sentence has exactly five words. Also short «add more words»!
+
+
+                        """,
+                testFile.toString(), testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for paragraph with too few lines")
     void shouldShowPlaceholderForParagraphWithTooFewLines(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 2 lines for paragraphs
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        lines:
-                          min: 2
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
+                            severity: error
+                            lines:
+                              min: 2
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with single-line paragraph
         String adocContent = """
-            = Test Document
-            
-            This is a single line paragraph.
-            """;
-        
+                = Test Document
+
+                This is a single line paragraph.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Paragraph has too few lines [paragraph.lines.min]
-              File: %s:3:33
-              Actual: 1
-              Expected: At least 2 lines
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is a single line paragraph.
-               4 | «Add more content here...»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Paragraph has too few lines [paragraph.lines.min]
+                          File: %s:3:33
+                          Actual: 1
+                          Expected: At least 2 lines
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | This is a single line paragraph.
+                           4 | «Add more content here...»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for paragraph missing second line")
     void shouldShowPlaceholderForParagraphMissingSecondLine(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 3 lines for paragraphs
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        lines:
-                          min: 3
-                          severity: warn
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
+                            severity: error
+                            lines:
+                              min: 3
+                              severity: warn
+                """;
+
         // Given - AsciiDoc content with two-line paragraph
         String adocContent = """
-            = Test Document
-            
-            This is the first line of content.
-            This is the second line of content.
-            """;
-        
+                = Test Document
+
+                This is the first line of content.
+                This is the second line of content.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [WARN]: Paragraph has too few lines [paragraph.lines.min]
-              File: %s:4:36
-              Actual: 2
-              Expected: At least 3 lines
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is the first line of content.
-               4 | This is the second line of content.
-               5 | «Add more content here...»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [WARN]: Paragraph has too few lines [paragraph.lines.min]
+                          File: %s:4:36
+                          Actual: 2
+                          Expected: At least 3 lines
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | This is the first line of content.
+                           4 | This is the second line of content.
+                           5 | «Add more content here...»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for paragraph with one line when three required")
     void shouldShowPlaceholderForParagraphWithOneLineWhenThreeRequired(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum 3 lines for paragraphs
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        lines:
-                          min: 3
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - paragraph:
+                            severity: error
+                            lines:
+                              min: 3
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with single-line paragraph
         String adocContent = """
-            = Test Document
-            
-            This is only one line when three are required.
-            """;
-        
+                = Test Document
+
+                This is only one line when three are required.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Paragraph has too few lines [paragraph.lines.min]
-              File: %s:3:47
-              Actual: 1
-              Expected: At least 3 lines
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is only one line when three are required.
-               4 | «Add more content here...»
-               5 | «Add more content here...»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Paragraph has too few lines [paragraph.lines.min]
+                          File: %s:3:47
+                          Actual: 1
+                          Expected: At least 3 lines
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | This is only one line when three are required.
+                           4 | «Add more content here...»
+                           5 | «Add more content here...»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for missing video URL")
     void shouldShowPlaceholderForMissingVideoUrl(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring URL for video blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - video:
-                        severity: error
-                        url:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - video:
+                            severity: error
+                            url:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing video URL
         String adocContent = """
-            = Test Document
-            
-            video::[]
-            """;
-        
+                = Test Document
+
+                video::[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Video URL is required but not provided [video.url.required]
-              File: %s:3:8
-            
-               1 | = Test Document
-               2 |\s
-               3 | video::«target»[]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Video URL is required but not provided [video.url.required]
+                          File: %s:3:8
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | video::«target»[]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing video width")
     void shouldShowPlaceholderForMissingVideoWidth(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring width for video blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - video:
-                        severity: error
-                        width:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - video:
+                            severity: error
+                            width:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing width
         String adocContent = """
-            = Test Document
-            
-            video::example.mp4[]
-            """;
-        
+                = Test Document
+
+                video::example.mp4[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Video width is required but not provided [video.width.required]
-              File: %s:3:20
-            
-               1 | = Test Document
-               2 |\s
-               3 | video::example.mp4[width=«640»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Video width is required but not provided [video.width.required]
+                          File: %s:3:20
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | video::example.mp4[width=«640»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing video height")
     void shouldShowPlaceholderForMissingVideoHeight(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring height for video blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - video:
-                        severity: error
-                        height:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - video:
+                            severity: error
+                            height:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing height
         String adocContent = """
-            = Test Document
-            
-            video::example.mp4[width=640]
-            """;
-        
+                = Test Document
+
+                video::example.mp4[width=640]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Video height is required but not provided [video.height.required]
-              File: %s:3:29
-            
-               1 | = Test Document
-               2 |\s
-               3 | video::example.mp4[width=640,height=«360»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Video height is required but not provided [video.height.required]
+                          File: %s:3:29
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | video::example.mp4[width=640,height=«360»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing video poster")
     void shouldShowPlaceholderForMissingVideoPoster(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring poster for video blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - video:
-                        severity: error
-                        poster:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - video:
+                            severity: error
+                            poster:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing poster
         String adocContent = """
-            = Test Document
-            
-            video::example.mp4[width=640,height=360]
-            """;
-        
+                = Test Document
+
+                video::example.mp4[width=640,height=360]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Video poster image is required but not provided [video.poster.required]
-              File: %s:3:40
-            
-               1 | = Test Document
-               2 |\s
-               3 | video::example.mp4[width=640,height=360,poster=«thumbnail.jpg»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Video poster image is required but not provided [video.poster.required]
+                          File: %s:3:40
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | video::example.mp4[width=640,height=360,poster=«thumbnail.jpg»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing video controls")
     void shouldShowPlaceholderForMissingVideoControls(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring controls for video blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - video:
-                        severity: error
-                        options:
-                          controls:
-                            required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - video:
+                            severity: error
+                            options:
+                              controls:
+                                required: true
+                """;
+
         // Given - AsciiDoc content with missing controls
         String adocContent = """
-            = Test Document
-            
-            video::example.mp4[]
-            """;
-        
+                = Test Document
+
+                video::example.mp4[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Video controls are required but not enabled [video.controls.required]
-              File: %s:3:20
-              Expected: controls
-            
-               1 | = Test Document
-               2 |\s
-               3 | video::example.mp4[options=«controls»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Video controls are required but not enabled [video.controls.required]
+                          File: %s:3:20
+                          Expected: controls
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | video::example.mp4[options=«controls»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing video caption")
     void shouldShowPlaceholderForMissingVideoCaption(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring caption for video blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - video:
-                        severity: error
-                        caption:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - video:
+                            severity: error
+                            caption:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing caption
         String adocContent = """
-            = Test Document
-            
-            video::example.mp4[]
-            """;
-        
+                = Test Document
+
+                video::example.mp4[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Video caption is required but not provided [video.caption.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | «.Video Title»
-               4 | video::example.mp4[]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Video caption is required but not provided [video.caption.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «.Video Title»
+                           4 | video::example.mp4[]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for missing audio URL")
     void shouldShowPlaceholderForMissingAudioUrl(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring URL for audio blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - audio:
-                        severity: error
-                        url:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - audio:
+                            severity: error
+                            url:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing URL
         String adocContent = """
-            = Test Document
-            
-            audio::[]
-            """;
-        
+                = Test Document
+
+                audio::[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Audio URL is required but not provided [audio.url.required]
-              File: %s:3:8
-            
-               1 | = Test Document
-               2 |\s
-               3 | audio::«target»[]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Audio URL is required but not provided [audio.url.required]
+                          File: %s:3:8
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | audio::«target»[]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing audio title")
     void shouldShowPlaceholderForMissingAudioTitle(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring title for audio blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - audio:
-                        severity: error
-                        title:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - audio:
+                            severity: error
+                            title:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing caption
         String adocContent = """
-            = Test Document
-            
-            audio::example.mp3[]
-            """;
-        
+                = Test Document
+
+                audio::example.mp3[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Audio title is required but not provided [audio.title.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | «.Audio Title»
-               4 | audio::example.mp3[]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Audio title is required but not provided [audio.title.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «.Audio Title»
+                           4 | audio::example.mp3[]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for missing audio controls")
     void shouldShowPlaceholderForMissingAudioControls(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring controls for audio blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - audio:
-                        severity: error
-                        options:
-                          controls:
-                            required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - audio:
+                            severity: error
+                            options:
+                              controls:
+                                required: true
+                """;
+
         // Given - AsciiDoc content without controls
         String adocContent = """
-            = Test Document
-            
-            audio::example.mp3[]
-            """;
-        
+                = Test Document
+
+                audio::example.mp3[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Audio controls are required but not enabled [audio.options.controls.required]
-              File: %s:3:20
-            
-               1 | = Test Document
-               2 |\s
-               3 | audio::example.mp3[options=«controls»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Audio controls are required but not enabled [audio.options.controls.required]
+                          File: %s:3:20
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | audio::example.mp3[options=«controls»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for missing audio autoplay")
     void shouldShowPlaceholderForMissingAudioAutoplay(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring autoplay for audio blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - audio:
-                        severity: error
-                        options:
-                          autoplay:
-                            required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - audio:
+                            severity: error
+                            options:
+                              autoplay:
+                                required: true
+                """;
+
         // Given - AsciiDoc content without autoplay
         String adocContent = """
-            = Test Document
-            
-            audio::example.mp3[]
-            """;
-        
+                = Test Document
+
+                audio::example.mp3[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Audio autoplay is required but not enabled [audio.autoplay.required]
-              File: %s:3:20
-            
-               1 | = Test Document
-               2 |\s
-               3 | audio::example.mp3[options=«autoplay»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Audio autoplay is required but not enabled [audio.autoplay.required]
+                          File: %s:3:20
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | audio::example.mp3[options=«autoplay»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for missing audio loop")
     void shouldShowPlaceholderForMissingAudioLoop(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring loop for audio blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - audio:
-                        severity: error
-                        options:
-                          loop:
-                            required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - audio:
+                            severity: error
+                            options:
+                              loop:
+                                required: true
+                """;
+
         // Given - AsciiDoc content without loop
         String adocContent = """
-            = Test Document
-            
-            audio::example.mp3[]
-            """;
-        
+                = Test Document
+
+                audio::example.mp3[]
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Audio loop is required but not enabled [audio.loop.required]
-              File: %s:3:20
-            
-               1 | = Test Document
-               2 |\s
-               3 | audio::example.mp3[options=«loop»]
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Audio loop is required but not enabled [audio.loop.required]
+                          File: %s:3:20
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | audio::example.mp3[options=«loop»]
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing table caption")
     void shouldShowPlaceholderForMissingTableCaption(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring caption for table blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - table:
-                        severity: error
-                        caption:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - table:
+                            severity: error
+                            caption:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing caption
         String adocContent = """
-            = Test Document
-            
-            |===
-            | Column 1 | Column 2
-            | Data 1 | Data 2
-            |===
-            """;
-        
+                = Test Document
+
+                |===
+                | Column 1 | Column 2
+                | Data 1 | Data 2
+                |===
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Table caption is required but not provided [table.caption.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | «.Table Title»
-               4 | |===
-               5 | | Column 1 | Column 2
-               6 | | Data 1 | Data 2
-               7 | |===
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Table caption is required but not provided [table.caption.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «.Table Title»
+                           4 | |===
+                           5 | | Column 1 | Column 2
+                           6 | | Data 1 | Data 2
+                           7 | |===
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing table header")
     void shouldShowPlaceholderForMissingTableHeader(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring header for table blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - table:
-                        severity: error
-                        header:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - table:
+                            severity: error
+                            header:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing header
         String adocContent = """
-            = Test Document
-            
-            |===
-            | Data 1 | Data 2
-            | Data 3 | Data 4
-            |===
-            """;
-        
+                = Test Document
+
+                |===
+                | Data 1 | Data 2
+                | Data 3 | Data 4
+                |===
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Table header is required but not provided [table.header.required]
-              File: %s:4:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | |===
-               4 | «| Header 1 | Header 2»
-               5 | | Data 1 | Data 2
-               6 | | Data 3 | Data 4
-               7 | |===
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Table header is required but not provided [table.header.required]
+                          File: %s:4:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | |===
+                           4 | «| Header 1 | Header 2»
+                           5 | | Data 1 | Data 2
+                           6 | | Data 3 | Data 4
+                           7 | |===
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for table with too few columns")
     void shouldShowPlaceholderForTableWithTooFewColumns(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum columns for table blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - table:
-                        severity: error
-                        columns:
-                          min: 3
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - table:
+                            severity: error
+                            columns:
+                              min: 3
+                """;
+
         // Given - AsciiDoc content with only 2 columns
         String adocContent = """
-            = Test Document
-            
-            |===
-            | Column 1 | Column 2
-            | Data 1 | Data 2
-            |===
-            """;
-        
+                = Test Document
+
+                |===
+                | Column 1 | Column 2
+                | Data 1 | Data 2
+                |===
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Table has too few columns [table.columns.min]
-              File: %s:4:21
-            
-               1 | = Test Document
-               2 |\s
-               3 | |===
-               4 | | Column 1 | Column 2 «| Column 3»
-               5 | | Data 1 | Data 2
-               6 | |===
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Table has too few columns [table.columns.min]
+                          File: %s:4:21
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | |===
+                           4 | | Column 1 | Column 2 «| Column 3»
+                           5 | | Data 1 | Data 2
+                           6 | |===
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for table with too few rows")
     void shouldShowPlaceholderForTableWithTooFewRows(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum rows for table blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - table:
-                        severity: error
-                        rows:
-                          min: 3
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - table:
+                            severity: error
+                            rows:
+                              min: 3
+                """;
+
         // Given - AsciiDoc content with only 2 rows (including header)
         String adocContent = """
-            = Test Document
-            
-            |===
-            | Column 1 | Column 2
-            | Data 1 | Data 2
-            |===
-            """;
-        
+                = Test Document
+
+                |===
+                | Column 1 | Column 2
+                | Data 1 | Data 2
+                |===
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Table has too few rows [table.rows.min]
-              File: %s:5:17
-            
-               1 | = Test Document
-               2 |\s
-               3 | |===
-               4 | | Column 1 | Column 2
-               5 | | Data 1 | Data 2
-               6 | «| Data 3 | Data 4»
-               7 | |===
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Table has too few rows [table.rows.min]
+                          File: %s:5:17
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | |===
+                           4 | | Column 1 | Column 2
+                           5 | | Data 1 | Data 2
+                           6 | «| Data 3 | Data 4»
+                           7 | |===
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing section when min-occurrences not met")
     void shouldShowPlaceholderForMissingSectionMinOccurrences(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring a section with min occurrences
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  subsections:
-                    - name: headerTypeRule
-                      order: 1
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      subsections:
+                        - name: headerTypeRule
+                          order: 1
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                """;
+
         // Given - AsciiDoc content missing the required section
         // Note: The string has line 1: title, line 2: empty, line 3: content
         String adocContent = """
-            = Test Document
-            
-            Some content without the required section.
-            """;
-        
+                = Test Document
+
+                Some content without the required section.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required section 'headerTypeRule' at level 1 (expected in null at level 0) [section.min-occurrences]
-              File: %s:1
-              Actual: 0 occurrences
-              Expected: At least 1 occurrence(s)
-            
-               1 | = Test Document
-               2 |\s
-               3 | «== headerTypeRule»
-               4 | Some content without the required section.
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required section 'headerTypeRule' at level 1 (expected in null at level 0) [section.min-occurrences]
+                          File: %s:1
+                          Actual: 0 occurrences
+                          Expected: At least 1 occurrence(s)
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «== headerTypeRule»
+                           4 | Some content without the required section.
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing level 0 section when min-occurrences not met")
     void shouldShowPlaceholderForMissingLevel0SectionMinOccurrences(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring a level 0 section with min occurrences
         String rules = """
-            document:
-              sections:
-                # Document title (Level 0) - HTTP Header Name
-                - name: headerTitleRule
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 1
-                  title:
-                    pattern: "^[A-Za-z][A-Za-z0-9-]*$"
-                    severity: error
-            """;
-        
+                document:
+                  sections:
+                    # Document title (Level 0) - HTTP Header Name
+                    - name: headerTitleRule
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 1
+                      title:
+                        pattern: "^[A-Za-z][A-Za-z0-9-]*$"
+                        severity: error
+                """;
+
         // Given - AsciiDoc content missing the required level 0 section
         String adocContent = """
-            Some content without any document title.
-            """;
-        
+                Some content without any document title.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required section 'headerTitleRule' at level 0 [section.min-occurrences]
-              File: %s:1
-              Actual: 0 occurrences
-              Expected: At least 1 occurrence(s)
-            
-               1 | «= headerTitleRule»
-               2 | Some content without any document title.
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required section 'headerTitleRule' at level 0 [section.min-occurrences]
+                          File: %s:1
+                          Actual: 0 occurrences
+                          Expected: At least 1 occurrence(s)
+
+                           1 | «= headerTitleRule»
+                           2 | Some content without any document title.
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing level 4 section when min-occurrences not met")
     void shouldShowPlaceholderForMissingLevel4SectionMinOccurrences(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring a level 4 section with min occurrences
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  subsections:
-                    - name: introduction
-                      level: 1
+                document:
+                  sections:
+                    - level: 0
                       subsections:
-                        - name: overview
-                          level: 2
+                        - name: introduction
+                          level: 1
                           subsections:
-                            - name: details
-                              level: 3
+                            - name: overview
+                              level: 2
                               subsections:
-                                - name: implementation
-                                  level: 4
-                                  occurrence:
-                                    min: 1
-                                    max: 1
-            """;
-        
+                                - name: details
+                                  level: 3
+                                  subsections:
+                                    - name: implementation
+                                      level: 4
+                                      occurrence:
+                                        min: 1
+                                        max: 1
+                """;
+
         // Given - AsciiDoc content with nested sections but missing the required level 4 section
         String adocContent = """
-            = Test Document
-            
-            == Introduction
-            
-            === Overview
-            
-            ==== Details
-            
-            Some content here but missing the required implementation section.
-            """;
-        
+                = Test Document
+
+                == Introduction
+
+                === Overview
+
+                ==== Details
+
+                Some content here but missing the required implementation section.
+                """;
+
         // When - Validate and format output (with more context lines to show the full structure)
         String actualOutput = validateAndFormat(rules, adocContent, tempDir, createDefaultOutputConfig(10));
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required section 'implementation' at level 4 (expected in details at level 3) [section.min-occurrences]
-              File: %s:1
-              Actual: 0 occurrences
-              Expected: At least 1 occurrence(s)
-            
-               1 | = Test Document
-               2 |\s
-               3 | == Introduction
-               4 |\s
-               5 | === Overview
-               6 |\s
-               7 | ==== Details
-               8 |\s
-               9 | Some content here but missing the required implementation section.
-              10 | «===== implementation»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required section 'implementation' at level 4 (expected in details at level 3) [section.min-occurrences]
+                          File: %s:1
+                          Actual: 0 occurrences
+                          Expected: At least 1 occurrence(s)
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | == Introduction
+                           4 |\s
+                           5 | === Overview
+                           6 |\s
+                           7 | ==== Details
+                           8 |\s
+                           9 | Some content here but missing the required implementation section.
+                          10 | «===== implementation»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing quote attribution")
     void shouldShowPlaceholderForMissingQuoteAttribution(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring attribution for quote blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - quote:
-                        severity: error
-                        attribution:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - quote:
+                            severity: error
+                            attribution:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing attribution
         String adocContent = """
-            = Test Document
-            
-            [quote]
-            ____
-            This is a quote without attribution.
-            ____
-            """;
-        
+                = Test Document
+
+                [quote]
+                ____
+                This is a quote without attribution.
+                ____
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Quote attribution is required but not provided [quote.attribution.required]
-              File: %s:3:7
-            
-               1 | = Test Document
-               2 |\s
-               3 | [quote,«attribution»]
-               4 | ____
-               5 | This is a quote without attribution.
-               6 | ____
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Quote attribution is required but not provided [quote.attribution.required]
+                          File: %s:3:7
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [quote,«attribution»]
+                           4 | ____
+                           5 | This is a quote without attribution.
+                           6 | ____
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing quote citation")
     void shouldShowPlaceholderForMissingQuoteCitation(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring citation for quote blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - quote:
-                        severity: error
-                        citation:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - quote:
+                            severity: error
+                            citation:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing citation
         String adocContent = """
-            = Test Document
-            
-            [quote,John Doe]
-            ____
-            This is a quote without citation.
-            ____
-            """;
-        
+                = Test Document
+
+                [quote,John Doe]
+                ____
+                This is a quote without citation.
+                ____
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Quote citation is required but not provided [quote.citation.required]
-              File: %s:3:16
-            
-               1 | = Test Document
-               2 |\s
-               3 | [quote,John Doe,«citation»]
-               4 | ____
-               5 | This is a quote without citation.
-               6 | ____
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Quote citation is required but not provided [quote.citation.required]
+                          File: %s:3:16
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [quote,John Doe,«citation»]
+                           4 | ____
+                           5 | This is a quote without citation.
+                           6 | ____
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing example caption")
     void shouldShowPlaceholderForMissingExampleCaption(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring caption for example blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - example:
-                        severity: error
-                        caption:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - example:
+                            severity: error
+                            caption:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing caption
         String adocContent = """
-            = Test Document
-            
-            ====
-            This is an example block without a caption.
-            ====
-            """;
-        
+                = Test Document
+
+                ====
+                This is an example block without a caption.
+                ====
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Example block requires a caption [example.caption.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | «.Example Title»
-               4 | ====
-               5 | This is an example block without a caption.
-               6 | ====
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Example block requires a caption [example.caption.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «.Example Title»
+                           4 | ====
+                           5 | This is an example block without a caption.
+                           6 | ====
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing example collapsible attribute")
     void shouldShowPlaceholderForMissingExampleCollapsible(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring collapsible for example blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - example:
-                        severity: error
-                        collapsible:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - example:
+                            severity: error
+                            collapsible:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing collapsible attribute
         String adocContent = """
-            = Test Document
-            
-            ====
-            This is an example block without collapsible attribute.
-            ====
-            """;
-        
+                = Test Document
+
+                ====
+                This is an example block without collapsible attribute.
+                ====
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Example block requires a collapsible attribute [example.collapsible.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | «[%%collapsible]»
-               4 | ====
-               5 | This is an example block without collapsible attribute.
-               6 | ====
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Example block requires a collapsible attribute [example.collapsible.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «[%%collapsible]»
+                           4 | ====
+                           5 | This is an example block without collapsible attribute.
+                           6 | ====
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
-    //@Test
+
+    // @Test
     @DisplayName("should show placeholder for missing admonition type")
     void shouldShowPlaceholderForMissingAdmonitionType(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring type for admonition blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - admonition:
-                        severity: error
-                        type:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - admonition:
+                            severity: error
+                            type:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing admonition type
         String adocContent = """
-            = Test Document
-            
-            []
-            ====
-            This is an admonition without a type.
-            ====
-            """;
-        
+                = Test Document
+
+                []
+                ====
+                This is an admonition without a type.
+                ====
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Admonition block must have a type [admonition.type.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | [«NOTE»]
-               4 | ====
-               5 | This is an admonition without a type.
-               6 | ====
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Admonition block must have a type [admonition.type.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [«NOTE»]
+                           4 | ====
+                           5 | This is an admonition without a type.
+                           6 | ====
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing admonition title")
     void shouldShowPlaceholderForMissingAdmonitionTitle(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring title for admonition blocks
         String rules = """
-            document:
-            
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - admonition:
-                        severity: error
-                        title:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - admonition:
+                            severity: error
+                            title:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing admonition title
         String adocContent = """
-            = Test Document
-            
-            [NOTE]
-            ====
-            This is an admonition without a title.
-            ====
-            """;
-        
+                = Test Document
+
+                [NOTE]
+                ====
+                This is an admonition without a title.
+                ====
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Admonition block requires a title [admonition.title.required]
-              File: %s:4-1
-              Actual: No title
-              Expected: Title required
-            
-               1 | = Test Document
-               2 |\s
-               3 | «.Title»
-               4 | [NOTE]
-               5 | ====
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Admonition block requires a title [admonition.title.required]
+                          File: %s:4-1
+                          Actual: No title
+                          Expected: Title required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «.Title»
+                           4 | [NOTE]
+                           5 | ====
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing admonition content")
     void shouldShowPlaceholderForMissingAdmonitionContent(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring content for admonition blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - admonition:
-                        severity: error
-                        content:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - admonition:
+                            severity: error
+                            content:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with empty admonition
         String adocContent = """
-            = Test Document
-            
-            [NOTE]
-            ====
-            ====
-            """;
-        
+                = Test Document
+
+                [NOTE]
+                ====
+                ====
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Admonition block requires content [admonition.content.required]
-              File: %s:4-1
-              Actual: No content
-              Expected: Content required
-            
-               1 | = Test Document
-               2 |\s
-               3 | [NOTE]
-               4 | ====
-               5 | «Content»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Admonition block requires content [admonition.content.required]
+                          File: %s:4-1
+                          Actual: No content
+                          Expected: Content required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [NOTE]
+                           4 | ====
+                           5 | «Content»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing sidebar title")
     void shouldShowPlaceholderForMissingSidebarTitle(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring title for sidebar blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - sidebar:
-                        severity: error
-                        title:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - sidebar:
+                            severity: error
+                            title:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing sidebar title
         String adocContent = """
-            = Test Document
-            
-            ****
-            This is a sidebar without a title.
-            ****
-            """;
-        
+                = Test Document
+
+                ****
+                This is a sidebar without a title.
+                ****
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Sidebar block requires a title [sidebar.title.required]
-              File: %s:3-1
-              Actual: No title
-              Expected: Title required
-            
-               1 | = Test Document
-               2 | «.Sidebar Title»
-               3 |\s
-               4 | ****
-               5 | This is a sidebar without a title.
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Sidebar block requires a title [sidebar.title.required]
+                          File: %s:3-1
+                          Actual: No title
+                          Expected: Title required
+
+                           1 | = Test Document
+                           2 | «.Sidebar Title»
+                           3 |\s
+                           4 | ****
+                           5 | This is a sidebar without a title.
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing sidebar content")
     void shouldShowPlaceholderForMissingSidebarContent(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring content for sidebar blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - sidebar:
-                        severity: error
-                        content:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - sidebar:
+                            severity: error
+                            content:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with empty sidebar
         String adocContent = """
-            = Test Document
-            
-            ****
-            ****
-            """;
-        
+                = Test Document
+
+                ****
+                ****
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Sidebar block requires content [sidebar.content.required]
-              File: %s:3:1
-              Actual: No content
-              Expected: Content required
-            
-               1 | = Test Document
-               2 |\s
-               3 | ****
-               4 | «Content»
-               5 | ****
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Sidebar block requires content [sidebar.content.required]
+                          File: %s:3:1
+                          Actual: No content
+                          Expected: Content required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | ****
+                           4 | «Content»
+                           5 | ****
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing sidebar position")
     void shouldShowPlaceholderForMissingSidebarPosition(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring position for sidebar blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - sidebar:
-                        severity: error
-                        position:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - sidebar:
+                            severity: error
+                            position:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing position attribute
         String adocContent = """
-            = Test Document
-            
-            ****
-            This is a sidebar without a position attribute.
-            ****
-            """;
-        
+                = Test Document
+
+                ****
+                This is a sidebar without a position attribute.
+                ****
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Sidebar block requires a position attribute [sidebar.position.required]
-              File: %s:3:1
-              Actual: No position attribute
-              Expected: Position attribute required
-            
-               1 | = Test Document
-               2 |\s
-               3 | «[position=left]»
-               4 | ****
-               5 | This is a sidebar without a position attribute.
-               6 | ****
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Sidebar block requires a position attribute [sidebar.position.required]
+                          File: %s:3:1
+                          Actual: No position attribute
+                          Expected: Position attribute required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «[position=left]»
+                           4 | ****
+                           5 | This is a sidebar without a position attribute.
+                           6 | ****
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing verse author")
     void shouldShowPlaceholderForMissingVerseAuthor(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring author for verse blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - verse:
-                        severity: error
-                        author:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - verse:
+                            severity: error
+                            author:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing verse author
         String adocContent = """
-            = Test Document
-            
-            [verse]
-            ____
-            Roses are red,
-            Violets are blue.
-            ____
-            """;
-        
+                = Test Document
+
+                [verse]
+                ____
+                Roses are red,
+                Violets are blue.
+                ____
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Verse author is required but not provided [verse.author.required]
-              File: %s:3:7
-              Actual: No author
-              Expected: Author required
-            
-               1 | = Test Document
-               2 |\s
-               3 | [verse,«author»]
-               4 | ____
-               5 | Roses are red,
-               6 | Violets are blue.
-               7 | ____
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Verse author is required but not provided [verse.author.required]
+                          File: %s:3:7
+                          Actual: No author
+                          Expected: Author required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [verse,«author»]
+                           4 | ____
+                           5 | Roses are red,
+                           6 | Violets are blue.
+                           7 | ____
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing verse attribution")
     void shouldShowPlaceholderForMissingVerseAttribution(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring attribution for verse blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - verse:
-                        severity: error
-                        attribution:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - verse:
+                            severity: error
+                            attribution:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing verse attribution
         String adocContent = """
-            = Test Document
-            
-            [verse]
-            ____
-            Roses are red,
-            Violets are blue.
-            ____
-            """;
-        
+                = Test Document
+
+                [verse]
+                ____
+                Roses are red,
+                Violets are blue.
+                ____
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Verse attribution is required but not provided [verse.attribution.required]
-              File: %s:3:7
-              Actual: No attribution
-              Expected: Attribution required
-            
-               1 | = Test Document
-               2 |\s
-               3 | [verse,«attribution»]
-               4 | ____
-               5 | Roses are red,
-               6 | Violets are blue.
-               7 | ____
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Verse attribution is required but not provided [verse.attribution.required]
+                          File: %s:3:7
+                          Actual: No attribution
+                          Expected: Attribution required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [verse,«attribution»]
+                           4 | ____
+                           5 | Roses are red,
+                           6 | Violets are blue.
+                           7 | ____
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing verse content")
     void shouldShowPlaceholderForMissingVerseContent(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring content for verse blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - verse:
-                        severity: error
-                        content:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - verse:
+                            severity: error
+                            content:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with empty verse
         String adocContent = """
-            = Test Document
-            
-            [verse]
-            ____
-            ____
-            """;
-        
+                = Test Document
+
+                [verse]
+                ____
+                ____
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Verse block requires content [verse.content.required]
-              File: %s:3:1
-              Actual: No content
-              Expected: Content required
-            
-               1 | = Test Document
-               2 |\s
-               3 | [verse]
-               4 | ____
-               5 | «Content»
-               6 | ____
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Verse block requires content [verse.content.required]
+                          File: %s:3:1
+                          Actual: No content
+                          Expected: Content required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | [verse]
+                           4 | ____
+                           5 | «Content»
+                           6 | ____
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing pass type")
     void shouldShowPlaceholderForMissingPassType(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring type for pass blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - pass:
-                        severity: error
-                        type:
-                          required: true
-                          severity: error
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - pass:
+                            severity: error
+                            type:
+                              required: true
+                              severity: error
+                """;
+
         // Given - AsciiDoc content with missing pass type
         String adocContent = """
-            = Test Document
-            
-            ++++
-            <p>This is a pass block without a type.</p>
-            ++++
-            """;
-        
+                = Test Document
+
+                ++++
+                <p>This is a pass block without a type.</p>
+                ++++
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Pass block requires a type [pass.type.required]
-              File: %s:3:1
-              Actual: No type specified
-              Expected: Type required (type attribute)
-            
-               1 | = Test Document
-               2 |\s
-               3 | «[pass,type=html]»
-               4 | ++++
-               5 | <p>This is a pass block without a type.</p>
-               6 | ++++
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Pass block requires a type [pass.type.required]
+                          File: %s:3:1
+                          Actual: No type specified
+                          Expected: Type required (type attribute)
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «[pass,type=html]»
+                           4 | ++++
+                           5 | <p>This is a pass block without a type.</p>
+                           6 | ++++
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing pass content")
     void shouldShowPlaceholderForMissingPassContent(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring content for pass blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - pass:
-                        severity: error
-                        content:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - pass:
+                            severity: error
+                            content:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with empty pass block
         String adocContent = """
-            = Test Document
-            
-            ++++
-            ++++
-            """;
-        
+                = Test Document
+
+                ++++
+                ++++
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Pass block requires content [pass.content.required]
-              File: %s:3:1
-              Actual: No content
-              Expected: Content required
-            
-               1 | = Test Document
-               2 |\s
-               3 | ++++
-               4 | «Content»
-               5 | ++++
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Pass block requires content [pass.content.required]
+                          File: %s:3:1
+                          Actual: No content
+                          Expected: Content required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | ++++
+                           4 | «Content»
+                           5 | ++++
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing pass reason")
     void shouldShowPlaceholderForMissingPassReason(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring reason for pass blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - pass:
-                        severity: error
-                        reason:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - pass:
+                            severity: error
+                            reason:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing reason
         String adocContent = """
-            = Test Document
-            
-            ++++
-            <p>This is a pass block without a reason.</p>
-            ++++
-            """;
-        
+                = Test Document
+
+                ++++
+                <p>This is a pass block without a reason.</p>
+                ++++
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Pass block requires a reason [pass.reason.required]
-              File: %s:3:1
-              Actual: No reason provided
-              Expected: Reason required (reason attribute)
-            
-               1 | = Test Document
-               2 |\s
-               3 | «[pass,reason="explanation"]»
-               4 | ++++
-               5 | <p>This is a pass block without a reason.</p>
-               6 | ++++
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Pass block requires a reason [pass.reason.required]
+                          File: %s:3:1
+                          Actual: No reason provided
+                          Expected: Reason required (reason attribute)
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «[pass,reason="explanation"]»
+                           4 | ++++
+                           5 | <p>This is a pass block without a reason.</p>
+                           6 | ++++
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing dlist description")
     void shouldShowPlaceholderForMissingDlistDescription(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring descriptions for dlist blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - dlist:
-                        severity: error
-                        descriptions:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - dlist:
+                            severity: error
+                            descriptions:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with term but missing description
         String adocContent = """
-            = Test Document
-            
-            Term1::
-            Term2::
-            """;
-        
+                = Test Document
+
+                Term1::
+                Term2::
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Definition list term missing required description [dlist.descriptions.required]
-              File: %s:3:1-5
-              Actual: No description
-              Expected: Description required
-            
-               1 | = Test Document
-               2 |\s
-               3 | Term1:: «Description»
-               4 | Term2::
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Definition list term missing required description [dlist.descriptions.required]
+                          File: %s:3:1-5
+                          Actual: No description
+                          Expected: Description required
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | Term1:: «Description»
+                           4 | Term2::
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing literal block title")
     void shouldShowPlaceholderForMissingLiteralBlockTitle(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring title for literal blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - literal:
-                        severity: error
-                        title:
-                          required: true
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - literal:
+                            severity: error
+                            title:
+                              required: true
+                """;
+
         // Given - AsciiDoc content with missing title
         String adocContent = """
-            = Test Document
-            
-            ....
-            This is a literal block without a title.
-            ....
-            """;
-        
+                = Test Document
+
+                ....
+                This is a literal block without a title.
+                ....
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Literal block requires a title [literal.title.required]
-              File: %s:3:1
-            
-               1 | = Test Document
-               2 |\s
-               3 | «.Title»
-               4 | ....
-               5 | This is a literal block without a title.
-               6 | ....
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Literal block requires a title [literal.title.required]
+                          File: %s:3:1
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | «.Title»
+                           4 | ....
+                           5 | This is a literal block without a title.
+                           6 | ....
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for literal block with insufficient indentation")
     void shouldShowPlaceholderForLiteralBlockInsufficientIndentation(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum indentation for literal blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - literal:
-                        severity: error
-                        indentation:
-                          required: true
-                          minSpaces: 4
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - literal:
+                            severity: error
+                            indentation:
+                              required: true
+                              minSpaces: 4
+                """;
+
         // Given - AsciiDoc content with insufficient indentation
         String adocContent = """
-            = Test Document
-            
-            ....
-            This line has no indentation.
-              This line has only 2 spaces.
-            ....
-            """;
-        
+                = Test Document
+
+                ....
+                This line has no indentation.
+                  This line has only 2 spaces.
+                ....
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Literal block requires minimum indentation of 4 spaces [literal.indentation.minSpaces]
-              File: %s:4:1
-              Actual: 0 spaces
-              Expected: At least 4 spaces
-            
-               1 | = Test Document
-               2 |\s
-               3 | ....
-               4 | «    »This line has no indentation.
-               5 |   This line has only 2 spaces.
-               6 | ....
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Literal block requires minimum indentation of 4 spaces [literal.indentation.minSpaces]
+                          File: %s:4:1
+                          Actual: 0 spaces
+                          Expected: At least 4 spaces
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | ....
+                           4 | «    »This line has no indentation.
+                           5 |   This line has only 2 spaces.
+                           6 | ....
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for ulist with too few items")
     void shouldShowPlaceholderForUlistWithTooFewItems(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum items for ulist blocks
         String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - ulist:
-                        severity: error
-                        items:
-                          min: 3
-            """;
-        
+                document:
+                  sections:
+                    - level: 0
+                      allowedBlocks:
+                        - ulist:
+                            severity: error
+                            items:
+                              min: 3
+                """;
+
         // Given - AsciiDoc content with only 2 items
         String adocContent = """
-            = Test Document
-            
-            * First item
-            * Second item
-            """;
-        
+                = Test Document
+
+                * First item
+                * Second item
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Unordered list has too few items [ulist.items.min]
-              File: %s:4:14
-              Actual: 2
-              Expected: At least 3 items
-            
-               1 | = Test Document
-               2 |\s
-               3 | * First item
-               4 | * Second item
-               5 | «* Item»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Unordered list has too few items [ulist.items.min]
+                          File: %s:4:14
+                          Actual: 2
+                          Expected: At least 3 items
+
+                           1 | = Test Document
+                           2 |\s
+                           3 | * First item
+                           4 | * Second item
+                           5 | «* Item»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing paragraph block when occurrence.min not met")
     void shouldShowPlaceholderForMissingParagraphBlockWithOccurrenceMin(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring minimum occurrence of paragraph block
         String rules = """
-            document:
-              sections:
-                - name: headerTitleRule
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 1
-                  title:
-                    pattern: "^[A-Za-z][A-Za-z0-9-]*$"
-                    severity: error
-                  allowedBlocks:
-                   - paragraph:
-                       severity: error
-                       occurrence:
-                         min: 1
-                         max: 1
-            """;
-        
+                document:
+                  sections:
+                    - name: headerTitleRule
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 1
+                      title:
+                        pattern: "^[A-Za-z][A-Za-z0-9-]*$"
+                        severity: error
+                      allowedBlocks:
+                       - paragraph:
+                           severity: error
+                           occurrence:
+                             min: 1
+                             max: 1
+                """;
+
         // Given - AsciiDoc content with only title, no paragraph
         String adocContent = """
-            = Accept
-            """;
-        
+                = Accept
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
-              File: %s:2
-              Actual: 0
-              Expected: At least 1 occurrences
-            
-               1 | = Accept
-               2 | «Paragraph content»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
+                          File: %s:2
+                          Actual: 0
+                          Expected: At least 1 occurrences
+
+                           1 | = Accept
+                           2 | «Paragraph content»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show multi-line placeholders for complex block types")
     void shouldShowMultiLinePlaceholdersForComplexBlockTypes(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring a table block
         String rules = """
-            document:
-              sections:
-                - name: documentTitle
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 1
-                  allowedBlocks:
-                    - table:
-                        severity: error
-                        occurrence:
-                          min: 1
-                          max: 1
-            """;
-        
+                document:
+                  sections:
+                    - name: documentTitle
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 1
+                      allowedBlocks:
+                        - table:
+                            severity: error
+                            occurrence:
+                              min: 1
+                              max: 1
+                """;
+
         // Given - AsciiDoc content missing the table
         String adocContent = """
-            = My Document
-            """;
-        
+                = My Document
+                """;
+
         // When - Validate and format output
         Path testFile = tempDir.resolve("test.adoc");
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify multi-line table placeholder with full output comparison
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Too few occurrences of block: table [block.occurrence.min]
-              File: %s:2
-              Actual: 0
-              Expected: At least 1 occurrences
-            
-               1 | = My Document
-               2 | «|===
-               3 | | Header 1 | Header 2
-               4 | | Data 1 | Data 2
-               5 | |===»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Too few occurrences of block: table [block.occurrence.min]
+                          File: %s:2
+                          Actual: 0
+                          Expected: At least 1 occurrences
+
+                           1 | = My Document
+                           2 | «|===
+                           3 | | Header 1 | Header 2
+                           4 | | Data 1 | Data 2
+                           5 | |===»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder at correct position for missing block in nested sections")
-    void shouldShowPlaceholderAtCorrectPositionForMissingBlockInNestedSections(@TempDir Path tempDir) throws IOException {
+    void shouldShowPlaceholderAtCorrectPositionForMissingBlockInNestedSections(@TempDir Path tempDir)
+            throws IOException {
         // Given - YAML rules with nested sections where listing block is required in level 2
         String rules = """
-            document:
-              sections:
-                - name: documentTitle
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 1
-                  title:
-                    pattern: "^[A-Z].*"
-                    severity: error
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        occurrence:
-                          min: 1
-                          severity: error
-                - name: mainSection
-                  level: 1
-                  title:
-                    pattern: "^[A-Z].*"
-                    severity: error
-                  allowedBlocks:
-                    - paragraph:
-                        severity: error
-                        occurrence:
-                          min: 1
-                          severity: error
-                  subsections:
-                    - name: subSection
-                      level: 2
+                document:
+                  sections:
+                    - name: documentTitle
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 1
                       title:
                         pattern: "^[A-Z].*"
                         severity: error
@@ -2985,427 +3061,464 @@ class PlaceholderHighlightIntegrationTest {
                             occurrence:
                               min: 1
                               severity: error
-                        - listing:
+                    - name: mainSection
+                      level: 1
+                      title:
+                        pattern: "^[A-Z].*"
+                        severity: error
+                      allowedBlocks:
+                        - paragraph:
                             severity: error
                             occurrence:
                               min: 1
                               severity: error
-            """;
-        
+                      subsections:
+                        - name: subSection
+                          level: 2
+                          title:
+                            pattern: "^[A-Z].*"
+                            severity: error
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                            - listing:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                """;
+
         // Given - AsciiDoc content missing the listing block in subsection and paragraph in main section
         String adocContent = """
-            = My Document
-            
-            This is a paragraph at document level.
-            
-            == Main Section
-            
-            === Sub Section
-            
-            This is a paragraph in the sub section.
-            """;
-        
+                = My Document
+
+                This is a paragraph at document level.
+
+                == Main Section
+
+                === Sub Section
+
+                This is a paragraph in the sub section.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify the placeholder appears after the subsection paragraph
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
-              File: %s:7
-              Actual: 0
-              Expected: At least 1 occurrences
-            
-               4 |\s
-               5 | == Main Section
-               6 |\s
-               7 | «Paragraph content»
-               8 |\s
-               9 | === Sub Section
-              10 |\s
-              11 | This is a paragraph in the sub section.
-            
-            [ERROR]: Too few occurrences of block: listing [block.occurrence.min]
-              File: %s:11
-              Actual: 0
-              Expected: At least 1 occurrences
-            
-               8 |\s
-               9 | This is a paragraph in the sub section.
-              10 |\s
-              11 | «[source]
-              12 | ----
-              13 | Code here
-              14 | ----»
-            
-            
-            """, testFile.toString(), testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
+                          File: %s:7
+                          Actual: 0
+                          Expected: At least 1 occurrences
+
+                           4 |\s
+                           5 | == Main Section
+                           6 |\s
+                           7 | «Paragraph content»
+                           8 |\s
+                           9 | === Sub Section
+                          10 |\s
+                          11 | This is a paragraph in the sub section.
+
+                        [ERROR]: Too few occurrences of block: listing [block.occurrence.min]
+                          File: %s:11
+                          Actual: 0
+                          Expected: At least 1 occurrences
+
+                           8 |\s
+                           9 | This is a paragraph in the sub section.
+                          10 |\s
+                          11 | «[source]
+                          12 | ----
+                          13 | Code here
+                          14 | ----»
+
+
+                        """,
+                testFile.toString(), testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder at correct line for missing paragraph block with dlist")
     void shouldShowPlaceholderAtCorrectLineForMissingBlock(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring paragraph block after dlist
         String rules = """
-            document:
-              sections:
-                - name: documentTitle
-                  level: 0
-                  occurrence:
-                    min: 1
-                    max: 1
-                  subsections:
-                    - name: contentSection
-                      level: 1
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 2
-                              severity: error
-                        - dlist:
-                            severity: error
-                            occurrence:
-                              min: 1
-            """;
-        
+                document:
+                  sections:
+                    - name: documentTitle
+                      level: 0
+                      occurrence:
+                        min: 1
+                        max: 1
+                      subsections:
+                        - name: contentSection
+                          level: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 2
+                                  severity: error
+                            - dlist:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                """;
+
         // Given - AsciiDoc content with dlist but missing second paragraph
         String adocContent = """
-            = Test Document
-            
-            == Content Section
-            
-            This is the first paragraph in the section.
-            
-            `<media-range>`:: Ein MIME-Typ in der Form `type/subtype`. Wildcards wie `text/*` oder `*/*` sind zulässig.
-            `q=<gewicht>`:: Optionaler Qualitätsfaktor zwischen 0 und 1 zur Priorisierung (Standard: 1). Höhere Werte bedeuten stärkere Präferenz.
-            
-            == Next Section
-            
-            Some other content here.
-            """;
-        
+                = Test Document
+
+                == Content Section
+
+                This is the first paragraph in the section.
+
+                `<media-range>`:: Ein MIME-Typ in der Form `type/subtype`. Wildcards wie `text/*` oder `*/*` sind zulässig.
+                `q=<gewicht>`:: Optionaler Qualitätsfaktor zwischen 0 und 1 zur Priorisierung (Standard: 1). Höhere Werte bedeuten stärkere Präferenz.
+
+                == Next Section
+
+                Some other content here.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
         System.out.println(actualOutput);
-        
+
         // Then - Verify exact console output with placeholder at correct position
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
-              File: %s:10
-              Actual: 1
-              Expected: At least 2 occurrences
-            
-               7 | `<media-range>`:: Ein MIME-Typ in der Form `type/subtype`. Wildcards wie `text/*` oder `*/*` sind zulässig.
-               8 | `q=<gewicht>`:: Optionaler Qualitätsfaktor zwischen 0 und 1 zur Priorisierung (Standard: 1). Höhere Werte bedeuten stärkere Präferenz.
-               9 |\s
-              10 | «Paragraph content»
-              11 |\s
-              12 | == Next Section
-              13 |\s
-              14 | Some other content here.
-            
-            [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
-              File: %s:14
-              Actual: 1
-              Expected: At least 2 occurrences
-            
-              11 |\s
-              12 | Some other content here.
-              13 |\s
-              14 | «Paragraph content»
-            
-            [ERROR]: Too few occurrences of block: dlist [block.occurrence.min]
-              File: %s:14
-              Actual: 0
-              Expected: At least 1 occurrences
-            
-              11 |\s
-              12 | Some other content here.
-              13 |\s
-              14 | «Term:: Description»
-            
-            
-            """, testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
+                          File: %s:10
+                          Actual: 1
+                          Expected: At least 2 occurrences
+
+                           7 | `<media-range>`:: Ein MIME-Typ in der Form `type/subtype`. Wildcards wie `text/*` oder `*/*` sind zulässig.
+                           8 | `q=<gewicht>`:: Optionaler Qualitätsfaktor zwischen 0 und 1 zur Priorisierung (Standard: 1). Höhere Werte bedeuten stärkere Präferenz.
+                           9 |\s
+                          10 | «Paragraph content»
+                          11 |\s
+                          12 | == Next Section
+                          13 |\s
+                          14 | Some other content here.
+
+                        [ERROR]: Too few occurrences of block: paragraph [block.occurrence.min]
+                          File: %s:14
+                          Actual: 1
+                          Expected: At least 2 occurrences
+
+                          11 |\s
+                          12 | Some other content here.
+                          13 |\s
+                          14 | «Paragraph content»
+
+                        [ERROR]: Too few occurrences of block: dlist [block.occurrence.min]
+                          File: %s:14
+                          Actual: 0
+                          Expected: At least 1 occurrences
+
+                          11 |\s
+                          12 | Some other content here.
+                          13 |\s
+                          14 | «Term:: Description»
+
+
+                        """,
+                testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing metadata attribute with document title")
     void shouldShowPlaceholderForMissingMetadataAttributeWithTitle(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring author metadata attribute
         String rules = """
-            document:
-              metadata:
-                attributes:
-                  - name: author
-                    required: true
-                    severity: error
-            """;
-        
+                document:
+                  metadata:
+                    attributes:
+                      - name: author
+                        required: true
+                        severity: error
+                """;
+
         // Given - AsciiDoc content with title but missing author
         String adocContent = """
-            = Test Document
-            :email: test@example.com
-            
-            Some content here.
-            """;
-        
+                = Test Document
+                :email: test@example.com
+
+                Some content here.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required attribute 'author' [metadata.required]
-              File: %s:3:1
-              Expected: Attribute must be present
-            
-               1 | = Test Document
-               2 | :email: test@example.com
-               3 | «:author: value»
-               4 |\s
-               5 | Some content here.
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required attribute 'author' [metadata.required]
+                          File: %s:3:1
+                          Expected: Attribute must be present
+
+                           1 | = Test Document
+                           2 | :email: test@example.com
+                           3 | «:author: value»
+                           4 |\s
+                           5 | Some content here.
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing metadata attribute without document title")
     void shouldShowPlaceholderForMissingMetadataAttributeWithoutTitle(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring author metadata attribute
         String rules = """
-            document:
-              metadata:
-                attributes:
-                  - name: author
-                    required: true
-                    severity: error
-            """;
-        
+                document:
+                  metadata:
+                    attributes:
+                      - name: author
+                        required: true
+                        severity: error
+                """;
+
         // Given - AsciiDoc content without title and missing author
         String adocContent = """
-            :email: test@example.com
-            
-            Some content here.
-            """;
-        
+                :email: test@example.com
+
+                Some content here.
+                """;
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required attribute 'author' [metadata.required]
-              File: %s:2:1
-              Expected: Attribute must be present
-            
-               1 | :email: test@example.com
-               2 | «:author: value»
-               3 |\s
-               4 | Some content here.
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required attribute 'author' [metadata.required]
+                          File: %s:2:1
+                          Expected: Attribute must be present
+
+                           1 | :email: test@example.com
+                           2 | «:author: value»
+                           3 |\s
+                           4 | Some content here.
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing metadata attribute with front matter")
     void shouldShowPlaceholderForMissingMetadataAttributeWithFrontMatter(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring author metadata attribute
         String rules = """
-            document:
-              metadata:
-                attributes:
-                  - name: author
-                    required: true
-                    severity: error
-            """;
-        
+                document:
+                  metadata:
+                    attributes:
+                      - name: author
+                        required: true
+                        severity: error
+                """;
+
         // Given - AsciiDoc content with front matter and missing author
         String adocContent = """
-            ---
-            title: Test Document
-            date: 2024-01-01
-            ---
-            = Test Document
-            :email: test@example.com
-            
-            Some content here.
-            """;
-        
+                ---
+                title: Test Document
+                date: 2024-01-01
+                ---
+                = Test Document
+                :email: test@example.com
+
+                Some content here.
+                """;
+
         // When - Validate and format output with more context lines
         String actualOutput = validateAndFormat(rules, adocContent, tempDir, createDefaultOutputConfig(4));
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required attribute 'author' [metadata.required]
-              File: %s:7:1
-              Expected: Attribute must be present
-            
-               3 | date: 2024-01-01
-               4 | ---
-               5 | = Test Document
-               6 | :email: test@example.com
-               7 | «:author: value»
-               8 |\s
-               9 | Some content here.
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required attribute 'author' [metadata.required]
+                          File: %s:7:1
+                          Expected: Attribute must be present
+
+                           3 | date: 2024-01-01
+                           4 | ---
+                           5 | = Test Document
+                           6 | :email: test@example.com
+                           7 | «:author: value»
+                           8 |\s
+                           9 | Some content here.
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for missing metadata attribute in empty document")
     void shouldShowPlaceholderForMissingMetadataAttributeInEmptyDocument(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring author metadata attribute
         String rules = """
-            document:
-              metadata:
-                attributes:
-                  - name: author
-                    required: true
-                    severity: error
-            """;
-        
+                document:
+                  metadata:
+                    attributes:
+                      - name: author
+                        required: true
+                        severity: error
+                """;
+
         // Given - Empty AsciiDoc content
         String adocContent = "";
-        
+
         // When - Validate and format output
         String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
+
         // Then - Verify exact console output with placeholder
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required attribute 'author' [metadata.required]
-              File: %s:1:1
-              Expected: Attribute must be present
-            
-               1 | «:author: value»
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required attribute 'author' [metadata.required]
+                          File: %s:1:1
+                          Expected: Attribute must be present
+
+                           1 | «:author: value»
+
+
+                        """,
+                testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
     @Test
     @DisplayName("should show placeholder for multiple missing metadata attributes")
     void shouldShowPlaceholderForMultipleMissingMetadataAttributes(@TempDir Path tempDir) throws IOException {
         // Given - YAML rules requiring multiple metadata attributes
         String rules = """
-            document:
-              metadata:
-                attributes:
-                  - name: author
-                    required: true
-                    severity: error
-                  - name: version
-                    required: true
-                    severity: error
-                  - name: revdate
-                    required: true
-                    severity: error
-            """;
-        
+                document:
+                  metadata:
+                    attributes:
+                      - name: author
+                        required: true
+                        severity: error
+                      - name: version
+                        required: true
+                        severity: error
+                      - name: revdate
+                        required: true
+                        severity: error
+                """;
+
         // Given - AsciiDoc content with title but missing all required attributes
         String adocContent = """
-            = Test Document
-            
-            Some content here.
-            """;
-        
+                = Test Document
+
+                Some content here.
+                """;
+
         // When - Validate and format output with more context lines
         String actualOutput = validateAndFormat(rules, adocContent, tempDir, createDefaultOutputConfig(6));
-        
+
         // Then - Verify exact console output with placeholders
         Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Missing required attribute 'revdate' [metadata.required]
-              File: %s:2:1
-              Expected: Attribute must be present
-            
-               1 | = Test Document
-               2 | «:revdate: value»
-               3 |\s
-               4 | Some content here.
-            
-            [ERROR]: Missing required attribute 'version' [metadata.required]
-              File: %s:2:1
-              Expected: Attribute must be present
-            
-               1 | = Test Document
-               2 | «:version: value»
-               3 |\s
-               4 | Some content here.
-            
-            [ERROR]: Missing required attribute 'author' [metadata.required]
-              File: %s:2:1
-              Expected: Attribute must be present
-            
-               1 | = Test Document
-               2 | «:author: value»
-               3 |\s
-               4 | Some content here.
-            
-            
-            """, testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
-        
+        String expectedOutput = String.format(
+                """
+                        +----------------------------------------------------------------------------------------------------------------------+
+                        |                                                  Validation Report                                                   |
+                        +----------------------------------------------------------------------------------------------------------------------+
+
+                        %s:
+
+                        [ERROR]: Missing required attribute 'revdate' [metadata.required]
+                          File: %s:2:1
+                          Expected: Attribute must be present
+
+                           1 | = Test Document
+                           2 | «:revdate: value»
+                           3 |\s
+                           4 | Some content here.
+
+                        [ERROR]: Missing required attribute 'version' [metadata.required]
+                          File: %s:2:1
+                          Expected: Attribute must be present
+
+                           1 | = Test Document
+                           2 | «:version: value»
+                           3 |\s
+                           4 | Some content here.
+
+                        [ERROR]: Missing required attribute 'author' [metadata.required]
+                          File: %s:2:1
+                          Expected: Attribute must be present
+
+                           1 | = Test Document
+                           2 | «:author: value»
+                           3 |\s
+                           4 | Some content here.
+
+
+                        """,
+                testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
+
         assertEquals(expectedOutput, actualOutput);
     }
-    
+
 }

--- a/src/test/java/com/dataliquid/asciidoc/linter/highlight/UnderlineHighlightIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/highlight/UnderlineHighlightIntegrationTest.java
@@ -29,18 +29,17 @@ import com.dataliquid.asciidoc.linter.report.ConsoleFormatter;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 /**
- * Integration test for underline highlighting in console output.
- * Tests that validation errors properly underline problematic text areas,
- * especially for maxLength and minLength validation rules.
+ * Integration test for underline highlighting in console output. Tests that validation errors properly underline
+ * problematic text areas, especially for maxLength and minLength validation rules.
  */
 @DisplayName("Underline Highlight Integration Test")
 class UnderlineHighlightIntegrationTest {
-    
+
     private Linter linter;
     private ConfigurationLoader configLoader;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
-    
+
     @BeforeEach
     void setUp() {
         linter = new Linter();
@@ -48,3591 +47,3672 @@ class UnderlineHighlightIntegrationTest {
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
-    
+
     @AfterEach
     void tearDown() {
         linter.close();
     }
-    
+
     /**
      * Creates the default output configuration for underline display.
      */
     private OutputConfiguration createDefaultOutputConfig() {
-        return OutputConfiguration.builder()
-            .format(OutputFormat.ENHANCED)
-            .display(DisplayConfig.builder()
-                .contextLines(3)
-                .useColors(false)  // No colors for easier testing
-                .showLineNumbers(true)
-                .showHeader(true)  // Enable header to match expected output
-                .highlightStyle(HighlightStyle.UNDERLINE) // Enable underline highlighting
-                .maxLineWidth(120)
-                .build())
-            .suggestions(SuggestionsConfig.builder()
-                .enabled(false)
-                .build())
-            .errorGrouping(ErrorGroupingConfig.builder()
-                .enabled(false)  // Disable error grouping for predictable output
-                .build())
-            .summary(SummaryConfig.builder()
-                .enabled(false)
-                .build())
-            .build();
+        return OutputConfiguration.builder().format(OutputFormat.ENHANCED)
+                .display(DisplayConfig.builder().contextLines(3).useColors(false) // No colors for easier testing
+                        .showLineNumbers(true).showHeader(true) // Enable header to match expected output
+                        .highlightStyle(HighlightStyle.UNDERLINE) // Enable underline highlighting
+                        .maxLineWidth(120).build())
+                .suggestions(SuggestionsConfig.builder().enabled(false).build())
+                .errorGrouping(ErrorGroupingConfig.builder().enabled(false) // Disable error grouping for predictable
+                                                                            // output
+                        .build())
+                .summary(SummaryConfig.builder().enabled(false).build()).build();
     }
-    
+
     /**
      * Validates content and returns the formatted console output.
      */
     private String validateAndFormat(String rules, String adocContent, Path tempDir) throws IOException {
         // Clear any previous output
         stringWriter.getBuffer().setLength(0);
-        
+
         // Create temporary file with content
         Path testFile = tempDir.resolve("test.adoc");
         Files.writeString(testFile, adocContent);
-        
+
         // Load configuration and validate
         LinterConfiguration config = configLoader.loadConfiguration(rules);
         ValidationResult result = linter.validateFile(testFile, config);
-        
+
         // Format output
         ConsoleFormatter formatter = new ConsoleFormatter(createDefaultOutputConfig());
         formatter.format(result, printWriter);
         printWriter.flush();
-        
+
         return stringWriter.toString();
     }
-    
+
     @Nested
     @DisplayName("DList Validation Tests")
     class DlistValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for dlist term exceeding max length")
         void shouldShowUnderlineForDlistTermExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for dlist terms
-        String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - dlist:
-                        severity: error
-                        terms:
-                          maxLength: 20
-                          severity: error
-            """;
-        
-        // Given - AsciiDoc content with a term exceeding max length
-        String adocContent = """
-            = Test Document
-            
-            This is a very long definition list term that exceeds twenty characters::
-              The description for the long term.
-            
-            Short term::
-              Another description.
-            """;
-        
-        // When - Validate and format output
-        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
-        // Then - Verify exact console output with underline
-        Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Definition list term is too long [dlist.terms.maxLength]
-              File: %s:3:1-71
-              Actual: This is a very long definition list term that exceeds twenty characters (length: 71)
-              Expected: Maximum length: 20
-            
-               1 | = Test Document
-               2 |\s
-               3 | This is a very long definition list term that exceeds twenty characters::
-                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-               4 |   The description for the long term.
-               5 |\s
-               6 | Short term::
-            
-            
-            """, testFile.toString(), testFile.toString());
-        
-        assertEquals(expectedOutput, actualOutput);
-    }
-    
+            String rules = """
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                terms:
+                                  maxLength: 20
+                                  severity: error
+                    """;
+
+            // Given - AsciiDoc content with a term exceeding max length
+            String adocContent = """
+                    = Test Document
+
+                    This is a very long definition list term that exceeds twenty characters::
+                      The description for the long term.
+
+                    Short term::
+                      Another description.
+                    """;
+
+            // When - Validate and format output
+            String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+
+            // Then - Verify exact console output with underline
+            Path testFile = tempDir.resolve("test.adoc");
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Definition list term is too long [dlist.terms.maxLength]
+                              File: %s:3:1-71
+                              Actual: This is a very long definition list term that exceeds twenty characters (length: 71)
+                              Expected: Maximum length: 20
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | This is a very long definition list term that exceeds twenty characters::
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 |   The description for the long term.
+                               5 |\s
+                               6 | Short term::
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
+            assertEquals(expectedOutput, actualOutput);
+        }
+
         @Test
         @DisplayName("should show underline for dlist term below min length")
         void shouldShowUnderlineForDlistTermBelowMinLength(@TempDir Path tempDir) throws IOException {
-        // Given - YAML rules with min length for dlist terms
-        String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - dlist:
-                        severity: error
-                        terms:
-                          minLength: 10
-                          severity: warn
-            """;
-        
-        // Given - AsciiDoc content with a term below min length
-        String adocContent = """
-            = Test Document
-            
-            API::
-              Application Programming Interface
-            
-            Term::
-              This term is too short
-            """;
-        
-        // When - Validate and format output
-        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
-        // Then - Verify exact console output with underline
-        Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [WARN]: Definition list term is too short [dlist.terms.minLength]
-              File: %s:3:1-3
-              Actual: API (length: 3)
-              Expected: Minimum length: 10
-            
-               1 | = Test Document
-               2 |\s
-               3 | API::
-                 | ~~~
-               4 |   Application Programming Interface
-               5 |\s
-               6 | Term::
-            
-            [WARN]: Definition list term is too short [dlist.terms.minLength]
-              File: %s:6:1-4
-              Actual: Term (length: 4)
-              Expected: Minimum length: 10
-            
-               3 | API::
-               4 |   Application Programming Interface
-               5 |\s
-               6 | Term::
-                 | ~~~~
-               7 |   This term is too short
-            
-            
-            """, testFile.toString(), testFile.toString(), testFile.toString());
-        
-        assertEquals(expectedOutput, actualOutput);
-    }
-    
-    
+            // Given - YAML rules with min length for dlist terms
+            String rules = """
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                terms:
+                                  minLength: 10
+                                  severity: warn
+                    """;
+
+            // Given - AsciiDoc content with a term below min length
+            String adocContent = """
+                    = Test Document
+
+                    API::
+                      Application Programming Interface
+
+                    Term::
+                      This term is too short
+                    """;
+
+            // When - Validate and format output
+            String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+
+            // Then - Verify exact console output with underline
+            Path testFile = tempDir.resolve("test.adoc");
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Definition list term is too short [dlist.terms.minLength]
+                              File: %s:3:1-3
+                              Actual: API (length: 3)
+                              Expected: Minimum length: 10
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | API::
+                                 | ~~~
+                               4 |   Application Programming Interface
+                               5 |\s
+                               6 | Term::
+
+                            [WARN]: Definition list term is too short [dlist.terms.minLength]
+                              File: %s:6:1-4
+                              Actual: Term (length: 4)
+                              Expected: Minimum length: 10
+
+                               3 | API::
+                               4 |   Application Programming Interface
+                               5 |\s
+                               6 | Term::
+                                 | ~~~~
+                               7 |   This term is too short
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
+            assertEquals(expectedOutput, actualOutput);
+        }
+
         @Test
         @DisplayName("should show underline for dlist term not matching pattern")
         void shouldShowUnderlineForDlistTermNotMatchingPattern(@TempDir Path tempDir) throws IOException {
-        // Given - YAML rules with pattern for dlist terms
-        String rules = """
-            document:
-              sections:
-                - level: 0
-                  allowedBlocks:
-                    - dlist:
-                        severity: error
-                        terms:
-                          pattern: "^[A-Z][A-Z0-9_]+$"
-                          severity: error
-            """;
-        
-        // Given - AsciiDoc content with terms not matching the pattern
-        String adocContent = """
-            = Test Document
-            
-            lowercase_term::
-              This term starts with lowercase.
-            
-            VALID_TERM::
-              This term matches the pattern.
-            
-            Mixed-Case::
-              This term has invalid characters.
-            """;
-        
-        // When - Validate and format output
-        String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-        
-        // Then - Verify exact console output with underline
-        Path testFile = tempDir.resolve("test.adoc");
-        String expectedOutput = String.format("""
-            +----------------------------------------------------------------------------------------------------------------------+
-            |                                                  Validation Report                                                   |
-            +----------------------------------------------------------------------------------------------------------------------+
-            
-            %s:
-            
-            [ERROR]: Definition list term does not match required pattern [dlist.terms.pattern]
-              File: %s:3:1-14
-              Actual: lowercase_term
-              Expected: Pattern: ^[A-Z][A-Z0-9_]+$
-            
-               1 | = Test Document
-               2 |\s
-               3 | lowercase_term::
-                 | ~~~~~~~~~~~~~~
-               4 |   This term starts with lowercase.
-               5 |\s
-               6 | VALID_TERM::
-            
-            [ERROR]: Definition list term does not match required pattern [dlist.terms.pattern]
-              File: %s:9:1-10
-              Actual: Mixed-Case
-              Expected: Pattern: ^[A-Z][A-Z0-9_]+$
-            
-               6 | VALID_TERM::
-               7 |   This term matches the pattern.
-               8 |\s
-               9 | Mixed-Case::
-                 | ~~~~~~~~~~
-              10 |   This term has invalid characters.
-            
-            
-            """, testFile.toString(), testFile.toString(), testFile.toString());
-        
-        assertEquals(expectedOutput, actualOutput);
+            // Given - YAML rules with pattern for dlist terms
+            String rules = """
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                terms:
+                                  pattern: "^[A-Z][A-Z0-9_]+$"
+                                  severity: error
+                    """;
+
+            // Given - AsciiDoc content with terms not matching the pattern
+            String adocContent = """
+                    = Test Document
+
+                    lowercase_term::
+                      This term starts with lowercase.
+
+                    VALID_TERM::
+                      This term matches the pattern.
+
+                    Mixed-Case::
+                      This term has invalid characters.
+                    """;
+
+            // When - Validate and format output
+            String actualOutput = validateAndFormat(rules, adocContent, tempDir);
+
+            // Then - Verify exact console output with underline
+            Path testFile = tempDir.resolve("test.adoc");
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Definition list term does not match required pattern [dlist.terms.pattern]
+                              File: %s:3:1-14
+                              Actual: lowercase_term
+                              Expected: Pattern: ^[A-Z][A-Z0-9_]+$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | lowercase_term::
+                                 | ~~~~~~~~~~~~~~
+                               4 |   This term starts with lowercase.
+                               5 |\s
+                               6 | VALID_TERM::
+
+                            [ERROR]: Definition list term does not match required pattern [dlist.terms.pattern]
+                              File: %s:9:1-10
+                              Actual: Mixed-Case
+                              Expected: Pattern: ^[A-Z][A-Z0-9_]+$
+
+                               6 | VALID_TERM::
+                               7 |   This term matches the pattern.
+                               8 |\s
+                               9 | Mixed-Case::
+                                 | ~~~~~~~~~~
+                              10 |   This term has invalid characters.
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
+            assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Image Block Validation Tests")
     class ImageValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for image URL not matching pattern")
         void shouldShowUnderlineForImageUrlPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with URL pattern for image blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - image:
-                            severity: error
-                            url:
-                              required: true
-                              pattern: "^https?://.*\\\\.(jpg|jpeg|png|gif|svg)$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - image:
+                                severity: error
+                                url:
+                                  required: true
+                                  pattern: "^https?://.*\\\\.(jpg|jpeg|png|gif|svg)$"
+                    """;
+
             // Given - AsciiDoc content with image URLs not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                image::file:///local/path/image.png[Local file]
-                
-                image::https://example.com/image.bmp[Wrong format]
-                
-                image::https://example.com/valid.png[Valid image]
-                """;
-            
+                    = Test Document
+
+                    image::file:///local/path/image.png[Local file]
+
+                    image::https://example.com/image.bmp[Wrong format]
+
+                    image::https://example.com/valid.png[Valid image]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Image URL does not match required pattern [image.url.pattern]
-                  File: %s:3:8-35
-                  Actual: file:///local/path/image.png
-                  Expected: Pattern: ^https?://.*\\.(jpg|jpeg|png|gif|svg)$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | image::file:///local/path/image.png[Local file]
-                     |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 |\s
-                   5 | image::https://example.com/image.bmp[Wrong format]
-                   6 |\s
-                
-                [ERROR]: Image URL does not match required pattern [image.url.pattern]
-                  File: %s:5:8-36
-                  Actual: https://example.com/image.bmp
-                  Expected: Pattern: ^https?://.*\\.(jpg|jpeg|png|gif|svg)$
-                
-                   2 |\s
-                   3 | image::file:///local/path/image.png[Local file]
-                   4 |\s
-                   5 | image::https://example.com/image.bmp[Wrong format]
-                     |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 |\s
-                   7 | image::https://example.com/valid.png[Valid image]
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Image URL does not match required pattern [image.url.pattern]
+                              File: %s:3:8-35
+                              Actual: file:///local/path/image.png
+                              Expected: Pattern: ^https?://.*\\.(jpg|jpeg|png|gif|svg)$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | image::file:///local/path/image.png[Local file]
+                                 |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 |\s
+                               5 | image::https://example.com/image.bmp[Wrong format]
+                               6 |\s
+
+                            [ERROR]: Image URL does not match required pattern [image.url.pattern]
+                              File: %s:5:8-36
+                              Actual: https://example.com/image.bmp
+                              Expected: Pattern: ^https?://.*\\.(jpg|jpeg|png|gif|svg)$
+
+                               2 |\s
+                               3 | image::file:///local/path/image.png[Local file]
+                               4 |\s
+                               5 | image::https://example.com/image.bmp[Wrong format]
+                                 |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 |\s
+                               7 | image::https://example.com/valid.png[Valid image]
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for image alt text exceeding max length")
         void shouldShowUnderlineForImageAltExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for image alt text
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - image:
-                            severity: error
-                            alt:
-                              required: true
-                              maxLength: 30
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - image:
+                                severity: error
+                                alt:
+                                  required: true
+                                  maxLength: 30
+                    """;
+
             // Given - AsciiDoc content with alt text exceeding max length
             String adocContent = """
-                = Test Document
-                
-                image::diagram.png[This is a very long alternative text that exceeds the maximum allowed length]
-                
-                image::logo.png[Short alt text]
-                
-                image::chart.png[Another extremely long alternative text description that should be shorter]
-                """;
-            
+                    = Test Document
+
+                    image::diagram.png[This is a very long alternative text that exceeds the maximum allowed length]
+
+                    image::logo.png[Short alt text]
+
+                    image::chart.png[Another extremely long alternative text description that should be shorter]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Image alt text is too long [image.alt.maxLength]
-                  File: %s:3:20-95
-                  Actual: 76 characters
-                  Expected: At most 30 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | image::diagram.png[This is a very long alternative text that exceeds the maximum allowed length]
-                     |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 |\s
-                   5 | image::logo.png[Short alt text]
-                   6 |\s
-                
-                [ERROR]: Image alt text is too long [image.alt.maxLength]
-                  File: %s:7:18-91
-                  Actual: 74 characters
-                  Expected: At most 30 characters
-                
-                   4 |\s
-                   5 | image::logo.png[Short alt text]
-                   6 |\s
-                   7 | image::chart.png[Another extremely long alternative text description that should be shorter]
-                     |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Image alt text is too long [image.alt.maxLength]
+                              File: %s:3:20-95
+                              Actual: 76 characters
+                              Expected: At most 30 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | image::diagram.png[This is a very long alternative text that exceeds the maximum allowed length]
+                                 |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 |\s
+                               5 | image::logo.png[Short alt text]
+                               6 |\s
+
+                            [ERROR]: Image alt text is too long [image.alt.maxLength]
+                              File: %s:7:18-91
+                              Actual: 74 characters
+                              Expected: At most 30 characters
+
+                               4 |\s
+                               5 | image::logo.png[Short alt text]
+                               6 |\s
+                               7 | image::chart.png[Another extremely long alternative text description that should be shorter]
+                                 |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for image alt text below min length")
         void shouldShowUnderlineForImageAltBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for image alt text
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - image:
-                            severity: warn
-                            alt:
-                              required: true
-                              minLength: 10
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - image:
+                                severity: warn
+                                alt:
+                                  required: true
+                                  minLength: 10
+                    """;
+
             // Given - AsciiDoc content with alt text below min length
             String adocContent = """
-                = Test Document
-                
-                image::icon.png[Logo]
-                
-                image::screenshot.png[Application screenshot showing main window]
-                
-                image::btn.png[OK]
-                """;
-            
+                    = Test Document
+
+                    image::icon.png[Logo]
+
+                    image::screenshot.png[Application screenshot showing main window]
+
+                    image::btn.png[OK]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Image alt text is too short [image.alt.minLength]
-                  File: %s:3:17-20
-                  Actual: 4 characters
-                  Expected: At least 10 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | image::icon.png[Logo]
-                     |                 ~~~~
-                   4 |\s
-                   5 | image::screenshot.png[Application screenshot showing main window]
-                   6 |\s
-                
-                [WARN]: Image alt text is too short [image.alt.minLength]
-                  File: %s:7:16-17
-                  Actual: 2 characters
-                  Expected: At least 10 characters
-                
-                   4 |\s
-                   5 | image::screenshot.png[Application screenshot showing main window]
-                   6 |\s
-                   7 | image::btn.png[OK]
-                     |                ~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Image alt text is too short [image.alt.minLength]
+                              File: %s:3:17-20
+                              Actual: 4 characters
+                              Expected: At least 10 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | image::icon.png[Logo]
+                                 |                 ~~~~
+                               4 |\s
+                               5 | image::screenshot.png[Application screenshot showing main window]
+                               6 |\s
+
+                            [WARN]: Image alt text is too short [image.alt.minLength]
+                              File: %s:7:16-17
+                              Actual: 2 characters
+                              Expected: At least 10 characters
+
+                               4 |\s
+                               5 | image::screenshot.png[Application screenshot showing main window]
+                               6 |\s
+                               7 | image::btn.png[OK]
+                                 |                ~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Video Block Validation Tests")
     class VideoValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for video URL not matching pattern")
         void shouldShowUnderlineForVideoUrlPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with URL pattern for video blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - video:
-                            severity: error
-                            url:
-                              required: true
-                              pattern: "^https?://.*\\\\.(mp4|webm|ogg|avi)$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - video:
+                                severity: error
+                                url:
+                                  required: true
+                                  pattern: "^https?://.*\\\\.(mp4|webm|ogg|avi)$"
+                    """;
+
             // Given - AsciiDoc content with video URLs not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                video::file:///local/video.mp4[Local video file]
-                
-                video::https://example.com/video.mov[Unsupported format]
-                
-                video::https://example.com/demo.mp4[Valid video]
-                """;
-            
+                    = Test Document
+
+                    video::file:///local/video.mp4[Local video file]
+
+                    video::https://example.com/video.mov[Unsupported format]
+
+                    video::https://example.com/demo.mp4[Valid video]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Video URL does not match required pattern [video.url.pattern]
-                  File: %s:3:8-30
-                  Actual: file:///local/video.mp4
-                  Expected: ^https?://.*\\.(mp4|webm|ogg|avi)$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | video::file:///local/video.mp4[Local video file]
-                     |        ~~~~~~~~~~~~~~~~~~~~~~~
-                   4 |\s
-                   5 | video::https://example.com/video.mov[Unsupported format]
-                   6 |\s
-                
-                [ERROR]: Video URL does not match required pattern [video.url.pattern]
-                  File: %s:5:8-36
-                  Actual: https://example.com/video.mov
-                  Expected: ^https?://.*\\.(mp4|webm|ogg|avi)$
-                
-                   2 |\s
-                   3 | video::file:///local/video.mp4[Local video file]
-                   4 |\s
-                   5 | video::https://example.com/video.mov[Unsupported format]
-                     |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 |\s
-                   7 | video::https://example.com/demo.mp4[Valid video]
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Video URL does not match required pattern [video.url.pattern]
+                              File: %s:3:8-30
+                              Actual: file:///local/video.mp4
+                              Expected: ^https?://.*\\.(mp4|webm|ogg|avi)$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | video::file:///local/video.mp4[Local video file]
+                                 |        ~~~~~~~~~~~~~~~~~~~~~~~
+                               4 |\s
+                               5 | video::https://example.com/video.mov[Unsupported format]
+                               6 |\s
+
+                            [ERROR]: Video URL does not match required pattern [video.url.pattern]
+                              File: %s:5:8-36
+                              Actual: https://example.com/video.mov
+                              Expected: ^https?://.*\\.(mp4|webm|ogg|avi)$
+
+                               2 |\s
+                               3 | video::file:///local/video.mp4[Local video file]
+                               4 |\s
+                               5 | video::https://example.com/video.mov[Unsupported format]
+                                 |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 |\s
+                               7 | video::https://example.com/demo.mp4[Valid video]
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for video poster not matching pattern")
         void shouldShowUnderlineForVideoPosterPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with poster pattern for video blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - video:
-                            severity: error
-                            poster:
-                              required: true
-                              pattern: "^https?://.*\\\\.(jpg|jpeg|png)$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - video:
+                                severity: error
+                                poster:
+                                  required: true
+                                  pattern: "^https?://.*\\\\.(jpg|jpeg|png)$"
+                    """;
+
             // Given - AsciiDoc content with poster URLs not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                video::https://example.com/video.mp4[poster=file:///local/poster.jpg]
-                
-                video::https://example.com/video.mp4[poster=https://example.com/poster.bmp]
-                
-                video::https://example.com/video.mp4[poster=https://example.com/poster.png]
-                """;
-            
+                    = Test Document
+
+                    video::https://example.com/video.mp4[poster=file:///local/poster.jpg]
+
+                    video::https://example.com/video.mp4[poster=https://example.com/poster.bmp]
+
+                    video::https://example.com/video.mp4[poster=https://example.com/poster.png]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Video poster does not match required pattern [video.poster.pattern]
-                  File: %s:3:45-68
-                  Actual: file:///local/poster.jpg
-                  Expected: ^https?://.*\\.(jpg|jpeg|png)$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | video::https://example.com/video.mp4[poster=file:///local/poster.jpg]
-                     |                                             ~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 |\s
-                   5 | video::https://example.com/video.mp4[poster=https://example.com/poster.bmp]
-                   6 |\s
-                
-                [ERROR]: Video poster does not match required pattern [video.poster.pattern]
-                  File: %s:5:45-74
-                  Actual: https://example.com/poster.bmp
-                  Expected: ^https?://.*\\.(jpg|jpeg|png)$
-                
-                   2 |\s
-                   3 | video::https://example.com/video.mp4[poster=file:///local/poster.jpg]
-                   4 |\s
-                   5 | video::https://example.com/video.mp4[poster=https://example.com/poster.bmp]
-                     |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 |\s
-                   7 | video::https://example.com/video.mp4[poster=https://example.com/poster.png]
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Video poster does not match required pattern [video.poster.pattern]
+                              File: %s:3:45-68
+                              Actual: file:///local/poster.jpg
+                              Expected: ^https?://.*\\.(jpg|jpeg|png)$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | video::https://example.com/video.mp4[poster=file:///local/poster.jpg]
+                                 |                                             ~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 |\s
+                               5 | video::https://example.com/video.mp4[poster=https://example.com/poster.bmp]
+                               6 |\s
+
+                            [ERROR]: Video poster does not match required pattern [video.poster.pattern]
+                              File: %s:5:45-74
+                              Actual: https://example.com/poster.bmp
+                              Expected: ^https?://.*\\.(jpg|jpeg|png)$
+
+                               2 |\s
+                               3 | video::https://example.com/video.mp4[poster=file:///local/poster.jpg]
+                               4 |\s
+                               5 | video::https://example.com/video.mp4[poster=https://example.com/poster.bmp]
+                                 |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 |\s
+                               7 | video::https://example.com/video.mp4[poster=https://example.com/poster.png]
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for video caption exceeding max length")
         void shouldShowUnderlineForVideoCaptionExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for video caption
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - video:
-                            severity: error
-                            caption:
-                              required: true
-                              maxLength: 25
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - video:
+                                severity: error
+                                caption:
+                                  required: true
+                                  maxLength: 25
+                    """;
+
             // Given - AsciiDoc content with captions exceeding max length
             String adocContent = """
-                = Test Document
-                
-                .This is an extremely long video caption that definitely exceeds the maximum allowed length
-                video::https://example.com/intro.mp4[]
-                
-                .Short caption
-                video::https://example.com/demo.mp4[]
-                
-                .Another very long caption that should be much shorter to comply with rules
-                video::https://example.com/tutorial.mp4[]
-                """;
-            
+                    = Test Document
+
+                    .This is an extremely long video caption that definitely exceeds the maximum allowed length
+                    video::https://example.com/intro.mp4[]
+
+                    .Short caption
+                    video::https://example.com/demo.mp4[]
+
+                    .Another very long caption that should be much shorter to comply with rules
+                    video::https://example.com/tutorial.mp4[]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Video caption is too long [video.caption.maxLength]
-                  File: %s:3:1-91
-                  Actual: 90 characters
-                  Expected: <= 25 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .This is an extremely long video caption that definitely exceeds the maximum allowed length
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 | video::https://example.com/intro.mp4[]
-                   5 |\s
-                   6 | .Short caption
-                
-                [ERROR]: Video caption is too long [video.caption.maxLength]
-                  File: %s:9:1-75
-                  Actual: 74 characters
-                  Expected: <= 25 characters
-                
-                   6 | .Short caption
-                   7 | video::https://example.com/demo.mp4[]
-                   8 |\s
-                   9 | .Another very long caption that should be much shorter to comply with rules
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  10 | video::https://example.com/tutorial.mp4[]
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Video caption is too long [video.caption.maxLength]
+                              File: %s:3:1-91
+                              Actual: 90 characters
+                              Expected: <= 25 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .This is an extremely long video caption that definitely exceeds the maximum allowed length
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 | video::https://example.com/intro.mp4[]
+                               5 |\s
+                               6 | .Short caption
+
+                            [ERROR]: Video caption is too long [video.caption.maxLength]
+                              File: %s:9:1-75
+                              Actual: 74 characters
+                              Expected: <= 25 characters
+
+                               6 | .Short caption
+                               7 | video::https://example.com/demo.mp4[]
+                               8 |\s
+                               9 | .Another very long caption that should be much shorter to comply with rules
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              10 | video::https://example.com/tutorial.mp4[]
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for video caption below min length")
         void shouldShowUnderlineForVideoCaptionBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for video caption
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - video:
-                            severity: warn
-                            caption:
-                              required: true
-                              minLength: 15
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - video:
+                                severity: warn
+                                caption:
+                                  required: true
+                                  minLength: 15
+                    """;
+
             // Given - AsciiDoc content with captions below min length
             String adocContent = """
-                = Test Document
-                
-                .Demo
-                video::https://example.com/demo.mp4[]
-                
-                .Product demonstration video showing main features
-                video::https://example.com/product.mp4[]
-                
-                .Tutorial
-                video::https://example.com/tutorial.mp4[]
-                """;
-            
+                    = Test Document
+
+                    .Demo
+                    video::https://example.com/demo.mp4[]
+
+                    .Product demonstration video showing main features
+                    video::https://example.com/product.mp4[]
+
+                    .Tutorial
+                    video::https://example.com/tutorial.mp4[]
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Video caption is too short [video.caption.minLength]
-                  File: %s:3:1-5
-                  Actual: 4 characters
-                  Expected: >= 15 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .Demo
-                     | ~~~~~
-                   4 | video::https://example.com/demo.mp4[]
-                   5 |\s
-                   6 | .Product demonstration video showing main features
-                
-                [WARN]: Video caption is too short [video.caption.minLength]
-                  File: %s:9:1-9
-                  Actual: 8 characters
-                  Expected: >= 15 characters
-                
-                   6 | .Product demonstration video showing main features
-                   7 | video::https://example.com/product.mp4[]
-                   8 |\s
-                   9 | .Tutorial
-                     | ~~~~~~~~~
-                  10 | video::https://example.com/tutorial.mp4[]
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Video caption is too short [video.caption.minLength]
+                              File: %s:3:1-5
+                              Actual: 4 characters
+                              Expected: >= 15 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .Demo
+                                 | ~~~~~
+                               4 | video::https://example.com/demo.mp4[]
+                               5 |\s
+                               6 | .Product demonstration video showing main features
+
+                            [WARN]: Video caption is too short [video.caption.minLength]
+                              File: %s:9:1-9
+                              Actual: 8 characters
+                              Expected: >= 15 characters
+
+                               6 | .Product demonstration video showing main features
+                               7 | video::https://example.com/product.mp4[]
+                               8 |\s
+                               9 | .Tutorial
+                                 | ~~~~~~~~~
+                              10 | video::https://example.com/tutorial.mp4[]
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Table Block Validation Tests")
     class TableValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for table header not matching pattern")
         void shouldShowUnderlineForTableHeaderPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with header pattern for table blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - table:
-                            severity: error
-                            header:
-                              severity: error
-                              required: true
-                              pattern: "^[A-Z][a-zA-Z0-9 ]+$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - table:
+                                severity: error
+                                header:
+                                  severity: error
+                                  required: true
+                                  pattern: "^[A-Z][a-zA-Z0-9 ]+$"
+                    """;
+
             // Given - AsciiDoc content with table headers not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                |===
-                | lowercase header | Another Column
-                
-                | Data 1 | Data 2
-                |===
-                
-                |===
-                | Valid Header | Second Column
-                
-                | Data 1 | Data 2
-                |===
-                
-                |===
-                | Special-Characters! | Column#2
-                
-                | Data 1 | Data 2
-                |===
-                """;
-            
+                    = Test Document
+
+                    |===
+                    | lowercase header | Another Column
+
+                    | Data 1 | Data 2
+                    |===
+
+                    |===
+                    | Valid Header | Second Column
+
+                    | Data 1 | Data 2
+                    |===
+
+                    |===
+                    | Special-Characters! | Column#2
+
+                    | Data 1 | Data 2
+                    |===
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Table header does not match required pattern [table.header.pattern]
-                  File: %s:4:3-18
-                  Actual: lowercase header
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | |===
-                   4 | | lowercase header | Another Column
-                     |   ~~~~~~~~~~~~~~~~
-                   5 |\s
-                   6 | | Data 1 | Data 2
-                   7 | |===
-                
-                [ERROR]: Table header does not match required pattern [table.header.pattern]
-                  File: %s:16:3-21
-                  Actual: Special-Characters!
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
-                
-                  13 | |===
-                  14 |\s
-                  15 | |===
-                  16 | | Special-Characters! | Column#2
-                     |   ~~~~~~~~~~~~~~~~~~~
-                  17 |\s
-                  18 | | Data 1 | Data 2
-                  19 | |===
-                
-                [ERROR]: Table header does not match required pattern [table.header.pattern]
-                  File: %s:16:25-32
-                  Actual: Column#2
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
-                
-                  13 | |===
-                  14 |\s
-                  15 | |===
-                  16 | | Special-Characters! | Column#2
-                     |                         ~~~~~~~~
-                  17 |\s
-                  18 | | Data 1 | Data 2
-                  19 | |===
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Table header does not match required pattern [table.header.pattern]
+                              File: %s:4:3-18
+                              Actual: lowercase header
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | |===
+                               4 | | lowercase header | Another Column
+                                 |   ~~~~~~~~~~~~~~~~
+                               5 |\s
+                               6 | | Data 1 | Data 2
+                               7 | |===
+
+                            [ERROR]: Table header does not match required pattern [table.header.pattern]
+                              File: %s:16:3-21
+                              Actual: Special-Characters!
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
+
+                              13 | |===
+                              14 |\s
+                              15 | |===
+                              16 | | Special-Characters! | Column#2
+                                 |   ~~~~~~~~~~~~~~~~~~~
+                              17 |\s
+                              18 | | Data 1 | Data 2
+                              19 | |===
+
+                            [ERROR]: Table header does not match required pattern [table.header.pattern]
+                              File: %s:16:25-32
+                              Actual: Column#2
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
+
+                              13 | |===
+                              14 |\s
+                              15 | |===
+                              16 | | Special-Characters! | Column#2
+                                 |                         ~~~~~~~~
+                              17 |\s
+                              18 | | Data 1 | Data 2
+                              19 | |===
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for table caption below min length")
         void shouldShowUnderlineForTableCaptionBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for table caption
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - table:
-                            severity: warn
-                            caption:
-                              severity: warn
-                              required: true
-                              minLength: 20
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - table:
+                                severity: warn
+                                caption:
+                                  severity: warn
+                                  required: true
+                                  minLength: 20
+                    """;
+
             // Given - AsciiDoc content with table captions below min length
             String adocContent = """
-                = Test Document
-                
-                .Results
-                |===
-                | Name | Score
-                
-                | Alice | 95
-                | Bob | 87
-                |===
-                
-                .Comprehensive analysis of test results
-                |===
-                | Name | Score
-                
-                | Charlie | 92
-                | David | 88
-                |===
-                
-                .Data
-                |===
-                | ID | Value
-                
-                | 1 | 100
-                | 2 | 200
-                |===
-                """;
-            
+                    = Test Document
+
+                    .Results
+                    |===
+                    | Name | Score
+
+                    | Alice | 95
+                    | Bob | 87
+                    |===
+
+                    .Comprehensive analysis of test results
+                    |===
+                    | Name | Score
+
+                    | Charlie | 92
+                    | David | 88
+                    |===
+
+                    .Data
+                    |===
+                    | ID | Value
+
+                    | 1 | 100
+                    | 2 | 200
+                    |===
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Table caption is too short [table.caption.minLength]
-                  File: %s:3:1-8
-                  Actual: 7 characters
-                  Expected: At least 20 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .Results
-                     | ~~~~~~~~
-                   4 | |===
-                   5 | | Name | Score
-                   6 |\s
-                
-                [WARN]: Table caption is too short [table.caption.minLength]
-                  File: %s:19:1-5
-                  Actual: 4 characters
-                  Expected: At least 20 characters
-                
-                  16 | | David | 88
-                  17 | |===
-                  18 |\s
-                  19 | .Data
-                     | ~~~~~
-                  20 | |===
-                  21 | | ID | Value
-                  22 |\s
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Table caption is too short [table.caption.minLength]
+                              File: %s:3:1-8
+                              Actual: 7 characters
+                              Expected: At least 20 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .Results
+                                 | ~~~~~~~~
+                               4 | |===
+                               5 | | Name | Score
+                               6 |\s
+
+                            [WARN]: Table caption is too short [table.caption.minLength]
+                              File: %s:19:1-5
+                              Actual: 4 characters
+                              Expected: At least 20 characters
+
+                              16 | | David | 88
+                              17 | |===
+                              18 |\s
+                              19 | .Data
+                                 | ~~~~~
+                              20 | |===
+                              21 | | ID | Value
+                              22 |\s
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for table caption exceeding max length")
         void shouldShowUnderlineForTableCaptionExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for table caption
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - table:
-                            severity: error
-                            caption:
-                              severity: error
-                              required: true
-                              maxLength: 30
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - table:
+                                severity: error
+                                caption:
+                                  severity: error
+                                  required: true
+                                  maxLength: 30
+                    """;
+
             // Given - AsciiDoc content with table captions exceeding max length
             String adocContent = """
-                = Test Document
-                
-                .This is an extremely long table caption that definitely exceeds the maximum allowed length
-                |===
-                | Column 1 | Column 2
-                
-                | Data 1 | Data 2
-                |===
-                
-                .Short caption
-                |===
-                | A | B
-                
-                | 1 | 2
-                |===
-                
-                .Another excessively long caption that should be shortened to comply with the rules
-                |===
-                | X | Y
-                
-                | 3 | 4
-                |===
-                """;
-            
+                    = Test Document
+
+                    .This is an extremely long table caption that definitely exceeds the maximum allowed length
+                    |===
+                    | Column 1 | Column 2
+
+                    | Data 1 | Data 2
+                    |===
+
+                    .Short caption
+                    |===
+                    | A | B
+
+                    | 1 | 2
+                    |===
+
+                    .Another excessively long caption that should be shortened to comply with the rules
+                    |===
+                    | X | Y
+
+                    | 3 | 4
+                    |===
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Table caption is too long [table.caption.maxLength]
-                  File: %s:3:1-91
-                  Actual: 90 characters
-                  Expected: At most 30 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .This is an extremely long table caption that definitely exceeds the maximum allowed length
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 | |===
-                   5 | | Column 1 | Column 2
-                   6 |\s
-                
-                [ERROR]: Table caption is too long [table.caption.maxLength]
-                  File: %s:17:1-83
-                  Actual: 82 characters
-                  Expected: At most 30 characters
-                
-                  14 | | 1 | 2
-                  15 | |===
-                  16 |\s
-                  17 | .Another excessively long caption that should be shortened to comply with the rules
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  18 | |===
-                  19 | | X | Y
-                  20 |\s
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Table caption is too long [table.caption.maxLength]
+                              File: %s:3:1-91
+                              Actual: 90 characters
+                              Expected: At most 30 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .This is an extremely long table caption that definitely exceeds the maximum allowed length
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 | |===
+                               5 | | Column 1 | Column 2
+                               6 |\s
+
+                            [ERROR]: Table caption is too long [table.caption.maxLength]
+                              File: %s:17:1-83
+                              Actual: 82 characters
+                              Expected: At most 30 characters
+
+                              14 | | 1 | 2
+                              15 | |===
+                              16 |\s
+                              17 | .Another excessively long caption that should be shortened to comply with the rules
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              18 | |===
+                              19 | | X | Y
+                              20 |\s
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for table caption not matching pattern")
         void shouldShowUnderlineForTableCaptionPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with caption pattern for table blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - table:
-                            severity: error
-                            caption:
-                              severity: error
-                              required: true
-                              pattern: "^Table \\\\d+\\\\.+"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - table:
+                                severity: error
+                                caption:
+                                  severity: error
+                                  required: true
+                                  pattern: "^Table \\\\d+\\\\.+"
+                    """;
+
             // Given - AsciiDoc content with table captions not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                .Results Summary
-                |===
-                | Name | Score
-                
-                | Alice | 95
-                |===
-                
-                .Table 1. Valid caption format
-                |===
-                | ID | Value
-                
-                | 1 | 100
-                |===
-                
-                .Invalid format
-                |===
-                | X | Y
-                
-                | A | B
-                |===
-                """;
-            
+                    = Test Document
+
+                    .Results Summary
+                    |===
+                    | Name | Score
+
+                    | Alice | 95
+                    |===
+
+                    .Table 1. Valid caption format
+                    |===
+                    | ID | Value
+
+                    | 1 | 100
+                    |===
+
+                    .Invalid format
+                    |===
+                    | X | Y
+
+                    | A | B
+                    |===
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Table caption does not match required pattern [table.caption.pattern]
-                  File: %s:3:1-16
-                  Actual: Results Summary
-                  Expected: Pattern: ^Table \\d+\\.+
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .Results Summary
-                     | ~~~~~~~~~~~~~~~~
-                   4 | |===
-                   5 | | Name | Score
-                   6 |\s
-                
-                [ERROR]: Table caption does not match required pattern [table.caption.pattern]
-                  File: %s:10:1-30
-                  Actual: Table 1. Valid caption format
-                  Expected: Pattern: ^Table \\d+\\.+
-                
-                   7 | | Alice | 95
-                   8 | |===
-                   9 |\s
-                  10 | .Table 1. Valid caption format
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  11 | |===
-                  12 | | ID | Value
-                  13 |\s
-                
-                [ERROR]: Table caption does not match required pattern [table.caption.pattern]
-                  File: %s:17:1-15
-                  Actual: Invalid format
-                  Expected: Pattern: ^Table \\d+\\.+
-                
-                  14 | | 1 | 100
-                  15 | |===
-                  16 |\s
-                  17 | .Invalid format
-                     | ~~~~~~~~~~~~~~~
-                  18 | |===
-                  19 | | X | Y
-                  20 |\s
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Table caption does not match required pattern [table.caption.pattern]
+                              File: %s:3:1-16
+                              Actual: Results Summary
+                              Expected: Pattern: ^Table \\d+\\.+
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .Results Summary
+                                 | ~~~~~~~~~~~~~~~~
+                               4 | |===
+                               5 | | Name | Score
+                               6 |\s
+
+                            [ERROR]: Table caption does not match required pattern [table.caption.pattern]
+                              File: %s:10:1-30
+                              Actual: Table 1. Valid caption format
+                              Expected: Pattern: ^Table \\d+\\.+
+
+                               7 | | Alice | 95
+                               8 | |===
+                               9 |\s
+                              10 | .Table 1. Valid caption format
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              11 | |===
+                              12 | | ID | Value
+                              13 |\s
+
+                            [ERROR]: Table caption does not match required pattern [table.caption.pattern]
+                              File: %s:17:1-15
+                              Actual: Invalid format
+                              Expected: Pattern: ^Table \\d+\\.+
+
+                              14 | | 1 | 100
+                              15 | |===
+                              16 |\s
+                              17 | .Invalid format
+                                 | ~~~~~~~~~~~~~~~
+                              18 | |===
+                              19 | | X | Y
+                              20 |\s
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Verse Block Validation Tests")
     class VerseValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for verse author exceeding max length")
         void shouldShowUnderlineForVerseAuthorExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for verse author
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - verse:
-                            severity: error
-                            author:
-                              required: true
-                              maxLength: 25
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - verse:
+                                severity: error
+                                author:
+                                  required: true
+                                  maxLength: 25
+                    """;
+
             // Given - AsciiDoc content with verse authors exceeding max length
             String adocContent = """
-                = Test Document
-                
-                [verse, "William Shakespeare and all his collaborators", "Hamlet"]
-                ____
-                To be, or not to be, that is the question
-                ____
-                
-                [verse, "Emily Dickinson", "Complete Poems"]
-                ____
-                Because I could not stop for Death
-                ____
-                """;
-            
+                    = Test Document
+
+                    [verse, "William Shakespeare and all his collaborators", "Hamlet"]
+                    ____
+                    To be, or not to be, that is the question
+                    ____
+
+                    [verse, "Emily Dickinson", "Complete Poems"]
+                    ____
+                    Because I could not stop for Death
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Verse author is too long [verse.author.maxLength]
-                  File: %s:3:10-54
-                  Actual: 45 characters
-                  Expected: At most 25 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [verse, "William Shakespeare and all his collaborators", "Hamlet"]
-                     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 | ____
-                   5 | To be, or not to be, that is the question
-                   6 | ____
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Verse author is too long [verse.author.maxLength]
+                              File: %s:3:10-54
+                              Actual: 45 characters
+                              Expected: At most 25 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [verse, "William Shakespeare and all his collaborators", "Hamlet"]
+                                 |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 | ____
+                               5 | To be, or not to be, that is the question
+                               6 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for verse author below min length")
         void shouldShowUnderlineForVerseAuthorBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for verse author
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - verse:
-                            severity: warn
-                            author:
-                              required: true
-                              minLength: 10
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - verse:
+                                severity: warn
+                                author:
+                                  required: true
+                                  minLength: 10
+                    """;
+
             // Given - AsciiDoc content with verse authors below min length
             String adocContent = """
-                = Test Document
-                
-                [verse, "Anon", "Unknown"]
-                ____
-                Roses are red, violets are blue
-                ____
-                
-                [verse, "Shakespeare", "Sonnets"]
-                ____
-                Shall I compare thee to a summer's day?
-                ____
-                """;
-            
+                    = Test Document
+
+                    [verse, "Anon", "Unknown"]
+                    ____
+                    Roses are red, violets are blue
+                    ____
+
+                    [verse, "Shakespeare", "Sonnets"]
+                    ____
+                    Shall I compare thee to a summer's day?
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Verse author is too short [verse.author.minLength]
-                  File: %s:3:10-13
-                  Actual: 4 characters
-                  Expected: At least 10 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [verse, "Anon", "Unknown"]
-                     |          ~~~~
-                   4 | ____
-                   5 | Roses are red, violets are blue
-                   6 | ____
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Verse author is too short [verse.author.minLength]
+                              File: %s:3:10-13
+                              Actual: 4 characters
+                              Expected: At least 10 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [verse, "Anon", "Unknown"]
+                                 |          ~~~~
+                               4 | ____
+                               5 | Roses are red, violets are blue
+                               6 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for verse author not matching pattern")
         void shouldShowUnderlineForVerseAuthorPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for verse author
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - verse:
-                            severity: error
-                            author:
-                              required: true
-                              pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - verse:
+                                severity: error
+                                author:
+                                  required: true
+                                  pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
+                    """;
+
             // Given - AsciiDoc content with verse authors not matching pattern
             String adocContent = """
-                = Test Document
-                
-                [verse, "shakespeare", "Hamlet"]
-                ____
-                To be or not to be
-                ____
-                
-                [verse, "Emily Dickinson", "Poems"]
-                ____
-                I'm nobody! Who are you?
-                ____
-                
-                [verse, "E.E. Cummings", "Complete Poems"]
-                ____
-                i carry your heart with me
-                ____
-                """;
-            
+                    = Test Document
+
+                    [verse, "shakespeare", "Hamlet"]
+                    ____
+                    To be or not to be
+                    ____
+
+                    [verse, "Emily Dickinson", "Poems"]
+                    ____
+                    I'm nobody! Who are you?
+                    ____
+
+                    [verse, "E.E. Cummings", "Complete Poems"]
+                    ____
+                    i carry your heart with me
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Verse author does not match required pattern [verse.author.pattern]
-                  File: %s:3:10-20
-                  Actual: shakespeare
-                  Expected: Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [verse, "shakespeare", "Hamlet"]
-                     |          ~~~~~~~~~~~
-                   4 | ____
-                   5 | To be or not to be
-                   6 | ____
-                
-                [ERROR]: Verse author does not match required pattern [verse.author.pattern]
-                  File: %s:13:10-22
-                  Actual: E.E. Cummings
-                  Expected: Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$
-                
-                  10 | I'm nobody! Who are you?
-                  11 | ____
-                  12 |\s
-                  13 | [verse, "E.E. Cummings", "Complete Poems"]
-                     |          ~~~~~~~~~~~~~
-                  14 | ____
-                  15 | i carry your heart with me
-                  16 | ____
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Verse author does not match required pattern [verse.author.pattern]
+                              File: %s:3:10-20
+                              Actual: shakespeare
+                              Expected: Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [verse, "shakespeare", "Hamlet"]
+                                 |          ~~~~~~~~~~~
+                               4 | ____
+                               5 | To be or not to be
+                               6 | ____
+
+                            [ERROR]: Verse author does not match required pattern [verse.author.pattern]
+                              File: %s:13:10-22
+                              Actual: E.E. Cummings
+                              Expected: Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$
+
+                              10 | I'm nobody! Who are you?
+                              11 | ____
+                              12 |\s
+                              13 | [verse, "E.E. Cummings", "Complete Poems"]
+                                 |          ~~~~~~~~~~~~~
+                              14 | ____
+                              15 | i carry your heart with me
+                              16 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for verse attribution exceeding max length")
         void shouldShowUnderlineForVerseAttributionExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for verse attribution
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - verse:
-                            severity: error
-                            attribution:
-                              required: true
-                              maxLength: 20
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - verse:
+                                severity: error
+                                attribution:
+                                  required: true
+                                  maxLength: 20
+                    """;
+
             // Given - AsciiDoc content with verse attributions exceeding max length
             String adocContent = """
-                = Test Document
-                
-                [verse, "William Shakespeare", "Hamlet Act 3 Scene 1 Line 56"]
-                ____
-                To be, or not to be
-                ____
-                
-                [verse, "Emily Dickinson", "Poems"]
-                ____
-                Hope is the thing with feathers
-                ____
-                """;
-            
+                    = Test Document
+
+                    [verse, "William Shakespeare", "Hamlet Act 3 Scene 1 Line 56"]
+                    ____
+                    To be, or not to be
+                    ____
+
+                    [verse, "Emily Dickinson", "Poems"]
+                    ____
+                    Hope is the thing with feathers
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Verse attribution is too long [verse.attribution.maxLength]
-                  File: %s:3:33-60
-                  Actual: 28 characters
-                  Expected: At most 20 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [verse, "William Shakespeare", "Hamlet Act 3 Scene 1 Line 56"]
-                     |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 | ____
-                   5 | To be, or not to be
-                   6 | ____
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Verse attribution is too long [verse.attribution.maxLength]
+                              File: %s:3:33-60
+                              Actual: 28 characters
+                              Expected: At most 20 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [verse, "William Shakespeare", "Hamlet Act 3 Scene 1 Line 56"]
+                                 |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 | ____
+                               5 | To be, or not to be
+                               6 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for verse attribution not matching pattern")
         void shouldShowUnderlineForVerseAttributionPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for verse attribution
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - verse:
-                            severity: error
-                            attribution:
-                              required: true
-                              pattern: "^[A-Z][a-zA-Z\\\\s]+, \\\\d{4}$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - verse:
+                                severity: error
+                                attribution:
+                                  required: true
+                                  pattern: "^[A-Z][a-zA-Z\\\\s]+, \\\\d{4}$"
+                    """;
+
             // Given - AsciiDoc content with verse attributions not matching pattern
             String adocContent = """
-                = Test Document
-                
-                [verse, "Robert Frost", "Unknown date"]
-                ____
-                Two roads diverged in a wood
-                ____
-                
-                [verse, "Maya Angelou", "Still I Rise, 1978"]
-                ____
-                You may write me down in history
-                ____
-                """;
-            
+                    = Test Document
+
+                    [verse, "Robert Frost", "Unknown date"]
+                    ____
+                    Two roads diverged in a wood
+                    ____
+
+                    [verse, "Maya Angelou", "Still I Rise, 1978"]
+                    ____
+                    You may write me down in history
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Verse attribution does not match required pattern [verse.attribution.pattern]
-                  File: %s:3:26-37
-                  Actual: Unknown date
-                  Expected: Pattern: ^[A-Z][a-zA-Z\\s]+, \\d{4}$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [verse, "Robert Frost", "Unknown date"]
-                     |                          ~~~~~~~~~~~~
-                   4 | ____
-                   5 | Two roads diverged in a wood
-                   6 | ____
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Verse attribution does not match required pattern [verse.attribution.pattern]
+                              File: %s:3:26-37
+                              Actual: Unknown date
+                              Expected: Pattern: ^[A-Z][a-zA-Z\\s]+, \\d{4}$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [verse, "Robert Frost", "Unknown date"]
+                                 |                          ~~~~~~~~~~~~
+                               4 | ____
+                               5 | Two roads diverged in a wood
+                               6 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for verse content exceeding max length")
         void shouldShowUnderlineForVerseContentExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for verse content
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - verse:
-                            severity: error
-                            content:
-                              required: true
-                              maxLength: 50
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - verse:
+                                severity: error
+                                content:
+                                  required: true
+                                  maxLength: 50
+                    """;
+
             // Given - AsciiDoc content with verse content exceeding max length
             String adocContent = """
-                = Test Document
-                
-                [verse]
-                ____
-                This is an extremely long verse content that definitely exceeds the maximum allowed length of fifty characters
-                ____
-                
-                [verse]
-                ____
-                Short verse content
-                ____
-                """;
-            
+                    = Test Document
+
+                    [verse]
+                    ____
+                    This is an extremely long verse content that definitely exceeds the maximum allowed length of fifty characters
+                    ____
+
+                    [verse]
+                    ____
+                    Short verse content
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Verse content is too long [verse.content.maxLength]
-                  File: %s:5:1-110
-                  Actual: 110 characters
-                  Expected: At most 50 characters
-                
-                   2 |\s
-                   3 | [verse]
-                   4 | ____
-                   5 | This is an extremely long verse content that definitely exceeds the maximum allowed length of fifty characters
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 | ____
-                   7 |\s
-                   8 | [verse]
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Verse content is too long [verse.content.maxLength]
+                              File: %s:5:1-110
+                              Actual: 110 characters
+                              Expected: At most 50 characters
+
+                               2 |\s
+                               3 | [verse]
+                               4 | ____
+                               5 | This is an extremely long verse content that definitely exceeds the maximum allowed length of fifty characters
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 | ____
+                               7 |\s
+                               8 | [verse]
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Pass Block Validation Tests")
     class PassValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for pass block with disallowed type")
         void shouldShowUnderlineForPassDisallowedType(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with allowed types for pass blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - pass:
-                            severity: error
-                            type:
-                              required: true
-                              allowed: ["html", "xml", "svg"]
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - pass:
+                                severity: error
+                                type:
+                                  required: true
+                                  allowed: ["html", "xml", "svg"]
+                    """;
+
             // Given - AsciiDoc content with pass blocks having disallowed types
             String adocContent = """
-                = Test Document
-                
-                [pass,type=javascript]
-                ++++
-                console.log("Hello");
-                ++++
-                
-                [pass,type=html]
-                ++++
-                <p>Valid HTML</p>
-                ++++
-                
-                [pass,type=css]
-                ++++
-                body { color: red; }
-                ++++
-                """;
-            
+                    = Test Document
+
+                    [pass,type=javascript]
+                    ++++
+                    console.log("Hello");
+                    ++++
+
+                    [pass,type=html]
+                    ++++
+                    <p>Valid HTML</p>
+                    ++++
+
+                    [pass,type=css]
+                    ++++
+                    body { color: red; }
+                    ++++
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Pass block type 'javascript' is not allowed [pass.type.allowed]
-                  File: %s:3:12-21
-                  Actual: javascript
-                  Expected: One of: html, xml, svg
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [pass,type=javascript]
-                     |            ~~~~~~~~~~
-                   4 | ++++
-                   5 | console.log("Hello");
-                   6 | ++++
-                
-                [ERROR]: Pass block type 'css' is not allowed [pass.type.allowed]
-                  File: %s:13:12-14
-                  Actual: css
-                  Expected: One of: html, xml, svg
-                
-                  10 | <p>Valid HTML</p>
-                  11 | ++++
-                  12 |\s
-                  13 | [pass,type=css]
-                     |            ~~~
-                  14 | ++++
-                  15 | body { color: red; }
-                  16 | ++++
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Pass block type 'javascript' is not allowed [pass.type.allowed]
+                              File: %s:3:12-21
+                              Actual: javascript
+                              Expected: One of: html, xml, svg
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [pass,type=javascript]
+                                 |            ~~~~~~~~~~
+                               4 | ++++
+                               5 | console.log("Hello");
+                               6 | ++++
+
+                            [ERROR]: Pass block type 'css' is not allowed [pass.type.allowed]
+                              File: %s:13:12-14
+                              Actual: css
+                              Expected: One of: html, xml, svg
+
+                              10 | <p>Valid HTML</p>
+                              11 | ++++
+                              12 |\s
+                              13 | [pass,type=css]
+                                 |            ~~~
+                              14 | ++++
+                              15 | body { color: red; }
+                              16 | ++++
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for pass content exceeding max length")
         void shouldShowUnderlineForPassContentExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for pass content
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - pass:
-                            severity: error
-                            content:
-                              required: true
-                              maxLength: 50
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - pass:
+                                severity: error
+                                content:
+                                  required: true
+                                  maxLength: 50
+                    """;
+
             // Given - AsciiDoc content with pass content exceeding max length
             String adocContent = """
-                = Test Document
-                
-                [pass]
-                ++++
-                This is an extremely long pass block content that definitely exceeds the maximum allowed length
-                ++++
-                
-                [pass]
-                ++++
-                Short content
-                ++++
-                """;
-            
+                    = Test Document
+
+                    [pass]
+                    ++++
+                    This is an extremely long pass block content that definitely exceeds the maximum allowed length
+                    ++++
+
+                    [pass]
+                    ++++
+                    Short content
+                    ++++
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Pass block content is too long [pass.content.maxLength]
-                  File: %s:5:1-95
-                  Actual: 95 characters
-                  Expected: Maximum 50 characters
-                
-                   2 |\s
-                   3 | [pass]
-                   4 | ++++
-                   5 | This is an extremely long pass block content that definitely exceeds the maximum allowed length
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 | ++++
-                   7 |\s
-                   8 | [pass]
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Pass block content is too long [pass.content.maxLength]
+                              File: %s:5:1-95
+                              Actual: 95 characters
+                              Expected: Maximum 50 characters
+
+                               2 |\s
+                               3 | [pass]
+                               4 | ++++
+                               5 | This is an extremely long pass block content that definitely exceeds the maximum allowed length
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 | ++++
+                               7 |\s
+                               8 | [pass]
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for pass content not matching pattern")
         void shouldShowUnderlineForPassContentPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for pass content
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - pass:
-                            severity: error
-                            content:
-                              required: true
-                              pattern: "^<[^>]+>.*</[^>]+>$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - pass:
+                                severity: error
+                                content:
+                                  required: true
+                                  pattern: "^<[^>]+>.*</[^>]+>$"
+                    """;
+
             // Given - AsciiDoc content with pass content not matching pattern
             String adocContent = """
-                = Test Document
-                
-                [pass]
-                ++++
-                Not a valid XML/HTML tag
-                ++++
-                
-                [pass]
-                ++++
-                <div>Valid content</div>
-                ++++
-                
-                [pass]
-                ++++
-                <p>Unclosed tag
-                ++++
-                """;
-            
+                    = Test Document
+
+                    [pass]
+                    ++++
+                    Not a valid XML/HTML tag
+                    ++++
+
+                    [pass]
+                    ++++
+                    <div>Valid content</div>
+                    ++++
+
+                    [pass]
+                    ++++
+                    <p>Unclosed tag
+                    ++++
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Pass block content does not match required pattern [pass.content.pattern]
-                  File: %s:5:1-24
-                  Actual: Content does not match pattern
-                  Expected: Pattern: ^<[^>]+>.*</[^>]+>$
-                
-                   2 |\s
-                   3 | [pass]
-                   4 | ++++
-                   5 | Not a valid XML/HTML tag
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 | ++++
-                   7 |\s
-                   8 | [pass]
-                
-                [ERROR]: Pass block content does not match required pattern [pass.content.pattern]
-                  File: %s:15:1-15
-                  Actual: Content does not match pattern
-                  Expected: Pattern: ^<[^>]+>.*</[^>]+>$
-                
-                  12 |\s
-                  13 | [pass]
-                  14 | ++++
-                  15 | <p>Unclosed tag
-                     | ~~~~~~~~~~~~~~~
-                  16 | ++++
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Pass block content does not match required pattern [pass.content.pattern]
+                              File: %s:5:1-24
+                              Actual: Content does not match pattern
+                              Expected: Pattern: ^<[^>]+>.*</[^>]+>$
+
+                               2 |\s
+                               3 | [pass]
+                               4 | ++++
+                               5 | Not a valid XML/HTML tag
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 | ++++
+                               7 |\s
+                               8 | [pass]
+
+                            [ERROR]: Pass block content does not match required pattern [pass.content.pattern]
+                              File: %s:15:1-15
+                              Actual: Content does not match pattern
+                              Expected: Pattern: ^<[^>]+>.*</[^>]+>$
+
+                              12 |\s
+                              13 | [pass]
+                              14 | ++++
+                              15 | <p>Unclosed tag
+                                 | ~~~~~~~~~~~~~~~
+                              16 | ++++
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for pass reason below min length")
         void shouldShowUnderlineForPassReasonBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for pass reason
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - pass:
-                            severity: warn
-                            reason:
-                              required: true
-                              minLength: 20
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - pass:
+                                severity: warn
+                                reason:
+                                  required: true
+                                  minLength: 20
+                    """;
+
             // Given - AsciiDoc content with pass reasons below min length
             String adocContent = """
-                = Test Document
-                
-                [pass,reason=Legacy]
-                ++++
-                <custom>Content</custom>
-                ++++
-                
-                [pass,reason=For backwards compatibility with old systems]
-                ++++
-                <legacy>Data</legacy>
-                ++++
-                
-                [pass,reason=Custom]
-                ++++
-                <special>Tag</special>
-                ++++
-                """;
-            
+                    = Test Document
+
+                    [pass,reason=Legacy]
+                    ++++
+                    <custom>Content</custom>
+                    ++++
+
+                    [pass,reason=For backwards compatibility with old systems]
+                    ++++
+                    <legacy>Data</legacy>
+                    ++++
+
+                    [pass,reason=Custom]
+                    ++++
+                    <special>Tag</special>
+                    ++++
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Pass block reason is too short [pass.reason.minLength]
-                  File: %s:3:14-19
-                  Actual: 6 characters
-                  Expected: At least 20 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [pass,reason=Legacy]
-                     |              ~~~~~~
-                   4 | ++++
-                   5 | <custom>Content</custom>
-                   6 | ++++
-                
-                [WARN]: Pass block reason is too short [pass.reason.minLength]
-                  File: %s:13:14-19
-                  Actual: 6 characters
-                  Expected: At least 20 characters
-                
-                  10 | <legacy>Data</legacy>
-                  11 | ++++
-                  12 |\s
-                  13 | [pass,reason=Custom]
-                     |              ~~~~~~
-                  14 | ++++
-                  15 | <special>Tag</special>
-                  16 | ++++
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Pass block reason is too short [pass.reason.minLength]
+                              File: %s:3:14-19
+                              Actual: 6 characters
+                              Expected: At least 20 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [pass,reason=Legacy]
+                                 |              ~~~~~~
+                               4 | ++++
+                               5 | <custom>Content</custom>
+                               6 | ++++
+
+                            [WARN]: Pass block reason is too short [pass.reason.minLength]
+                              File: %s:13:14-19
+                              Actual: 6 characters
+                              Expected: At least 20 characters
+
+                              10 | <legacy>Data</legacy>
+                              11 | ++++
+                              12 |\s
+                              13 | [pass,reason=Custom]
+                                 |              ~~~~~~
+                              14 | ++++
+                              15 | <special>Tag</special>
+                              16 | ++++
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for pass reason exceeding max length")
         void shouldShowUnderlineForPassReasonExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for pass reason
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - pass:
-                            severity: error
-                            reason:
-                              required: true
-                              maxLength: 30
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - pass:
+                                severity: error
+                                reason:
+                                  required: true
+                                  maxLength: 30
+                    """;
+
             // Given - AsciiDoc content with pass reasons exceeding max length
             String adocContent = """
-                = Test Document
-                
-                [pass,reason=This is an extremely long reason that exceeds the maximum allowed length]
-                ++++
-                <content>Data</content>
-                ++++
-                
-                [pass,reason=Short reason]
-                ++++
-                <valid>Content</valid>
-                ++++
-                
-                [pass,reason=Another excessively long explanation for using passthrough that should be shorter]
-                ++++
-                <data>Value</data>
-                ++++
-                """;
-            
+                    = Test Document
+
+                    [pass,reason=This is an extremely long reason that exceeds the maximum allowed length]
+                    ++++
+                    <content>Data</content>
+                    ++++
+
+                    [pass,reason=Short reason]
+                    ++++
+                    <valid>Content</valid>
+                    ++++
+
+                    [pass,reason=Another excessively long explanation for using passthrough that should be shorter]
+                    ++++
+                    <data>Value</data>
+                    ++++
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Pass block reason is too long [pass.reason.maxLength]
-                  File: %s:3:14-85
-                  Actual: 72 characters
-                  Expected: At most 30 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [pass,reason=This is an extremely long reason that exceeds the maximum allowed length]
-                     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 | ++++
-                   5 | <content>Data</content>
-                   6 | ++++
-                
-                [ERROR]: Pass block reason is too long [pass.reason.maxLength]
-                  File: %s:13:14-94
-                  Actual: 81 characters
-                  Expected: At most 30 characters
-                
-                  10 | <valid>Content</valid>
-                  11 | ++++
-                  12 |\s
-                  13 | [pass,reason=Another excessively long explanation for using passthrough that should be shorter]
-                     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  14 | ++++
-                  15 | <data>Value</data>
-                  16 | ++++
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Pass block reason is too long [pass.reason.maxLength]
+                              File: %s:3:14-85
+                              Actual: 72 characters
+                              Expected: At most 30 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [pass,reason=This is an extremely long reason that exceeds the maximum allowed length]
+                                 |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 | ++++
+                               5 | <content>Data</content>
+                               6 | ++++
+
+                            [ERROR]: Pass block reason is too long [pass.reason.maxLength]
+                              File: %s:13:14-94
+                              Actual: 81 characters
+                              Expected: At most 30 characters
+
+                              10 | <valid>Content</valid>
+                              11 | ++++
+                              12 |\s
+                              13 | [pass,reason=Another excessively long explanation for using passthrough that should be shorter]
+                                 |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              14 | ++++
+                              15 | <data>Value</data>
+                              16 | ++++
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Paragraph Validation Tests")
     class ParagraphValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for paragraph with too many sentences")
         void shouldShowUnderlineForParagraphWithTooManySentences(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with maximum sentence count for paragraphs
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - paragraph:
-                            severity: warn
-                            sentence:
-                              occurrence:
-                                max: 2
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - paragraph:
                                 severity: warn
-                """;
-            
+                                sentence:
+                                  occurrence:
+                                    max: 2
+                                    severity: warn
+                    """;
+
             // Given - AsciiDoc content with paragraphs having too many sentences
             String adocContent = """
-                = Test Document
-                
-                This paragraph has only one sentence.
-                
-                This has two sentences. Here is the second.
-                
-                This paragraph contains three sentences. Here is the second one. And this is the third sentence.
-                
-                Another paragraph with four sentences here. This is the second sentence. Here is the third one. And finally the fourth.
-                """;
-            
+                    = Test Document
+
+                    This paragraph has only one sentence.
+
+                    This has two sentences. Here is the second.
+
+                    This paragraph contains three sentences. Here is the second one. And this is the third sentence.
+
+                    Another paragraph with four sentences here. This is the second sentence. Here is the third one. And finally the fourth.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Paragraph has too many sentences [paragraph.sentence.occurrence.max]
-                  File: %s:7:1-96
-                  Actual: 3
-                  Expected: At most 2 sentences
-                
-                   4 |\s
-                   5 | This has two sentences. Here is the second.
-                   6 |\s
-                   7 | This paragraph contains three sentences. Here is the second one. And this is the third sentence.
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   8 |\s
-                   9 | Another paragraph with four sentences here. This is the second sentence. Here is the third one. And finally the fourth.
-                
-                [WARN]: Paragraph has too many sentences [paragraph.sentence.occurrence.max]
-                  File: %s:9:1-119
-                  Actual: 4
-                  Expected: At most 2 sentences
-                
-                   6 |\s
-                   7 | This paragraph contains three sentences. Here is the second one. And this is the third sentence.
-                   8 |\s
-                   9 | Another paragraph with four sentences here. This is the second sentence. Here is the third one. And finally the fourth.
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Paragraph has too many sentences [paragraph.sentence.occurrence.max]
+                              File: %s:7:1-96
+                              Actual: 3
+                              Expected: At most 2 sentences
+
+                               4 |\s
+                               5 | This has two sentences. Here is the second.
+                               6 |\s
+                               7 | This paragraph contains three sentences. Here is the second one. And this is the third sentence.
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               8 |\s
+                               9 | Another paragraph with four sentences here. This is the second sentence. Here is the third one. And finally the fourth.
+
+                            [WARN]: Paragraph has too many sentences [paragraph.sentence.occurrence.max]
+                              File: %s:9:1-119
+                              Actual: 4
+                              Expected: At most 2 sentences
+
+                               6 |\s
+                               7 | This paragraph contains three sentences. Here is the second one. And this is the third sentence.
+                               8 |\s
+                               9 | Another paragraph with four sentences here. This is the second sentence. Here is the third one. And finally the fourth.
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for sentence with too many words")
         void shouldShowUnderlineForSentenceWithTooManyWords(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with maximum words per sentence
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            sentence:
-                              words:
-                                max: 10
-                                severity: warn
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                sentence:
+                                  words:
+                                    max: 10
+                                    severity: warn
+                    """;
+
             // Given - AsciiDoc content with sentences having too many words
             String adocContent = """
-                = Test Document
-                
-                This sentence is fine with exactly ten words in it.
-                
-                This sentence has way too many words and definitely exceeds the maximum limit that we have configured for validation purposes.
-                
-                Short sentence here. But this one also has too many words for the configured maximum limit.
-                """;
-            
+                    = Test Document
+
+                    This sentence is fine with exactly ten words in it.
+
+                    This sentence has way too many words and definitely exceeds the maximum limit that we have configured for validation purposes.
+
+                    Short sentence here. But this one also has too many words for the configured maximum limit.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Sentence 1 has too many words [paragraph.sentence.words.max]
-                  File: %s:5:1-126
-                  Actual: 20 words
-                  Expected: At most 10 words
-                
-                   2 |\s
-                   3 | This sentence is fine with exactly ten words in it.
-                   4 |\s
-                   5 | This sentence has way too many words and definitely exceeds the maximum limit that we have configured for validation purposes.
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   6 |\s
-                   7 | Short sentence here. But this one also has too many words for the configured maximum limit.
-                
-                [WARN]: Sentence 2 has too many words [paragraph.sentence.words.max]
-                  File: %s:7:22-91
-                  Actual: 13 words
-                  Expected: At most 10 words
-                
-                   4 |\s
-                   5 | This sentence has way too many words and definitely exceeds the maximum limit that we have configured for validation purposes.
-                   6 |\s
-                   7 | Short sentence here. But this one also has too many words for the configured maximum limit.
-                     |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Sentence 1 has too many words [paragraph.sentence.words.max]
+                              File: %s:5:1-126
+                              Actual: 20 words
+                              Expected: At most 10 words
+
+                               2 |\s
+                               3 | This sentence is fine with exactly ten words in it.
+                               4 |\s
+                               5 | This sentence has way too many words and definitely exceeds the maximum limit that we have configured for validation purposes.
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               6 |\s
+                               7 | Short sentence here. But this one also has too many words for the configured maximum limit.
+
+                            [WARN]: Sentence 2 has too many words [paragraph.sentence.words.max]
+                              File: %s:7:22-91
+                              Actual: 13 words
+                              Expected: At most 10 words
+
+                               4 |\s
+                               5 | This sentence has way too many words and definitely exceeds the maximum limit that we have configured for validation purposes.
+                               6 |\s
+                               7 | Short sentence here. But this one also has too many words for the configured maximum limit.
+                                 |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Quote Block Validation Tests")
     class QuoteValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for quote attribution not matching pattern")
         void shouldShowUnderlineForQuoteAttributionPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with attribution pattern for quote blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - quote:
-                            severity: error
-                            attribution:
-                              required: true
-                              pattern: "^[A-Z][a-zA-Z\\\\s\\\\.]+$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - quote:
+                                severity: error
+                                attribution:
+                                  required: true
+                                  pattern: "^[A-Z][a-zA-Z\\\\s\\\\.]+$"
+                    """;
+
             // Given - AsciiDoc content with quote attributions not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                [quote, "shakespeare123", "Hamlet"]
-                ____
-                To be, or not to be, that is the question.
-                ____
-                
-                [quote, "William Shakespeare", "Hamlet"]
-                ____
-                All the world's a stage.
-                ____
-                
-                [quote, "@john_doe", "Twitter"]
-                ____
-                Hello world!
-                ____
-                """;
-            
+                    = Test Document
+
+                    [quote, "shakespeare123", "Hamlet"]
+                    ____
+                    To be, or not to be, that is the question.
+                    ____
+
+                    [quote, "William Shakespeare", "Hamlet"]
+                    ____
+                    All the world's a stage.
+                    ____
+
+                    [quote, "@john_doe", "Twitter"]
+                    ____
+                    Hello world!
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Quote attribution does not match required pattern [quote.attribution.pattern]
-                  File: %s:3:10-23
-                  Actual: shakespeare123
-                  Expected: Pattern: ^[A-Z][a-zA-Z\\s\\.]+$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [quote, "shakespeare123", "Hamlet"]
-                     |          ~~~~~~~~~~~~~~
-                   4 | ____
-                   5 | To be, or not to be, that is the question.
-                   6 | ____
-                
-                [ERROR]: Quote attribution does not match required pattern [quote.attribution.pattern]
-                  File: %s:13:10-18
-                  Actual: @john_doe
-                  Expected: Pattern: ^[A-Z][a-zA-Z\\s\\.]+$
-                
-                  10 | All the world's a stage.
-                  11 | ____
-                  12 |\s
-                  13 | [quote, "@john_doe", "Twitter"]
-                     |          ~~~~~~~~~
-                  14 | ____
-                  15 | Hello world!
-                  16 | ____
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Quote attribution does not match required pattern [quote.attribution.pattern]
+                              File: %s:3:10-23
+                              Actual: shakespeare123
+                              Expected: Pattern: ^[A-Z][a-zA-Z\\s\\.]+$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [quote, "shakespeare123", "Hamlet"]
+                                 |          ~~~~~~~~~~~~~~
+                               4 | ____
+                               5 | To be, or not to be, that is the question.
+                               6 | ____
+
+                            [ERROR]: Quote attribution does not match required pattern [quote.attribution.pattern]
+                              File: %s:13:10-18
+                              Actual: @john_doe
+                              Expected: Pattern: ^[A-Z][a-zA-Z\\s\\.]+$
+
+                              10 | All the world's a stage.
+                              11 | ____
+                              12 |\s
+                              13 | [quote, "@john_doe", "Twitter"]
+                                 |          ~~~~~~~~~
+                              14 | ____
+                              15 | Hello world!
+                              16 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for quote citation not matching pattern")
         void shouldShowUnderlineForQuoteCitationPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with citation pattern for quote blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - quote:
-                            severity: error
-                            citation:
-                              required: true
-                              pattern: "^[A-Z][a-zA-Z0-9\\\\s]+, \\\\d{4}$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - quote:
+                                severity: error
+                                citation:
+                                  required: true
+                                  pattern: "^[A-Z][a-zA-Z0-9\\\\s]+, \\\\d{4}$"
+                    """;
+
             // Given - AsciiDoc content with quote citations not matching the pattern
             String adocContent = """
-                = Test Document
-                
-                [quote, "Albert Einstein", "unknown date"]
-                ____
-                Imagination is more important than knowledge.
-                ____
-                
-                [quote, "Maya Angelou", "I Know Why the Caged Bird Sings, 1969"]
-                ____
-                There is no greater agony than bearing an untold story inside you.
-                ____
-                
-                [quote, "Oscar Wilde", "The Picture of Dorian Gray"]
-                ____
-                We are all in the gutter, but some of us are looking at the stars.
-                ____
-                """;
-            
+                    = Test Document
+
+                    [quote, "Albert Einstein", "unknown date"]
+                    ____
+                    Imagination is more important than knowledge.
+                    ____
+
+                    [quote, "Maya Angelou", "I Know Why the Caged Bird Sings, 1969"]
+                    ____
+                    There is no greater agony than bearing an untold story inside you.
+                    ____
+
+                    [quote, "Oscar Wilde", "The Picture of Dorian Gray"]
+                    ____
+                    We are all in the gutter, but some of us are looking at the stars.
+                    ____
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Quote citation does not match required pattern [quote.citation.pattern]
-                  File: %s:3:29-40
-                  Actual: unknown date
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9\\s]+, \\d{4}$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [quote, "Albert Einstein", "unknown date"]
-                     |                             ~~~~~~~~~~~~
-                   4 | ____
-                   5 | Imagination is more important than knowledge.
-                   6 | ____
-                
-                [ERROR]: Quote citation does not match required pattern [quote.citation.pattern]
-                  File: %s:13:25-50
-                  Actual: The Picture of Dorian Gray
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9\\s]+, \\d{4}$
-                
-                  10 | There is no greater agony than bearing an untold story inside you.
-                  11 | ____
-                  12 |\s
-                  13 | [quote, "Oscar Wilde", "The Picture of Dorian Gray"]
-                     |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  14 | ____
-                  15 | We are all in the gutter, but some of us are looking at the stars.
-                  16 | ____
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Quote citation does not match required pattern [quote.citation.pattern]
+                              File: %s:3:29-40
+                              Actual: unknown date
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9\\s]+, \\d{4}$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [quote, "Albert Einstein", "unknown date"]
+                                 |                             ~~~~~~~~~~~~
+                               4 | ____
+                               5 | Imagination is more important than knowledge.
+                               6 | ____
+
+                            [ERROR]: Quote citation does not match required pattern [quote.citation.pattern]
+                              File: %s:13:25-50
+                              Actual: The Picture of Dorian Gray
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9\\s]+, \\d{4}$
+
+                              10 | There is no greater agony than bearing an untold story inside you.
+                              11 | ____
+                              12 |\s
+                              13 | [quote, "Oscar Wilde", "The Picture of Dorian Gray"]
+                                 |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              14 | ____
+                              15 | We are all in the gutter, but some of us are looking at the stars.
+                              16 | ____
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Ulist Block Validation Tests")
     class UlistValidationTests {
-        
-        
-        
-    
+
     }
-    
+
     @Nested
     @DisplayName("Section Validation Tests")
     class SectionValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for section title not matching pattern")
         void shouldShowUnderlineForSectionTitleNotMatchingPattern(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with title pattern for sections
             String rules = """
-                document:
-                  sections:
-                    - level: 1
-                      title:
-                        pattern: "^(Introduction|Overview|Summary)$"
-                        severity: error
-                      subsections:
-                        - level: 2
+                    document:
+                      sections:
+                        - level: 1
                           title:
-                            pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
+                            pattern: "^(Introduction|Overview|Summary)$"
                             severity: error
-                """;
-            
+                          subsections:
+                            - level: 2
+                              title:
+                                pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
+                                severity: error
+                    """;
+
             // Given - AsciiDoc content with section titles not matching patterns
             String adocContent = """
-                = Test Document
-                
-                == Getting Started
-                
-                This section title doesn't match the required pattern.
-                
-                === technical details
-                
-                This subsection title doesn't start with uppercase.
-                
-                == Introduction
-                
-                This title matches the pattern.
-                
-                === Another Topic
-                
-                This subsection also matches the pattern.
-                """;
-            
+                    = Test Document
+
+                    == Getting Started
+
+                    This section title doesn't match the required pattern.
+
+                    === technical details
+
+                    This subsection title doesn't start with uppercase.
+
+                    == Introduction
+
+                    This title matches the pattern.
+
+                    === Another Topic
+
+                    This subsection also matches the pattern.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Section title does not match required pattern [section.title.pattern]
-                  File: %s:3:4-18
-                  Actual: Getting Started
-                  Expected: Pattern: ^(Introduction|Overview|Summary)$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | == Getting Started
-                     |    ~~~~~~~~~~~~~~~
-                   4 |\s
-                   5 | This section title doesn't match the required pattern.
-                   6 |\s
-                
-                [ERROR]: Section title does not match required pattern [section.title.pattern]
-                  File: %s:7:5-21
-                  Actual: technical details
-                  Expected: Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$
-                
-                   4 |\s
-                   5 | This section title doesn't match the required pattern.
-                   6 |\s
-                   7 | === technical details
-                     |     ~~~~~~~~~~~~~~~~~
-                   8 |\s
-                   9 | This subsection title doesn't start with uppercase.
-                  10 |\s
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Section title does not match required pattern [section.title.pattern]
+                              File: %s:3:4-18
+                              Actual: Getting Started
+                              Expected: Pattern: ^(Introduction|Overview|Summary)$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | == Getting Started
+                                 |    ~~~~~~~~~~~~~~~
+                               4 |\s
+                               5 | This section title doesn't match the required pattern.
+                               6 |\s
+
+                            [ERROR]: Section title does not match required pattern [section.title.pattern]
+                              File: %s:7:5-21
+                              Actual: technical details
+                              Expected: Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$
+
+                               4 |\s
+                               5 | This section title doesn't match the required pattern.
+                               6 |\s
+                               7 | === technical details
+                                 |     ~~~~~~~~~~~~~~~~~
+                               8 |\s
+                               9 | This subsection title doesn't start with uppercase.
+                              10 |\s
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for document title not matching pattern")
         void shouldShowUnderlineForDocumentTitleNotMatchingPattern(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for document title (level 0)
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z][A-Z0-9\\\\s]+$"
-                        severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z][A-Z0-9\\\\s]+$"
+                            severity: error
+                    """;
+
             // Given - AsciiDoc content with document title not matching pattern
             String adocContent = """
-                = My Test Document!
-                
-                == Section One
-                
-                Content here.
-                """;
-            
+                    = My Test Document!
+
+                    == Section One
+
+                    Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Document title does not match required pattern [section.title.pattern]
-                  File: %s:1:3-19
-                  Actual: My Test Document!
-                  Expected: Pattern: ^[A-Z][A-Z0-9\\s]+$
-                
-                   1 | = My Test Document!
-                     |   ~~~~~~~~~~~~~~~~~
-                   2 |\s
-                   3 | == Section One
-                   4 |\s
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Document title does not match required pattern [section.title.pattern]
+                              File: %s:1:3-19
+                              Actual: My Test Document!
+                              Expected: Pattern: ^[A-Z][A-Z0-9\\s]+$
+
+                               1 | = My Test Document!
+                                 |   ~~~~~~~~~~~~~~~~~
+                               2 |\s
+                               3 | == Section One
+                               4 |\s
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for section with subsection pattern mismatch")
         void shouldShowUnderlineForSectionWithSubsectionPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for subsection title
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      subsections:
-                        - name: headerTypeRule
-                          order: 1
-                          level: 1
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^Typ$"
-                            severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          subsections:
+                            - name: headerTypeRule
+                              order: 1
+                              level: 1
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^Typ$"
+                                severity: error
+                    """;
+
             // Given - AsciiDoc content with subsection title not matching pattern
             String adocContent = """
-                = Test Document
-                
-                == Wrong Title
-                
-                This section title doesn't match the required pattern "Typ".
-                """;
-            
+                    = Test Document
+
+                    == Wrong Title
+
+                    This section title doesn't match the required pattern "Typ".
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Section title does not match required pattern [section.title.pattern]
-                  File: %s:3:4-14
-                  Actual: Wrong Title
-                  Expected: Pattern: ^Typ$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | == Wrong Title
-                     |    ~~~~~~~~~~~
-                   4 |\s
-                   5 | This section title doesn't match the required pattern "Typ".
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Section title does not match required pattern [section.title.pattern]
+                              File: %s:3:4-14
+                              Actual: Wrong Title
+                              Expected: Pattern: ^Typ$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | == Wrong Title
+                                 |    ~~~~~~~~~~~
+                               4 |\s
+                               5 | This section title doesn't match the required pattern "Typ".
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for multiple section pattern mismatches")
         void shouldShowUnderlineForMultipleSectionPatternMismatches(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with different patterns for different section levels
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      title:
-                        pattern: "^[A-Z][a-zA-Z\\\\s]+Guide$"
-                        severity: error
-                      subsections:
-                        - level: 1
+                    document:
+                      sections:
+                        - level: 0
                           title:
-                            pattern: "^Chapter \\\\d+: .+$"
+                            pattern: "^[A-Z][a-zA-Z\\\\s]+Guide$"
                             severity: error
                           subsections:
-                            - level: 2
+                            - level: 1
                               title:
-                                pattern: "^\\\\d+\\\\.\\\\d+ .+$"
-                                severity: warn
-                """;
-            
+                                pattern: "^Chapter \\\\d+: .+$"
+                                severity: error
+                              subsections:
+                                - level: 2
+                                  title:
+                                    pattern: "^\\\\d+\\\\.\\\\d+ .+$"
+                                    severity: warn
+                    """;
+
             // Given - AsciiDoc content with multiple pattern violations
             String adocContent = """
-                = Technical Documentation
-                
-                == Introduction
-                
-                This doesn't match the Chapter pattern.
-                
-                === Overview
-                
-                This doesn't match the numbered pattern.
-                
-                == Chapter 1: Getting Started
-                
-                This section matches the pattern.
-                
-                === 1.1 Installation
-                
-                This subsection matches the pattern.
-                
-                === Setup Instructions
-                
-                This doesn't match the numbered pattern.
-                """;
-            
+                    = Technical Documentation
+
+                    == Introduction
+
+                    This doesn't match the Chapter pattern.
+
+                    === Overview
+
+                    This doesn't match the numbered pattern.
+
+                    == Chapter 1: Getting Started
+
+                    This section matches the pattern.
+
+                    === 1.1 Installation
+
+                    This subsection matches the pattern.
+
+                    === Setup Instructions
+
+                    This doesn't match the numbered pattern.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Document title does not match required pattern [section.title.pattern]
-                  File: %s:1:3-25
-                  Actual: Technical Documentation
-                  Expected: Pattern: ^[A-Z][a-zA-Z\\s]+Guide$
-                
-                   1 | = Technical Documentation
-                     |   ~~~~~~~~~~~~~~~~~~~~~~~
-                   2 |\s
-                   3 | == Introduction
-                   4 |\s
-                
-                [ERROR]: Section title does not match required pattern [section.title.pattern]
-                  File: %s:3:4-15
-                  Actual: Introduction
-                  Expected: Pattern: ^Chapter \\d+: .+$
-                
-                   1 | = Technical Documentation
-                   2 |\s
-                   3 | == Introduction
-                     |    ~~~~~~~~~~~~
-                   4 |\s
-                   5 | This doesn't match the Chapter pattern.
-                   6 |\s
-                
-                [WARN]: Section title does not match required pattern [section.title.pattern]
-                  File: %s:7:5-12
-                  Actual: Overview
-                  Expected: Pattern: ^\\d+\\.\\d+ .+$
-                
-                   4 |\s
-                   5 | This doesn't match the Chapter pattern.
-                   6 |\s
-                   7 | === Overview
-                     |     ~~~~~~~~
-                   8 |\s
-                   9 | This doesn't match the numbered pattern.
-                  10 |\s
-                
-                [WARN]: Section title does not match required pattern [section.title.pattern]
-                  File: %s:19:5-22
-                  Actual: Setup Instructions
-                  Expected: Pattern: ^\\d+\\.\\d+ .+$
-                
-                  16 |\s
-                  17 | This subsection matches the pattern.
-                  18 |\s
-                  19 | === Setup Instructions
-                     |     ~~~~~~~~~~~~~~~~~~
-                  20 |\s
-                  21 | This doesn't match the numbered pattern.
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Document title does not match required pattern [section.title.pattern]
+                              File: %s:1:3-25
+                              Actual: Technical Documentation
+                              Expected: Pattern: ^[A-Z][a-zA-Z\\s]+Guide$
+
+                               1 | = Technical Documentation
+                                 |   ~~~~~~~~~~~~~~~~~~~~~~~
+                               2 |\s
+                               3 | == Introduction
+                               4 |\s
+
+                            [ERROR]: Section title does not match required pattern [section.title.pattern]
+                              File: %s:3:4-15
+                              Actual: Introduction
+                              Expected: Pattern: ^Chapter \\d+: .+$
+
+                               1 | = Technical Documentation
+                               2 |\s
+                               3 | == Introduction
+                                 |    ~~~~~~~~~~~~
+                               4 |\s
+                               5 | This doesn't match the Chapter pattern.
+                               6 |\s
+
+                            [WARN]: Section title does not match required pattern [section.title.pattern]
+                              File: %s:7:5-12
+                              Actual: Overview
+                              Expected: Pattern: ^\\d+\\.\\d+ .+$
+
+                               4 |\s
+                               5 | This doesn't match the Chapter pattern.
+                               6 |\s
+                               7 | === Overview
+                                 |     ~~~~~~~~
+                               8 |\s
+                               9 | This doesn't match the numbered pattern.
+                              10 |\s
+
+                            [WARN]: Section title does not match required pattern [section.title.pattern]
+                              File: %s:19:5-22
+                              Actual: Setup Instructions
+                              Expected: Pattern: ^\\d+\\.\\d+ .+$
+
+                              16 |\s
+                              17 | This subsection matches the pattern.
+                              18 |\s
+                              19 | === Setup Instructions
+                                 |     ~~~~~~~~~~~~~~~~~~
+                              20 |\s
+                              21 | This doesn't match the numbered pattern.
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString(),
+                    testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Admonition Block Validation Tests")
     class AdmonitionValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for admonition with disallowed type")
         void shouldShowUnderlineForAdmonitionDisallowedType(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with allowed types for admonition blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: error
-                            type:
-                              required: true
-                              allowed: ["NOTE", "TIP", "WARNING"]
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: error
+                                type:
+                                  required: true
+                                  allowed: ["NOTE", "TIP", "WARNING"]
+                    """;
+
             // Given - AsciiDoc content with admonitions using different types
             String adocContent = """
-                = Test Document
-                
-                NOTE: This is a valid note.
-                
-                TIP: This is a valid tip.
-                
-                IMPORTANT: This type is not allowed.
-                
-                WARNING: This is allowed.
-                
-                CAUTION: This type is also not allowed.
-                """;
-            
+                    = Test Document
+
+                    NOTE: This is a valid note.
+
+                    TIP: This is a valid tip.
+
+                    IMPORTANT: This type is not allowed.
+
+                    WARNING: This is allowed.
+
+                    CAUTION: This type is also not allowed.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Admonition type 'IMPORTANT' is not allowed [admonition.type.allowed]
-                  File: %s:7:1-9
-                  Actual: IMPORTANT
-                  Expected: One of: NOTE, TIP, WARNING
-                
-                   4 |\s
-                   5 | TIP: This is a valid tip.
-                   6 |\s
-                   7 | IMPORTANT: This type is not allowed.
-                     | ~~~~~~~~~
-                   8 |\s
-                   9 | WARNING: This is allowed.
-                  10 |\s
-                
-                [ERROR]: Admonition type 'CAUTION' is not allowed [admonition.type.allowed]
-                  File: %s:11:1-7
-                  Actual: CAUTION
-                  Expected: One of: NOTE, TIP, WARNING
-                
-                   8 |\s
-                   9 | WARNING: This is allowed.
-                  10 |\s
-                  11 | CAUTION: This type is also not allowed.
-                     | ~~~~~~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Admonition type 'IMPORTANT' is not allowed [admonition.type.allowed]
+                              File: %s:7:1-9
+                              Actual: IMPORTANT
+                              Expected: One of: NOTE, TIP, WARNING
+
+                               4 |\s
+                               5 | TIP: This is a valid tip.
+                               6 |\s
+                               7 | IMPORTANT: This type is not allowed.
+                                 | ~~~~~~~~~
+                               8 |\s
+                               9 | WARNING: This is allowed.
+                              10 |\s
+
+                            [ERROR]: Admonition type 'CAUTION' is not allowed [admonition.type.allowed]
+                              File: %s:11:1-7
+                              Actual: CAUTION
+                              Expected: One of: NOTE, TIP, WARNING
+
+                               8 |\s
+                               9 | WARNING: This is allowed.
+                              10 |\s
+                              11 | CAUTION: This type is also not allowed.
+                                 | ~~~~~~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for admonition title below min length")
         void shouldShowUnderlineForAdmonitionTitleBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for admonition title
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: warn
-                            title:
-                              required: true
-                              minLength: 10
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: warn
+                                title:
+                                  required: true
+                                  minLength: 10
+                    """;
+
             // Given - AsciiDoc content with admonition titles below min length
             String adocContent = """
-                = Test Document
-                
-                .Note
-                NOTE: This title is too short.
-                
-                .Important Information
-                NOTE: This title has proper length.
-                
-                .Tip
-                TIP: Another short title.
-                """;
-            
+                    = Test Document
+
+                    .Note
+                    NOTE: This title is too short.
+
+                    .Important Information
+                    NOTE: This title has proper length.
+
+                    .Tip
+                    TIP: Another short title.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Admonition title is too short [admonition.title.minLength]
-                  File: %s:3:1-5
-                  Actual: 4 characters
-                  Expected: At least 10 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .Note
-                     | ~~~~~
-                   4 | NOTE: This title is too short.
-                   5 |\s
-                   6 | .Important Information
-                
-                [WARN]: Admonition title is too short [admonition.title.minLength]
-                  File: %s:9:1-4
-                  Actual: 3 characters
-                  Expected: At least 10 characters
-                
-                   6 | .Important Information
-                   7 | NOTE: This title has proper length.
-                   8 |\s
-                   9 | .Tip
-                     | ~~~~
-                  10 | TIP: Another short title.
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Admonition title is too short [admonition.title.minLength]
+                              File: %s:3:1-5
+                              Actual: 4 characters
+                              Expected: At least 10 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .Note
+                                 | ~~~~~
+                               4 | NOTE: This title is too short.
+                               5 |\s
+                               6 | .Important Information
+
+                            [WARN]: Admonition title is too short [admonition.title.minLength]
+                              File: %s:9:1-4
+                              Actual: 3 characters
+                              Expected: At least 10 characters
+
+                               6 | .Important Information
+                               7 | NOTE: This title has proper length.
+                               8 |\s
+                               9 | .Tip
+                                 | ~~~~
+                              10 | TIP: Another short title.
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for admonition title exceeding max length")
         void shouldShowUnderlineForAdmonitionTitleExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for admonition title
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: error
-                            title:
-                              required: true
-                              maxLength: 25
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: error
+                                title:
+                                  required: true
+                                  maxLength: 25
+                    """;
+
             // Given - AsciiDoc content with admonition titles exceeding max length
             String adocContent = """
-                = Test Document
-                
-                .This is an extremely long admonition title that exceeds the maximum allowed length
-                NOTE: Content here.
-                
-                .Short Title
-                WARNING: Content here.
-                
-                .Another very long title that should be much shorter
-                TIP: Content here.
-                """;
-            
+                    = Test Document
+
+                    .This is an extremely long admonition title that exceeds the maximum allowed length
+                    NOTE: Content here.
+
+                    .Short Title
+                    WARNING: Content here.
+
+                    .Another very long title that should be much shorter
+                    TIP: Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Admonition title is too long [admonition.title.maxLength]
-                  File: %s:3:1-83
-                  Actual: 82 characters
-                  Expected: At most 25 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .This is an extremely long admonition title that exceeds the maximum allowed length
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 | NOTE: Content here.
-                   5 |\s
-                   6 | .Short Title
-                
-                [ERROR]: Admonition title is too long [admonition.title.maxLength]
-                  File: %s:9:1-52
-                  Actual: 51 characters
-                  Expected: At most 25 characters
-                
-                   6 | .Short Title
-                   7 | WARNING: Content here.
-                   8 |\s
-                   9 | .Another very long title that should be much shorter
-                     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  10 | TIP: Content here.
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Admonition title is too long [admonition.title.maxLength]
+                              File: %s:3:1-83
+                              Actual: 82 characters
+                              Expected: At most 25 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .This is an extremely long admonition title that exceeds the maximum allowed length
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 | NOTE: Content here.
+                               5 |\s
+                               6 | .Short Title
+
+                            [ERROR]: Admonition title is too long [admonition.title.maxLength]
+                              File: %s:9:1-52
+                              Actual: 51 characters
+                              Expected: At most 25 characters
+
+                               6 | .Short Title
+                               7 | WARNING: Content here.
+                               8 |\s
+                               9 | .Another very long title that should be much shorter
+                                 | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              10 | TIP: Content here.
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for admonition title not matching pattern")
         void shouldShowUnderlineForAdmonitionTitlePatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for admonition title
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: error
-                            title:
-                              required: true
-                              pattern: "^[A-Z][a-zA-Z0-9 ]+$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: error
+                                title:
+                                  required: true
+                                  pattern: "^[A-Z][a-zA-Z0-9 ]+$"
+                    """;
+
             // Given - AsciiDoc content with admonition titles not matching pattern
             String adocContent = """
-                = Test Document
-                
-                .lowercase title
-                NOTE: Invalid title starting with lowercase.
-                
-                .Valid Title Format
-                WARNING: This title matches the pattern.
-                
-                .Title-with-hyphens!
-                TIP: Invalid title with special characters.
-                """;
-            
+                    = Test Document
+
+                    .lowercase title
+                    NOTE: Invalid title starting with lowercase.
+
+                    .Valid Title Format
+                    WARNING: This title matches the pattern.
+
+                    .Title-with-hyphens!
+                    TIP: Invalid title with special characters.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Admonition title does not match required pattern [admonition.title.pattern]
-                  File: %s:3:1-16
-                  Actual: lowercase title
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .lowercase title
-                     | ~~~~~~~~~~~~~~~~
-                   4 | NOTE: Invalid title starting with lowercase.
-                   5 |\s
-                   6 | .Valid Title Format
-                
-                [ERROR]: Admonition title does not match required pattern [admonition.title.pattern]
-                  File: %s:9:1-20
-                  Actual: Title-with-hyphens!
-                  Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
-                
-                   6 | .Valid Title Format
-                   7 | WARNING: This title matches the pattern.
-                   8 |\s
-                   9 | .Title-with-hyphens!
-                     | ~~~~~~~~~~~~~~~~~~~~
-                  10 | TIP: Invalid title with special characters.
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Admonition title does not match required pattern [admonition.title.pattern]
+                              File: %s:3:1-16
+                              Actual: lowercase title
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .lowercase title
+                                 | ~~~~~~~~~~~~~~~~
+                               4 | NOTE: Invalid title starting with lowercase.
+                               5 |\s
+                               6 | .Valid Title Format
+
+                            [ERROR]: Admonition title does not match required pattern [admonition.title.pattern]
+                              File: %s:9:1-20
+                              Actual: Title-with-hyphens!
+                              Expected: Pattern: ^[A-Z][a-zA-Z0-9 ]+$
+
+                               6 | .Valid Title Format
+                               7 | WARNING: This title matches the pattern.
+                               8 |\s
+                               9 | .Title-with-hyphens!
+                                 | ~~~~~~~~~~~~~~~~~~~~
+                              10 | TIP: Invalid title with special characters.
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for admonition content below min length")
         void shouldShowUnderlineForAdmonitionContentBelowMinLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with min length for admonition content
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: warn
-                            content:
-                              required: true
-                              minLength: 20
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: warn
+                                content:
+                                  required: true
+                                  minLength: 20
+                    """;
+
             // Given - AsciiDoc content with admonition content below min length
             String adocContent = """
-                = Test Document
-                
-                NOTE: Too short.
-                
-                WARNING: This content has sufficient length to pass validation.
-                
-                TIP: Brief tip.
-                """;
-            
+                    = Test Document
+
+                    NOTE: Too short.
+
+                    WARNING: This content has sufficient length to pass validation.
+
+                    TIP: Brief tip.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [WARN]: Admonition content is too short [admonition.content.minLength]
-                  File: %s:3:7-16
-                  Actual: 10 characters
-                  Expected: At least 20 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | NOTE: Too short.
-                     |       ~~~~~~~~~~
-                   4 |\s
-                   5 | WARNING: This content has sufficient length to pass validation.
-                   6 |\s
-                
-                [WARN]: Admonition content is too short [admonition.content.minLength]
-                  File: %s:7:6-15
-                  Actual: 10 characters
-                  Expected: At least 20 characters
-                
-                   4 |\s
-                   5 | WARNING: This content has sufficient length to pass validation.
-                   6 |\s
-                   7 | TIP: Brief tip.
-                     |      ~~~~~~~~~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [WARN]: Admonition content is too short [admonition.content.minLength]
+                              File: %s:3:7-16
+                              Actual: 10 characters
+                              Expected: At least 20 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | NOTE: Too short.
+                                 |       ~~~~~~~~~~
+                               4 |\s
+                               5 | WARNING: This content has sufficient length to pass validation.
+                               6 |\s
+
+                            [WARN]: Admonition content is too short [admonition.content.minLength]
+                              File: %s:7:6-15
+                              Actual: 10 characters
+                              Expected: At least 20 characters
+
+                               4 |\s
+                               5 | WARNING: This content has sufficient length to pass validation.
+                               6 |\s
+                               7 | TIP: Brief tip.
+                                 |      ~~~~~~~~~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for admonition content exceeding max length")
         void shouldShowUnderlineForAdmonitionContentExceedingMaxLength(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with max length for admonition content
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: error
-                            content:
-                              required: true
-                              maxLength: 50
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: error
+                                content:
+                                  required: true
+                                  maxLength: 50
+                    """;
+
             // Given - AsciiDoc content with admonition content exceeding max length
             String adocContent = """
-                = Test Document
-                
-                NOTE: This is an extremely long admonition content that definitely exceeds the maximum allowed length.
-                
-                WARNING: Short and concise warning message.
-                
-                TIP: Another excessively long tip content that should be shortened to comply with the maximum length rules.
-                """;
-            
+                    = Test Document
+
+                    NOTE: This is an extremely long admonition content that definitely exceeds the maximum allowed length.
+
+                    WARNING: Short and concise warning message.
+
+                    TIP: Another excessively long tip content that should be shortened to comply with the maximum length rules.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Admonition content is too long [admonition.content.maxLength]
-                  File: %s:3:7-102
-                  Actual: 96 characters
-                  Expected: At most 50 characters
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | NOTE: This is an extremely long admonition content that definitely exceeds the maximum allowed length.
-                     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   4 |\s
-                   5 | WARNING: Short and concise warning message.
-                   6 |\s
-                
-                [ERROR]: Admonition content is too long [admonition.content.maxLength]
-                  File: %s:7:6-107
-                  Actual: 102 characters
-                  Expected: At most 50 characters
-                
-                   4 |\s
-                   5 | WARNING: Short and concise warning message.
-                   6 |\s
-                   7 | TIP: Another excessively long tip content that should be shortened to comply with the maximum length rules.
-                     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Admonition content is too long [admonition.content.maxLength]
+                              File: %s:3:7-102
+                              Actual: 96 characters
+                              Expected: At most 50 characters
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | NOTE: This is an extremely long admonition content that definitely exceeds the maximum allowed length.
+                                 |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               4 |\s
+                               5 | WARNING: Short and concise warning message.
+                               6 |\s
+
+                            [ERROR]: Admonition content is too long [admonition.content.maxLength]
+                              File: %s:7:6-107
+                              Actual: 102 characters
+                              Expected: At most 50 characters
+
+                               4 |\s
+                               5 | WARNING: Short and concise warning message.
+                               6 |\s
+                               7 | TIP: Another excessively long tip content that should be shortened to comply with the maximum length rules.
+                                 |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for admonition icon not matching pattern")
         void shouldShowUnderlineForAdmonitionIconPatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern for admonition icon
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - admonition:
-                            severity: error
-                            icon:
-                              required: true
-                              pattern: "^icon:[a-z-]+\\\\[\\\\]$"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - admonition:
+                                severity: error
+                                icon:
+                                  required: true
+                                  pattern: "^icon:[a-z-]+\\\\[\\\\]$"
+                    """;
+
             // Given - AsciiDoc content with admonition icons not matching pattern
             String adocContent = """
-                = Test Document
-                
-                [NOTE,icon=warning]
-                ====
-                Invalid icon format.
-                ====
-                
-                [TIP,icon="icon:lightbulb[]"]
-                ====
-                Valid icon format.
-                ====
-                
-                [WARNING,icon="icon:ALERT[]"]
-                ====
-                Invalid uppercase icon.
-                ====
-                """;
-            
+                    = Test Document
+
+                    [NOTE,icon=warning]
+                    ====
+                    Invalid icon format.
+                    ====
+
+                    [TIP,icon="icon:lightbulb[]"]
+                    ====
+                    Valid icon format.
+                    ====
+
+                    [WARNING,icon="icon:ALERT[]"]
+                    ====
+                    Invalid uppercase icon.
+                    ====
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Admonition icon does not match required pattern [admonition.icon.pattern]
-                  File: %s:3:12-18
-                  Actual: warning
-                  Expected: Pattern: ^icon:[a-z-]+\\[\\]$
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | [NOTE,icon=warning]
-                     |            ~~~~~~~
-                   4 | ====
-                   5 | Invalid icon format.
-                   6 | ====
-                
-                [ERROR]: Admonition icon does not match required pattern [admonition.icon.pattern]
-                  File: %s:13:16-27
-                  Actual: icon:ALERT[]
-                  Expected: Pattern: ^icon:[a-z-]+\\[\\]$
-                
-                  10 | Valid icon format.
-                  11 | ====
-                  12 |\s
-                  13 | [WARNING,icon="icon:ALERT[]"]
-                     |                ~~~~~~~~~~~~
-                  14 | ====
-                  15 | Invalid uppercase icon.
-                  16 | ====
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Admonition icon does not match required pattern [admonition.icon.pattern]
+                              File: %s:3:12-18
+                              Actual: warning
+                              Expected: Pattern: ^icon:[a-z-]+\\[\\]$
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | [NOTE,icon=warning]
+                                 |            ~~~~~~~
+                               4 | ====
+                               5 | Invalid icon format.
+                               6 | ====
+
+                            [ERROR]: Admonition icon does not match required pattern [admonition.icon.pattern]
+                              File: %s:13:16-27
+                              Actual: icon:ALERT[]
+                              Expected: Pattern: ^icon:[a-z-]+\\[\\]$
+
+                              10 | Valid icon format.
+                              11 | ====
+                              12 |\s
+                              13 | [WARNING,icon="icon:ALERT[]"]
+                                 |                ~~~~~~~~~~~~
+                              14 | ====
+                              15 | Invalid uppercase icon.
+                              16 | ====
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Listing Block Validation Tests")
     class ListingValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for listing block with disallowed language")
         void shouldShowUnderlineForListingDisallowedLanguage(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with allowed languages for listing blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - listing:
-                            severity: error
-                            language:
-                              required: true
-                              severity: error
-                              allowed: ["java", "python", "javascript", "xml"]
-                              severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - listing:
+                                severity: error
+                                language:
+                                  required: true
+                                  severity: error
+                                  allowed: ["java", "python", "javascript", "xml"]
+                                  severity: error
+                    """;
+
             // Given - AsciiDoc content with listing blocks using different languages
             String adocContent = """
-                = Test Document
-                
-                [source,java]
-                ----
-                public class Hello {
-                    public static void main(String[] args) {
-                        System.out.println("Hello World");
+                    = Test Document
+
+                    [source,java]
+                    ----
+                    public class Hello {
+                        public static void main(String[] args) {
+                            System.out.println("Hello World");
+                        }
                     }
-                }
-                ----
-                
-                [source,ruby]
-                ----
-                puts "Hello World"
-                ----
-                
-                [source,python]
-                ----
-                print("Hello World")
-                ----
-                
-                [source,golang]
-                ----
-                fmt.Println("Hello World")
-                ----
-                """;
-            
+                    ----
+
+                    [source,ruby]
+                    ----
+                    puts "Hello World"
+                    ----
+
+                    [source,python]
+                    ----
+                    print("Hello World")
+                    ----
+
+                    [source,golang]
+                    ----
+                    fmt.Println("Hello World")
+                    ----
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Listing language 'ruby' is not allowed [listing.language.allowed]
-                  File: %s:12:9-12
-                  Actual: ruby
-                  Expected: One of: java, python, javascript, xml
-                
-                   9 | }
-                  10 | ----
-                  11 |\s
-                  12 | [source,ruby]
-                     |         ~~~~
-                  13 | ----
-                  14 | puts "Hello World"
-                  15 | ----
-                
-                [ERROR]: Listing language 'golang' is not allowed [listing.language.allowed]
-                  File: %s:22:9-14
-                  Actual: golang
-                  Expected: One of: java, python, javascript, xml
-                
-                  19 | print("Hello World")
-                  20 | ----
-                  21 |\s
-                  22 | [source,golang]
-                     |         ~~~~~~
-                  23 | ----
-                  24 | fmt.Println("Hello World")
-                  25 | ----
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Listing language 'ruby' is not allowed [listing.language.allowed]
+                              File: %s:12:9-12
+                              Actual: ruby
+                              Expected: One of: java, python, javascript, xml
+
+                               9 | }
+                              10 | ----
+                              11 |\s
+                              12 | [source,ruby]
+                                 |         ~~~~
+                              13 | ----
+                              14 | puts "Hello World"
+                              15 | ----
+
+                            [ERROR]: Listing language 'golang' is not allowed [listing.language.allowed]
+                              File: %s:22:9-14
+                              Actual: golang
+                              Expected: One of: java, python, javascript, xml
+
+                              19 | print("Hello World")
+                              20 | ----
+                              21 |\s
+                              22 | [source,golang]
+                                 |         ~~~~~~
+                              23 | ----
+                              24 | fmt.Println("Hello World")
+                              25 | ----
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for listing title not matching pattern")
         void shouldShowUnderlineForListingTitlePatternMismatch(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with title pattern for listing blocks
             String rules = """
-                document:
-                  sections:
-                    - level: 0
-                      allowedBlocks:
-                        - listing:
-                            severity: error
-                            title:
-                              severity: error
-                              required: true
-                              pattern: "^(Listing|Example|Code) \\\\d+\\\\..+"
-                """;
-            
+                    document:
+                      sections:
+                        - level: 0
+                          allowedBlocks:
+                            - listing:
+                                severity: error
+                                title:
+                                  severity: error
+                                  required: true
+                                  pattern: "^(Listing|Example|Code) \\\\d+\\\\..+"
+                    """;
+
             // Given - AsciiDoc content with listing blocks having titles
             String adocContent = """
-                = Test Document
-                
-                .Invalid title format
-                [source,java]
-                ----
-                public class Test {}
-                ----
-                
-                .Listing 1. Valid Java Example
-                [source,java]
-                ----
-                public class Valid {}
-                ----
-                
-                .My Code Sample
-                [source,python]
-                ----
-                def hello():
-                    pass
-                ----
-                
-                .Example 2. Another valid title
-                [source,xml]
-                ----
-                <root/>
-                ----
-                """;
-            
+                    = Test Document
+
+                    .Invalid title format
+                    [source,java]
+                    ----
+                    public class Test {}
+                    ----
+
+                    .Listing 1. Valid Java Example
+                    [source,java]
+                    ----
+                    public class Valid {}
+                    ----
+
+                    .My Code Sample
+                    [source,python]
+                    ----
+                    def hello():
+                        pass
+                    ----
+
+                    .Example 2. Another valid title
+                    [source,xml]
+                    ----
+                    <root/>
+                    ----
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Listing title does not match required pattern [listing.title.pattern]
-                  File: %s:3:1-21
-                  Actual: Invalid title format
-                  Expected: Pattern: ^(Listing|Example|Code) \\d+\\..+
-                
-                   1 | = Test Document
-                   2 |\s
-                   3 | .Invalid title format
-                     | ~~~~~~~~~~~~~~~~~~~~~
-                   4 | [source,java]
-                   5 | ----
-                   6 | public class Test {}
-                
-                [ERROR]: Listing title does not match required pattern [listing.title.pattern]
-                  File: %s:15:1-15
-                  Actual: My Code Sample
-                  Expected: Pattern: ^(Listing|Example|Code) \\d+\\..+
-                
-                  12 | public class Valid {}
-                  13 | ----
-                  14 |\s
-                  15 | .My Code Sample
-                     | ~~~~~~~~~~~~~~~
-                  16 | [source,python]
-                  17 | ----
-                  18 | def hello():
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Listing title does not match required pattern [listing.title.pattern]
+                              File: %s:3:1-21
+                              Actual: Invalid title format
+                              Expected: Pattern: ^(Listing|Example|Code) \\d+\\..+
+
+                               1 | = Test Document
+                               2 |\s
+                               3 | .Invalid title format
+                                 | ~~~~~~~~~~~~~~~~~~~~~
+                               4 | [source,java]
+                               5 | ----
+                               6 | public class Test {}
+
+                            [ERROR]: Listing title does not match required pattern [listing.title.pattern]
+                              File: %s:15:1-15
+                              Actual: My Code Sample
+                              Expected: Pattern: ^(Listing|Example|Code) \\d+\\..+
+
+                              12 | public class Valid {}
+                              13 | ----
+                              14 |\s
+                              15 | .My Code Sample
+                                 | ~~~~~~~~~~~~~~~
+                              16 | [source,python]
+                              17 | ----
+                              18 | def hello():
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
     @Nested
     @DisplayName("Metadata Attribute Validation Tests")
     class MetadataValidationTests {
-        
+
         @Test
         @DisplayName("should show underline for attribute value violating pattern rule")
         void shouldShowUnderlineForAttributePatternViolation(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern rule for metadata attributes
             String rules = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: author
-                        pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
-                        severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: author
+                            pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
+                            severity: error
+                    """;
+
             // Given - AsciiDoc content with invalid author format
             String adocContent = """
-                = Test Document
-                :author: john doe
-                :email: john@example.com
-                
-                Content here.
-                """;
-            
+                    = Test Document
+                    :author: john doe
+                    :email: john@example.com
+
+                    Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Attribute 'author' does not match required pattern: actual 'john doe', expected pattern '^[A-Z][a-z]+ [A-Z][a-z]+$' [metadata.pattern]
-                  File: %s:2:10-17
-                  Actual: john doe
-                  Expected: Pattern '^[A-Z][a-z]+ [A-Z][a-z]+$'
-                
-                   1 | = Test Document
-                   2 | :author: john doe
-                     |          ~~~~~~~~
-                   3 | :email: john@example.com
-                   4 |\s
-                   5 | Content here.
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Attribute 'author' does not match required pattern: actual 'john doe', expected pattern '^[A-Z][a-z]+ [A-Z][a-z]+$' [metadata.pattern]
+                              File: %s:2:10-17
+                              Actual: john doe
+                              Expected: Pattern '^[A-Z][a-z]+ [A-Z][a-z]+$'
+
+                               1 | = Test Document
+                               2 | :author: john doe
+                                 |          ~~~~~~~~
+                               3 | :email: john@example.com
+                               4 |\s
+                               5 | Content here.
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for attribute value violating minLength rule")
         void shouldShowUnderlineForAttributeMinLengthViolation(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with minLength rule for metadata attributes
             String rules = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: description
-                        minLength: 20
-                        severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: description
+                            minLength: 20
+                            severity: error
+                    """;
+
             // Given - AsciiDoc content with too short description
             String adocContent = """
-                = Test Document
-                :author: John Doe
-                :description: Short
-                
-                Content here.
-                """;
-            
+                    = Test Document
+                    :author: John Doe
+                    :description: Short
+
+                    Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Attribute 'description' is too short: actual 'Short' (5 characters), expected minimum 20 characters [metadata.length.min]
-                  File: %s:3:15-19
-                  Actual: Short (5 characters)
-                  Expected: Minimum 20 characters
-                
-                   1 | = Test Document
-                   2 | :author: John Doe
-                   3 | :description: Short
-                     |               ~~~~~
-                   4 |\s
-                   5 | Content here.
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Attribute 'description' is too short: actual 'Short' (5 characters), expected minimum 20 characters [metadata.length.min]
+                              File: %s:3:15-19
+                              Actual: Short (5 characters)
+                              Expected: Minimum 20 characters
+
+                               1 | = Test Document
+                               2 | :author: John Doe
+                               3 | :description: Short
+                                 |               ~~~~~
+                               4 |\s
+                               5 | Content here.
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for attribute value violating maxLength rule")
         void shouldShowUnderlineForAttributeMaxLengthViolation(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with maxLength rule for metadata attributes
             String rules = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: title
-                        maxLength: 10
-                        severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: title
+                            maxLength: 10
+                            severity: error
+                    """;
+
             // Given - AsciiDoc content with too long title
             String adocContent = """
-                = Test Document
-                :title: This is a very long title that exceeds the limit
-                :author: John Doe
-                
-                Content here.
-                """;
-            
+                    = Test Document
+                    :title: This is a very long title that exceeds the limit
+                    :author: John Doe
+
+                    Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Attribute 'title' is too long: actual 'This is a very long title that exceeds the limit' (48 characters), expected maximum 10 characters [metadata.length.max]
-                  File: %s:2:9-56
-                  Actual: This is a very long title that exceeds the limit (48 characters)
-                  Expected: Maximum 10 characters
-                
-                   1 | = Test Document
-                   2 | :title: This is a very long title that exceeds the limit
-                     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                   3 | :author: John Doe
-                   4 |\s
-                   5 | Content here.
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Attribute 'title' is too long: actual 'This is a very long title that exceeds the limit' (48 characters), expected maximum 10 characters [metadata.length.max]
+                              File: %s:2:9-56
+                              Actual: This is a very long title that exceeds the limit (48 characters)
+                              Expected: Maximum 10 characters
+
+                               1 | = Test Document
+                               2 | :title: This is a very long title that exceeds the limit
+                                 |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                               3 | :author: John Doe
+                               4 |\s
+                               5 | Content here.
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should correctly position underline for attribute value with spaces")
         void shouldCorrectlyPositionUnderlineWithSpaces(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with pattern rule for metadata attributes
             String rules = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: version
-                        pattern: "^\\\\d+\\\\.\\\\d+\\\\.\\\\d+$"
-                        severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: version
+                            pattern: "^\\\\d+\\\\.\\\\d+\\\\.\\\\d+$"
+                            severity: error
+                    """;
+
             // Given - AsciiDoc content with invalid version (has spaces before value)
             String adocContent = """
-                = Test Document
-                :version:   1.0
-                :author: John Doe
-                
-                Content here.
-                """;
-            
+                    = Test Document
+                    :version:   1.0
+                    :author: John Doe
+
+                    Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underline at correct position
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Attribute 'version' does not match required pattern: actual '1.0', expected pattern '^\\d+\\.\\d+\\.\\d+$' [metadata.pattern]
-                  File: %s:2:13-15
-                  Actual: 1.0
-                  Expected: Pattern '^\\d+\\.\\d+\\.\\d+$'
-                
-                   1 | = Test Document
-                   2 | :version:   1.0
-                     |             ~~~
-                   3 | :author: John Doe
-                   4 |\s
-                   5 | Content here.
-                
-                
-                """, testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Attribute 'version' does not match required pattern: actual '1.0', expected pattern '^\\d+\\.\\d+\\.\\d+$' [metadata.pattern]
+                              File: %s:2:13-15
+                              Actual: 1.0
+                              Expected: Pattern '^\\d+\\.\\d+\\.\\d+$'
+
+                               1 | = Test Document
+                               2 | :version:   1.0
+                                 |             ~~~
+                               3 | :author: John Doe
+                               4 |\s
+                               5 | Content here.
+
+
+                            """,
+                    testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
-        
+
         @Test
         @DisplayName("should show underline for multiple attribute violations")
         void shouldShowUnderlineForMultipleAttributeViolations(@TempDir Path tempDir) throws IOException {
             // Given - YAML rules with multiple constraints for metadata attributes
             String rules = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: author
-                        pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
-                        minLength: 10
-                        severity: error
-                      - name: version
-                        pattern: "^\\\\d+\\\\.\\\\d+\\\\.\\\\d+$"
-                        severity: warn
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: author
+                            pattern: "^[A-Z][a-z]+ [A-Z][a-z]+$"
+                            minLength: 10
+                            severity: error
+                          - name: version
+                            pattern: "^\\\\d+\\\\.\\\\d+\\\\.\\\\d+$"
+                            severity: warn
+                    """;
+
             // Given - AsciiDoc content with multiple violations
             String adocContent = """
-                = Test Document
-                :author: joe
-                :version: 1.0-SNAPSHOT
-                :description: Valid description
-                
-                Content here.
-                """;
-            
+                    = Test Document
+                    :author: joe
+                    :version: 1.0-SNAPSHOT
+                    :description: Valid description
+
+                    Content here.
+                    """;
+
             // When - Validate and format output
             String actualOutput = validateAndFormat(rules, adocContent, tempDir);
-            
+
             // Then - Verify exact console output with underlines for both violations
             Path testFile = tempDir.resolve("test.adoc");
-            String expectedOutput = String.format("""
-                +----------------------------------------------------------------------------------------------------------------------+
-                |                                                  Validation Report                                                   |
-                +----------------------------------------------------------------------------------------------------------------------+
-                
-                %s:
-                
-                [ERROR]: Attribute 'author' does not match required pattern: actual 'joe', expected pattern '^[A-Z][a-z]+ [A-Z][a-z]+$' [metadata.pattern]
-                  File: %s:2:10-12
-                  Actual: joe
-                  Expected: Pattern '^[A-Z][a-z]+ [A-Z][a-z]+$'
-                
-                   1 | = Test Document
-                   2 | :author: joe
-                     |          ~~~
-                   3 | :version: 1.0-SNAPSHOT
-                   4 | :description: Valid description
-                   5 |\s
-                
-                [ERROR]: Attribute 'author' is too short: actual 'joe' (3 characters), expected minimum 10 characters [metadata.length.min]
-                  File: %s:2:10-12
-                  Actual: joe (3 characters)
-                  Expected: Minimum 10 characters
-                
-                   1 | = Test Document
-                   2 | :author: joe
-                     |          ~~~
-                   3 | :version: 1.0-SNAPSHOT
-                   4 | :description: Valid description
-                   5 |\s
-                
-                [WARN]: Attribute 'version' does not match required pattern: actual '1.0-SNAPSHOT', expected pattern '^\\d+\\.\\d+\\.\\d+$' [metadata.pattern]
-                  File: %s:3:11-22
-                  Actual: 1.0-SNAPSHOT
-                  Expected: Pattern '^\\d+\\.\\d+\\.\\d+$'
-                
-                   1 | = Test Document
-                   2 | :author: joe
-                   3 | :version: 1.0-SNAPSHOT
-                     |           ~~~~~~~~~~~~
-                   4 | :description: Valid description
-                   5 |\s
-                   6 | Content here.
-                
-                
-                """, testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
-            
+            String expectedOutput = String.format(
+                    """
+                            +----------------------------------------------------------------------------------------------------------------------+
+                            |                                                  Validation Report                                                   |
+                            +----------------------------------------------------------------------------------------------------------------------+
+
+                            %s:
+
+                            [ERROR]: Attribute 'author' does not match required pattern: actual 'joe', expected pattern '^[A-Z][a-z]+ [A-Z][a-z]+$' [metadata.pattern]
+                              File: %s:2:10-12
+                              Actual: joe
+                              Expected: Pattern '^[A-Z][a-z]+ [A-Z][a-z]+$'
+
+                               1 | = Test Document
+                               2 | :author: joe
+                                 |          ~~~
+                               3 | :version: 1.0-SNAPSHOT
+                               4 | :description: Valid description
+                               5 |\s
+
+                            [ERROR]: Attribute 'author' is too short: actual 'joe' (3 characters), expected minimum 10 characters [metadata.length.min]
+                              File: %s:2:10-12
+                              Actual: joe (3 characters)
+                              Expected: Minimum 10 characters
+
+                               1 | = Test Document
+                               2 | :author: joe
+                                 |          ~~~
+                               3 | :version: 1.0-SNAPSHOT
+                               4 | :description: Valid description
+                               5 |\s
+
+                            [WARN]: Attribute 'version' does not match required pattern: actual '1.0-SNAPSHOT', expected pattern '^\\d+\\.\\d+\\.\\d+$' [metadata.pattern]
+                              File: %s:3:11-22
+                              Actual: 1.0-SNAPSHOT
+                              Expected: Pattern '^\\d+\\.\\d+\\.\\d+$'
+
+                               1 | = Test Document
+                               2 | :author: joe
+                               3 | :version: 1.0-SNAPSHOT
+                                 |           ~~~~~~~~~~~~
+                               4 | :description: Valid description
+                               5 |\s
+                               6 | Content here.
+
+
+                            """,
+                    testFile.toString(), testFile.toString(), testFile.toString(), testFile.toString());
+
             assertEquals(expectedOutput, actualOutput);
         }
     }
-    
+
 }

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatterTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/ConsoleFormatterTest.java
@@ -21,216 +21,156 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 @DisplayName("ConsoleFormatter")
 class ConsoleFormatterTest {
-    
+
     private ConsoleFormatter formatter;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
-    
+
     @BeforeEach
     void setUp() {
         // Create formatter with no colors for testing
-        OutputConfiguration config = OutputConfiguration.builder()
-            .format(OutputFormat.SIMPLE)
-            .display(DisplayConfig.builder()
-                .useColors(false)
-                .build())
-            .build();
+        OutputConfiguration config = OutputConfiguration.builder().format(OutputFormat.SIMPLE)
+                .display(DisplayConfig.builder().useColors(false).build()).build();
         formatter = new ConsoleFormatter(config);
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
-    
+
     @Nested
     @DisplayName("Basic Formatting")
     class BasicFormatting {
-        
+
         @Test
         @DisplayName("should format empty result")
         void shouldFormatEmptyResult() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .complete()
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("Validation Report"));
             assertTrue(output.contains("No validation issues found."));
             assertTrue(output.contains("Summary: 0 errors, 0 warnings, 0 info messages"));
         }
-        
+
         @Test
         @DisplayName("should format single error message")
         void shouldFormatSingleErrorMessage() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("required-attribute")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(10)
-                    .build())
-                .message("Missing required attribute")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR)
+                    .ruleId("required-attribute")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(10).build())
+                    .message("Missing required attribute").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("test.adoc:"));
             assertTrue(output.contains("Line 10, Column 1: [ERROR] Missing required attribute"));
             assertTrue(output.contains("Summary: 1 error, 0 warnings, 0 info messages"));
         }
-        
+
         @Test
         @DisplayName("should return correct name")
         void shouldReturnCorrectName() {
             assertEquals("console", formatter.getName());
         }
     }
-    
+
     @Nested
     @DisplayName("Message Details")
     class MessageDetails {
-        
+
         @Test
         @DisplayName("should include rule ID when present")
         void shouldIncludeRuleId() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(5)
-                    .build())
-                .message("Line too long")
-                .ruleId("line-length")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.WARN)
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(5).build())
+                    .message("Line too long").ruleId("line-length").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("Rule: line-length"));
         }
-        
+
         @Test
         @DisplayName("should include actual and expected values")
         void shouldIncludeActualAndExpectedValues() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("value-check")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(15)
-                    .build())
-                .message("Invalid value")
-                .actualValue("100")
-                .expectedValue("80")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("value-check")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(15).build())
+                    .message("Invalid value").actualValue("100").expectedValue("80").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("Actual: 100"));
             assertTrue(output.contains("Expected: 80"));
         }
-        
+
         @Test
         @DisplayName("should include column when present")
         void shouldIncludeColumn() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.INFO)
-                .ruleId("info-rule")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(20)
-                    .startColumn(15)
-                    .build())
-                .message("Info message")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.INFO).ruleId("info-rule")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(20).startColumn(15).build())
+                    .message("Info message").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("Line 20, Column 15: [INFO] Info message"));
         }
     }
-    
+
     @Nested
     @DisplayName("Multiple Files")
     class MultipleFiles {
-        
+
         @Test
         @DisplayName("should group messages by file")
         void shouldGroupMessagesByFile() {
             // Given
-            ValidationMessage msg1 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("file1.adoc")
-                    .startLine(10)
-                    .build())
-                .message("Error in file1")
-                .build();
-            
-            ValidationMessage msg2 = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("file2.adoc")
-                    .startLine(5)
-                    .build())
-                .message("Warning in file2")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(msg1)
-                .addMessage(msg2)
-                .complete()
-                .build();
-            
+            ValidationMessage msg1 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("file1.adoc").startLine(10).build())
+                    .message("Error in file1").build();
+
+            ValidationMessage msg2 = ValidationMessage.builder().severity(Severity.WARN).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("file2.adoc").startLine(5).build())
+                    .message("Warning in file2").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(msg1).addMessage(msg2).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("file1.adoc:"));
@@ -240,42 +180,29 @@ class ConsoleFormatterTest {
             assertTrue(file1Index < file2Index); // Files should be sorted
         }
     }
-    
+
     @Nested
     @DisplayName("Color Support")
     class ColorSupport {
-        
+
         @Test
         @DisplayName("should add colors when enabled")
         void shouldAddColorsWhenEnabled() {
             // Given
-            OutputConfiguration colorConfig = OutputConfiguration.builder()
-                .format(OutputFormat.SIMPLE)
-                .display(DisplayConfig.builder()
-                    .useColors(true)
-                    .build())
-                .build();
+            OutputConfiguration colorConfig = OutputConfiguration.builder().format(OutputFormat.SIMPLE)
+                    .display(DisplayConfig.builder().useColors(true).build()).build();
             ConsoleFormatter colorFormatter = new ConsoleFormatter(colorConfig);
-            
-            ValidationMessage error = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(1)
-                    .build())
-                .message("Error message")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(error)
-                .complete()
-                .build();
-            
+
+            ValidationMessage error = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(1).build())
+                    .message("Error message").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(error).complete().build();
+
             // When
             colorFormatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertTrue(output.contains("\u001B[31m[ERROR]\u001B[0m")); // Red color

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/JsonCompactFormatterTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/JsonCompactFormatterTest.java
@@ -23,21 +23,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Unit tests for JSON compact formatting.
- * 
- * <p>This test class validates the behavior of the JSON compact formatter,
- * which produces single-line JSON output suitable for log processing and
- * pipeline integration.</p>
- * 
+ *
+ * <p>
+ * This test class validates the behavior of the JSON compact formatter, which produces single-line JSON output suitable
+ * for log processing and pipeline integration.
+ * </p>
+ *
  * @see JsonFormatter
  */
 @DisplayName("JsonCompactFormatter")
 class JsonCompactFormatterTest {
-    
+
     private JsonFormatter formatter;
     private ObjectMapper objectMapper;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
-    
+
     @BeforeEach
     void setUp() {
         formatter = JsonFormatter.compact();
@@ -45,117 +46,93 @@ class JsonCompactFormatterTest {
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
-    
+
     @Test
     @DisplayName("should have correct name")
     void shouldHaveCorrectName() {
         // Given/When
         String name = formatter.getName();
-        
+
         // Then
         assertEquals("json-compact", name);
     }
-    
+
     @Test
     @DisplayName("should format empty result as single-line JSON")
     void shouldFormatEmptyResultAsSingleLineJson() throws IOException {
         // Given
-        ValidationResult result = ValidationResult.builder()
-            .startTime(System.currentTimeMillis() - 100)
-            .complete()
-            .build();
-        
+        ValidationResult result = ValidationResult.builder().startTime(System.currentTimeMillis() - 100).complete()
+                .build();
+
         // When
         formatter.format(result, printWriter);
         String output = stringWriter.toString();
-        
+
         // Then
         assertNotNull(output);
         assertFalse(output.contains("\n"), "Output should not contain newlines");
         assertFalse(output.contains("  "), "Output should not contain indentation");
-        
+
         // Parse and verify structure
         JsonNode json = objectMapper.readTree(output);
         assertTrue(json.has("timestamp"));
         assertTrue(json.has("duration"));
         assertTrue(json.has("summary"));
         assertTrue(json.has("messages"));
-        
+
         JsonNode summary = json.get("summary");
         assertEquals(0, summary.get("totalMessages").asInt());
         assertEquals(0, summary.get("errors").asInt());
         assertEquals(0, summary.get("warnings").asInt());
         assertEquals(0, summary.get("infos").asInt());
-        
+
         JsonNode messages = json.get("messages");
         assertTrue(messages.isArray());
         assertEquals(0, messages.size());
     }
-    
+
     @Test
     @DisplayName("should format result with messages as single-line JSON")
     void shouldFormatResultWithMessagesAsSingleLineJson() throws IOException {
         // Given
-        ValidationResult result = ValidationResult.builder()
-            .startTime(System.currentTimeMillis() - 250)
-            .addMessages(Arrays.asList(
-                ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId("metadata.required")
-                    .location(SourceLocation.builder()
-                        .filename("test.adoc")
-                        .startLine(1)
-                        .startColumn(5)
-                        .build())
-                    .message("Missing required attribute: title")
-                    .actualValue("null")
-                    .expectedValue("non-empty string")
-                    .build(),
-                ValidationMessage.builder()
-                    .severity(Severity.WARN)
-                    .ruleId("section.order")
-                    .location(SourceLocation.builder()
-                        .filename("test.adoc")
-                        .startLine(10)
-                        .build())
-                    .message("Section order violation")
-                    .build(),
-                ValidationMessage.builder()
-                    .severity(Severity.INFO)
-                    .ruleId("general.info")
-                    .location(SourceLocation.builder()
-                        .filename("test.adoc")
-                        .startLine(20)
-                        .build())
-                    .message("Consider adding description")
-                    .build()
-            ))
-            .complete()
-            .build();
-        
+        ValidationResult result = ValidationResult.builder().startTime(System.currentTimeMillis() - 250)
+                .addMessages(Arrays.asList(
+                        ValidationMessage.builder().severity(Severity.ERROR).ruleId("metadata.required")
+                                .location(SourceLocation.builder().filename("test.adoc").startLine(1).startColumn(5)
+                                        .build())
+                                .message("Missing required attribute: title").actualValue("null")
+                                .expectedValue("non-empty string").build(),
+                        ValidationMessage.builder().severity(Severity.WARN).ruleId("section.order")
+                                .location(SourceLocation.builder().filename("test.adoc").startLine(10).build())
+                                .message("Section order violation").build(),
+                        ValidationMessage.builder().severity(Severity.INFO).ruleId("general.info")
+                                .location(SourceLocation.builder().filename("test.adoc").startLine(20).build())
+                                .message("Consider adding description").build()))
+                .complete().build();
+
         // When
         formatter.format(result, printWriter);
         String output = stringWriter.toString();
-        
+
         // Then
         assertNotNull(output);
         assertFalse(output.contains("\n"), "Output should not contain newlines");
         assertFalse(output.contains("  "), "Output should not contain indentation");
-        
+
         // Parse and verify structure
         JsonNode json = objectMapper.readTree(output);
-        
+
         // Verify summary
         JsonNode summary = json.get("summary");
         assertEquals(3, summary.get("totalMessages").asInt());
         assertEquals(1, summary.get("errors").asInt());
         assertEquals(1, summary.get("warnings").asInt());
         assertEquals(1, summary.get("infos").asInt());
-        
+
         // Verify messages
         JsonNode messages = json.get("messages");
         assertEquals(3, messages.size());
-        
+
         // Verify first message (error)
         JsonNode error = messages.get(0);
         assertEquals("test.adoc", error.get("file").asText());
@@ -166,7 +143,7 @@ class JsonCompactFormatterTest {
         assertEquals("metadata.required", error.get("ruleId").asText());
         assertEquals("null", error.get("actualValue").asText());
         assertEquals("non-empty string", error.get("expectedValue").asText());
-        
+
         // Verify second message (warning) - no column
         JsonNode warning = messages.get(1);
         assertEquals("test.adoc", warning.get("file").asText());
@@ -174,124 +151,100 @@ class JsonCompactFormatterTest {
         assertFalse(warning.has("column"));
         assertEquals("WARN", warning.get("severity").asText());
         assertEquals("section.order", warning.get("ruleId").asText());
-        
+
         // Verify third message (info)
         JsonNode info = messages.get(2);
         assertEquals(20, info.get("line").asInt());
         assertEquals("INFO", info.get("severity").asText());
         assertEquals("general.info", info.get("ruleId").asText());
     }
-    
+
     @Test
     @DisplayName("should format duration correctly")
     void shouldFormatDurationCorrectly() throws IOException {
         // Given - test with milliseconds
-        ValidationResult result1 = ValidationResult.builder()
-            .startTime(System.currentTimeMillis() - 999)
-            .complete()
-            .build();
-        
+        ValidationResult result1 = ValidationResult.builder().startTime(System.currentTimeMillis() - 999).complete()
+                .build();
+
         // When
         formatter.format(result1, printWriter);
         String output1 = stringWriter.toString();
-        
+
         // Then
         JsonNode json1 = objectMapper.readTree(output1);
         assertEquals("999ms", json1.get("duration").asText());
-        
+
         // Given - test with seconds
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
-        ValidationResult result2 = ValidationResult.builder()
-            .startTime(System.currentTimeMillis() - 1500)
-            .complete()
-            .build();
-        
+        ValidationResult result2 = ValidationResult.builder().startTime(System.currentTimeMillis() - 1500).complete()
+                .build();
+
         // When
         formatter.format(result2, printWriter);
         String output2 = stringWriter.toString();
-        
+
         // Then
         JsonNode json2 = objectMapper.readTree(output2);
         assertEquals("1.500s", json2.get("duration").asText());
     }
-    
+
     @Test
     @DisplayName("should handle messages without optional fields")
     void shouldHandleMessagesWithoutOptionalFields() throws IOException {
         // Given
-        ValidationResult result = ValidationResult.builder()
-            .startTime(System.currentTimeMillis() - 50)
-            .addMessages(Arrays.asList(
-                ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId("basic.error")
-                    .location(SourceLocation.builder()
-                        .filename("test.adoc")
-                        .startLine(1)
-                        .build())
-                    .message("Basic error")
-                    .build()
-            ))
-            .complete()
-            .build();
-        
+        ValidationResult result = ValidationResult.builder().startTime(System.currentTimeMillis() - 50)
+                .addMessages(Arrays.asList(ValidationMessage.builder().severity(Severity.ERROR).ruleId("basic.error")
+                        .location(SourceLocation.builder().filename("test.adoc").startLine(1).build())
+                        .message("Basic error").build()))
+                .complete().build();
+
         // When
         formatter.format(result, printWriter);
         String output = stringWriter.toString();
-        
+
         // Then
         JsonNode json = objectMapper.readTree(output);
         JsonNode messages = json.get("messages");
         JsonNode message = messages.get(0);
-        
+
         // Required fields
         assertTrue(message.has("file"));
         assertTrue(message.has("line"));
         assertTrue(message.has("severity"));
         assertTrue(message.has("message"));
-        
+
         // Optional fields should not be present
         assertFalse(message.has("column"));
         assertTrue(message.has("ruleId")); // ruleId is always required in our implementation
         assertFalse(message.has("actualValue"));
         assertFalse(message.has("expectedValue"));
     }
-    
+
     @Test
     @DisplayName("should escape special characters properly")
     void shouldEscapeSpecialCharactersProperly() throws IOException {
         // Given
-        ValidationResult result = ValidationResult.builder()
-            .startTime(System.currentTimeMillis() - 100)
-            .addMessages(Arrays.asList(
-                ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId("test.escape")
-                    .location(SourceLocation.builder()
-                        .filename("test/with\"quotes\".adoc")
-                        .startLine(1)
-                        .build())
-                    .message("Message with \"quotes\" and backslash\\")
-                    .build()
-            ))
-            .complete()
-            .build();
-        
+        ValidationResult result = ValidationResult.builder().startTime(System.currentTimeMillis() - 100)
+                .addMessages(Arrays.asList(ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.escape")
+                        .location(SourceLocation.builder().filename("test/with\"quotes\".adoc").startLine(1).build())
+                        .message("Message with \"quotes\" and backslash\\").build()))
+                .complete().build();
+
         // When
         formatter.format(result, printWriter);
         String output = stringWriter.toString();
-        
+
         // Then
         // Verify it's valid JSON
         JsonNode json = objectMapper.readTree(output);
         JsonNode messages = json.get("messages");
         JsonNode message = messages.get(0);
-        
+
         // Jackson should handle escaping properly
         assertEquals("test/with\"quotes\".adoc", message.get("file").asText());
         assertEquals("Message with \"quotes\" and backslash\\", message.get("message").asText());
-        
+
         // Raw output should contain escaped characters
         assertTrue(output.contains("\\\"quotes\\\""));
         assertTrue(output.contains("backslash\\\\"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/JsonFormatterTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/JsonFormatterTest.java
@@ -21,34 +21,32 @@ import com.jayway.jsonpath.JsonPath;
 
 @DisplayName("JsonFormatter")
 class JsonFormatterTest {
-    
+
     private JsonFormatter formatter;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
-    
+
     @BeforeEach
     void setUp() {
         formatter = JsonFormatter.pretty();
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
-    
+
     @Nested
     @DisplayName("Basic JSON Structure")
     class BasicJsonStructure {
-        
+
         @Test
         @DisplayName("should format empty result as valid JSON")
         void shouldFormatEmptyResultAsValidJson() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .complete()
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertNotNull(JsonPath.read(output, "$.timestamp"));
@@ -59,30 +57,22 @@ class JsonFormatterTest {
             assertEquals(0, (int) JsonPath.read(output, "$.summary.infos"));
             assertTrue(((List<?>) JsonPath.read(output, "$.messages")).isEmpty());
         }
-        
+
         @Test
         @DisplayName("should format single message as valid JSON")
         void shouldFormatSingleMessageAsValidJson() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("required-attribute")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(10)
-                    .build())
-                .message("Missing required attribute")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR)
+                    .ruleId("required-attribute")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(10).build())
+                    .message("Missing required attribute").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals(1, (int) JsonPath.read(output, "$.summary.totalMessages"));
@@ -92,105 +82,75 @@ class JsonFormatterTest {
             assertEquals("ERROR", JsonPath.read(output, "$.messages[0].severity"));
             assertEquals("Missing required attribute", JsonPath.read(output, "$.messages[0].message"));
         }
-        
+
         @Test
         @DisplayName("should return correct name")
         void shouldReturnCorrectName() {
             assertEquals("json", formatter.getName());
         }
     }
-    
+
     @Nested
     @DisplayName("JSON Escaping")
     class JsonEscaping {
-        
+
         @Test
         @DisplayName("should escape special characters in messages")
         void shouldEscapeSpecialCharacters() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(5)
-                    .build())
-                .message("Message with \"quotes\" and \nnewline")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.WARN).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(5).build())
+                    .message("Message with \"quotes\" and \nnewline").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals("Message with \"quotes\" and \nnewline", JsonPath.read(output, "$.messages[0].message"));
         }
-        
+
         @Test
         @DisplayName("should escape backslashes")
         void shouldEscapeBackslashes() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.INFO)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("C:\\path\\to\\file.adoc")
-                    .startLine(1)
-                    .build())
-                .message("Path with backslashes")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.INFO).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("C:\\path\\to\\file.adoc").startLine(1).build())
+                    .message("Path with backslashes").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals("C:\\path\\to\\file.adoc", JsonPath.read(output, "$.messages[0].file"));
         }
     }
-    
+
     @Nested
     @DisplayName("Optional Fields")
     class OptionalFields {
-        
+
         @Test
         @DisplayName("should include optional fields when present")
         void shouldIncludeOptionalFields() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("value-check")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(15)
-                    .startColumn(20)
-                    .build())
-                .message("Invalid value")
-                .actualValue("100")
-                .expectedValue("80")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(message)
-                .complete()
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("value-check")
+                    .location(SourceLocation.builder().filename("test.adoc").startLine(15).startColumn(20).build())
+                    .message("Invalid value").actualValue("100").expectedValue("80").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(message).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals(20, (int) JsonPath.read(output, "$.messages[0].column"));
@@ -199,93 +159,71 @@ class JsonFormatterTest {
             assertEquals("80", JsonPath.read(output, "$.messages[0].expectedValue"));
         }
     }
-    
+
     @Nested
     @DisplayName("Multiple Messages")
     class MultipleMessages {
-        
+
         @Test
         @DisplayName("should format multiple messages with proper commas")
         void shouldFormatMultipleMessagesWithProperCommas() {
             // Given
-            ValidationMessage msg1 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("file1.adoc")
-                    .startLine(10)
-                    .build())
-                .message("First error")
-                .build();
-            
-            ValidationMessage msg2 = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("file2.adoc")
-                    .startLine(20)
-                    .build())
-                .message("Second warning")
-                .build();
-            
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(msg1)
-                .addMessage(msg2)
-                .complete()
-                .build();
-            
+            ValidationMessage msg1 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("file1.adoc").startLine(10).build())
+                    .message("First error").build();
+
+            ValidationMessage msg2 = ValidationMessage.builder().severity(Severity.WARN).ruleId("test-rule")
+                    .location(SourceLocation.builder().filename("file2.adoc").startLine(20).build())
+                    .message("Second warning").build();
+
+            ValidationResult result = ValidationResult.builder().addMessage(msg1).addMessage(msg2).complete().build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals(2, (int) JsonPath.read(output, "$.summary.totalMessages"));
             assertEquals(1, (int) JsonPath.read(output, "$.summary.errors"));
             assertEquals(1, (int) JsonPath.read(output, "$.summary.warnings"));
-            
+
             List<String> messages = JsonPath.read(output, "$.messages[*].message");
             assertEquals(2, messages.size());
             assertTrue(messages.contains("First error"));
             assertTrue(messages.contains("Second warning"));
         }
     }
-    
+
     @Nested
     @DisplayName("Duration Formatting")
     class DurationFormatting {
-        
+
         @Test
         @DisplayName("should format duration in milliseconds when less than 1 second")
         void shouldFormatDurationInMilliseconds() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .startTime(1000)
-                .endTime(1500)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().startTime(1000).endTime(1500).build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals("500ms", JsonPath.read(output, "$.duration"));
         }
-        
+
         @Test
         @DisplayName("should format duration in seconds when 1 second or more")
         void shouldFormatDurationInSeconds() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .startTime(1000)
-                .endTime(3500)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().startTime(1000).endTime(3500).build();
+
             // When
             formatter.format(result, printWriter);
             printWriter.flush();
-            
+
             // Then
             String output = stringWriter.toString();
             assertEquals("2.500s", JsonPath.read(output, "$.duration"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/ReportWriterTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/ReportWriterTest.java
@@ -23,32 +23,25 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 @DisplayName("ReportWriter")
 class ReportWriterTest {
-    
+
     private ReportWriter writer;
     private ValidationResult sampleResult;
-    
+
     @BeforeEach
     void setUp() {
         writer = new ReportWriter();
-        
+
         sampleResult = ValidationResult.builder()
-            .addMessage(ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test-rule")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .startLine(10)
-                    .build())
-                .message("Test error")
-                .build())
-            .complete()
-            .build();
+                .addMessage(ValidationMessage.builder().severity(Severity.ERROR).ruleId("test-rule")
+                        .location(SourceLocation.builder().filename("test.adoc").startLine(10).build())
+                        .message("Test error").build())
+                .complete().build();
     }
-    
+
     @Nested
     @DisplayName("Formatter Registration")
     class FormatterRegistration {
-        
+
         @Test
         @DisplayName("should have default formatters registered")
         void shouldHaveDefaultFormattersRegistered() {
@@ -57,7 +50,7 @@ class ReportWriterTest {
             assertTrue(formats.contains("json"));
             assertTrue(formats.contains("json-compact"));
         }
-        
+
         @Test
         @DisplayName("should register custom formatter")
         void shouldRegisterCustomFormatter() {
@@ -67,38 +60,38 @@ class ReportWriterTest {
                 public void format(ValidationResult result, java.io.PrintWriter writer) {
                     writer.println("CUSTOM");
                 }
-                
+
                 @Override
                 public String getName() {
                     return "custom";
                 }
             };
-            
+
             // When
             writer.registerFormatter(customFormatter);
-            
+
             // Then
             assertTrue(writer.getAvailableFormats().contains("custom"));
         }
-        
+
         @Test
         @DisplayName("should throw exception for null formatter")
         void shouldThrowExceptionForNullFormatter() {
             assertThrows(NullPointerException.class, () -> writer.registerFormatter(null));
         }
     }
-    
+
     @Nested
     @DisplayName("Console Output")
     class ConsoleOutput {
-        
+
         @Test
         @DisplayName("should write to console with default format")
         void shouldWriteToConsoleWithDefaultFormat() throws IOException {
             // When & Then - no exception thrown
             assertDoesNotThrow(() -> writer.write(sampleResult, null, (String) null));
         }
-        
+
         @Test
         @DisplayName("should write to console with explicit format")
         void shouldWriteToConsoleWithExplicitFormat() throws IOException {
@@ -106,39 +99,39 @@ class ReportWriterTest {
             assertDoesNotThrow(() -> writer.write(sampleResult, "json", (String) null));
         }
     }
-    
+
     @Nested
     @DisplayName("File Output")
     class FileOutput {
-        
+
         @TempDir
         Path tempDir;
-        
+
         @Test
         @DisplayName("should write console format to file")
         void shouldWriteConsoleFormatToFile() throws IOException {
             // Given
             Path outputFile = tempDir.resolve("report.txt");
-            
+
             // When
             writer.write(sampleResult, "console", outputFile.toString());
-            
+
             // Then
             assertTrue(Files.exists(outputFile));
             String content = Files.readString(outputFile);
             assertTrue(content.contains("Validation Report"));
             assertTrue(content.contains("Test error"));
         }
-        
+
         @Test
         @DisplayName("should write JSON format to file")
         void shouldWriteJsonFormatToFile() throws IOException {
             // Given
             Path outputFile = tempDir.resolve("report.json");
-            
+
             // When
             writer.write(sampleResult, "json", outputFile.toString());
-            
+
             // Then
             assertTrue(Files.exists(outputFile));
             String content = Files.readString(outputFile);
@@ -146,88 +139,75 @@ class ReportWriterTest {
             assertTrue(content.contains("\"severity\" : \"ERROR\""));
             assertTrue(content.contains("\"message\" : \"Test error\""));
         }
-        
+
         @Test
         @DisplayName("should accept Path object")
         void shouldAcceptPathObject() throws IOException {
             // Given
             Path outputFile = tempDir.resolve("report-path.txt");
-            
+
             // When
             writer.write(sampleResult, "console", outputFile);
-            
+
             // Then
             assertTrue(Files.exists(outputFile));
         }
     }
-    
+
     @Nested
     @DisplayName("Error Handling")
     class ErrorHandling {
-        
+
         @Test
         @DisplayName("should throw exception for unsupported format")
         void shouldThrowExceptionForUnsupportedFormat() {
-            IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> writer.write(sampleResult, "unknown", (String) null)
-            );
-            
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> writer.write(sampleResult, "unknown", (String) null));
+
             assertTrue(exception.getMessage().contains("Unsupported format: unknown"));
             assertTrue(exception.getMessage().contains("Available formats:"));
         }
-        
+
         @Test
         @DisplayName("should throw exception for null result")
         void shouldThrowExceptionForNullResult() {
-            assertThrows(NullPointerException.class,
-                () -> writer.write(null, "console", (String) null));
+            assertThrows(NullPointerException.class, () -> writer.write(null, "console", (String) null));
         }
-        
+
         @Test
         @DisplayName("should handle invalid file path")
         void shouldHandleInvalidFilePath() {
-            assertThrows(IOException.class,
-                () -> writer.write(sampleResult, "json", "/invalid/path/report.json"));
+            assertThrows(IOException.class, () -> writer.write(sampleResult, "json", "/invalid/path/report.json"));
         }
     }
-    
+
     @Nested
     @DisplayName("Exit Code Calculation")
     class ExitCodeCalculation {
-        
+
         @Test
         @DisplayName("should return 0 for no errors")
         void shouldReturnZeroForNoErrors() {
             ValidationResult result = ValidationResult.builder()
-                .addMessage(ValidationMessage.builder()
-                    .severity(Severity.WARN)
-                    .ruleId("test-rule")
-                    .location(SourceLocation.builder()
-                        .filename("test.adoc")
-                        .startLine(1)
-                        .build())
-                    .message("Warning")
-                    .build())
-                .complete()
-                .build();
-            
+                    .addMessage(ValidationMessage.builder().severity(Severity.WARN).ruleId("test-rule")
+                            .location(SourceLocation.builder().filename("test.adoc").startLine(1).build())
+                            .message("Warning").build())
+                    .complete().build();
+
             assertEquals(0, ReportWriter.calculateExitCode(result));
         }
-        
+
         @Test
         @DisplayName("should return 1 for errors")
         void shouldReturnOneForErrors() {
             assertEquals(1, ReportWriter.calculateExitCode(sampleResult));
         }
-        
+
         @Test
         @DisplayName("should return 0 for empty result")
         void shouldReturnZeroForEmptyResult() {
-            ValidationResult emptyResult = ValidationResult.builder()
-                .complete()
-                .build();
-            
+            ValidationResult emptyResult = ValidationResult.builder().complete().build();
+
             assertEquals(0, ReportWriter.calculateExitCode(emptyResult));
         }
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/console/ContextRendererTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/console/ContextRendererTest.java
@@ -19,142 +19,104 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("ContextRenderer")
 class ContextRendererTest {
-    
+
     private ContextRenderer renderer;
     private DisplayConfig displayConfig;
-    
+
     @BeforeEach
     void setUp() {
-        displayConfig = DisplayConfig.builder()
-            .contextLines(2)
-            .useColors(true)
-            .showLineNumbers(true)
-            .maxLineWidth(120)
-            .showHeader(true)
-            .build();
+        displayConfig = DisplayConfig.builder().contextLines(2).useColors(true).showLineNumbers(true).maxLineWidth(120)
+                .showHeader(true).build();
         renderer = new ContextRenderer(displayConfig);
     }
-    
+
     @Nested
     @DisplayName("getContext")
     class GetContext {
-        
+
         @Test
         @DisplayName("should handle short files without throwing exception")
         void shouldHandleShortFiles() {
             // Given
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .startLine(8)
-                .endLine(8)
-                .startColumn(1)
-                .endColumn(1)
-                .build();
-                
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(location)
-                .contextLines(List.of("Line 1", "Line 2", "Line 3")) // Short file with only 3 lines
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").startLine(8).endLine(8)
+                    .startColumn(1).endColumn(1).build();
+
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(location).contextLines(List.of("Line 1", "Line 2", "Line 3")) // Short
+                                                                                                                  // file
+                                                                                                                  // with
+                                                                                                                  // only
+                                                                                                                  // 3
+                                                                                                                  // lines
+                    .build();
+
             // When & Then - should not throw exception
             assertDoesNotThrow(() -> {
                 SourceContext context = renderer.getContext(message);
                 assertNotNull(context);
             });
         }
-        
+
         @Test
         @DisplayName("should use provided context lines when available")
         void shouldUseProvidedContextLines() {
             // Given
             List<String> providedLines = List.of("Line 1", "Line 2", "Line 3");
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .startLine(2)
-                .endLine(2)
-                .startColumn(1)
-                .endColumn(10)
-                .build();
-                
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(location)
-                .contextLines(providedLines)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").startLine(2).endLine(2)
+                    .startColumn(1).endColumn(10).build();
+
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(location).contextLines(providedLines).build();
+
             // When
             SourceContext context = renderer.getContext(message);
-            
+
             // Then
             assertNotNull(context.getLines());
             assertEquals(3, context.getLines().size());
             assertEquals(location, context.getErrorLocation());
         }
-        
+
         @Test
         @DisplayName("should handle empty file content")
         void shouldHandleEmptyFileContent() {
             // Given
-            SourceLocation location = SourceLocation.builder()
-                .filename("empty.adoc")
-                .startLine(1)
-                .endLine(1)
-                .startColumn(1)
-                .endColumn(1)
-                .build();
-                
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(location)
-                .contextLines(List.of()) // Empty context
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("empty.adoc").startLine(1).endLine(1)
+                    .startColumn(1).endColumn(1).build();
+
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(location).contextLines(List.of()) // Empty context
+                    .build();
+
             // When
             SourceContext context = renderer.getContext(message);
-            
+
             // Then
             assertTrue(context.getLines().isEmpty());
             assertEquals(location, context.getErrorLocation());
         }
-        
+
         @Test
         @DisplayName("should handle location at end of file")
         void shouldHandleLocationAtEndOfFile() {
             // Given
             List<String> lines = List.of("Line 1", "Line 2", "Line 3", "Line 4", "Line 5");
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .startLine(5)
-                .endLine(5)
-                .startColumn(1)
-                .endColumn(10)
-                .build();
-                
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(location)
-                .contextLines(lines)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").startLine(5).endLine(5)
+                    .startColumn(1).endColumn(10).build();
+
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(location).contextLines(lines).build();
+
             // When
             SourceContext context = renderer.getContext(message);
-            
+
             // Then
             assertNotNull(context.getLines());
             assertEquals(5, context.getLines().size());
             assertEquals(location, context.getErrorLocation());
         }
     }
-    
+
     @Test
     @DisplayName("should clear cache")
     void shouldClearCache() {

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/BlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/BlockValidatorTest.java
@@ -25,83 +25,73 @@ import com.dataliquid.asciidoc.linter.config.rule.SectionConfig;
 
 @DisplayName("BlockValidator")
 class BlockValidatorTest {
-    
+
     private BlockValidator validator;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new BlockValidator();
         mockSection = mock(Section.class);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return success when section has no blocks")
         void shouldReturnSuccessWhenSectionHasNoBlocks() {
             // Given
-            SectionConfig config = SectionConfig.builder()
-                .name("Introduction")
-                .build();
+            SectionConfig config = SectionConfig.builder().name("Introduction").build();
             when(mockSection.getBlocks()).thenReturn(null);
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertFalse(result.hasErrors());
             assertTrue(result.getMessages().isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate all blocks in section")
         void shouldValidateAllBlocksInSection() {
             // Given
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Introduction")
-                .allowedBlocks(Arrays.asList(paragraphConfig))
-                .build();
-            
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Introduction")
+                    .allowedBlocks(Arrays.asList(paragraphConfig)).build();
+
             Block block1 = mock(Block.class);
             Block block2 = mock(Block.class);
             when(block1.getContext()).thenReturn("paragraph");
             when(block2.getContext()).thenReturn("paragraph");
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(block1, block2));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertFalse(result.hasErrors()); // No validation rules configured
         }
-        
+
         @Test
         @DisplayName("should validate unknown block types")
         void shouldValidateUnknownBlockTypes() {
             // Given
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(paragraphConfig))
-                .build();
-            
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Section").allowedBlocks(Arrays.asList(paragraphConfig))
+                    .build();
+
             Block unknownBlock = mock(Block.class);
             when(unknownBlock.getContext()).thenReturn("unknown-type");
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(unknownBlock));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(1, result.getMessages().size());
@@ -110,64 +100,48 @@ class BlockValidatorTest {
             assertEquals("Unknown block type: unknown-type", msg.getMessage());
         }
     }
-    
+
     @Nested
     @DisplayName("occurrence validation")
     class OccurrenceValidation {
-        
+
         @Test
         @DisplayName("should validate block occurrences")
         void shouldValidateBlockOccurrences() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(2)
-                .max(3)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .name("content")
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(paragraphConfig))
-                .build();
-            
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(2).max(3).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().name("content").occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Section").allowedBlocks(Arrays.asList(paragraphConfig))
+                    .build();
+
             // Only one paragraph block (violates min)
             Block block = mock(Block.class);
             when(block.getContext()).thenReturn("paragraph");
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(block));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertTrue(result.hasErrors());
-            assertTrue(result.getMessages().stream()
-                .anyMatch(m -> "block.occurrence.min".equals(m.getRuleId())));
+            assertTrue(result.getMessages().stream().anyMatch(m -> "block.occurrence.min".equals(m.getRuleId())));
         }
-        
+
         @Test
         @DisplayName("should track occurrences across multiple blocks")
         void shouldTrackOccurrencesAcrossMultipleBlocks() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(1)
-                .max(2)
-                .severity(Severity.WARN)
-                .build();
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(paragraphConfig))
-                .build();
-            
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(1).max(2).severity(Severity.WARN)
+                    .build();
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Section").allowedBlocks(Arrays.asList(paragraphConfig))
+                    .build();
+
             // Three paragraph blocks (violates max)
             Block block1 = mock(Block.class);
             Block block2 = mock(Block.class);
@@ -176,143 +150,117 @@ class BlockValidatorTest {
             when(block2.getContext()).thenReturn("paragraph");
             when(block3.getContext()).thenReturn("paragraph");
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(block1, block2, block3));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertTrue(result.hasWarnings());
-            assertTrue(result.getMessages().stream()
-                .anyMatch(m -> "block.occurrence.max".equals(m.getRuleId())));
+            assertTrue(result.getMessages().stream().anyMatch(m -> "block.occurrence.max".equals(m.getRuleId())));
         }
     }
-    
+
     @Nested
     @DisplayName("order validation")
     class OrderValidation {
-        
+
         @Test
         @DisplayName("should validate block order using order attribute")
         void shouldValidateBlockOrderUsingOrderAttribute() {
             // Given
-            ParagraphBlock headerBlock = ParagraphBlock.builder()
-                .name("header")
-                .severity(Severity.ERROR)
-                .order(1)
-                .build();
-            TableBlock dataBlock = TableBlock.builder()
-                .name("data")
-                .severity(Severity.ERROR)
-                .order(2)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(headerBlock, dataBlock))
-                .build();
-            
+            ParagraphBlock headerBlock = ParagraphBlock.builder().name("header").severity(Severity.ERROR).order(1)
+                    .build();
+            TableBlock dataBlock = TableBlock.builder().name("data").severity(Severity.ERROR).order(2).build();
+
+            SectionConfig config = SectionConfig.builder().name("Section")
+                    .allowedBlocks(Arrays.asList(headerBlock, dataBlock)).build();
+
             // Wrong order: data before header
             Block block1 = mock(Block.class);
             Block block2 = mock(Block.class);
             when(block1.getContext()).thenReturn("table");
             when(block2.getContext()).thenReturn("paragraph");
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(block1, block2));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertTrue(result.hasErrors());
-            assertTrue(result.getMessages().stream()
-                .anyMatch(m -> "block.order".equals(m.getRuleId())));
+            assertTrue(result.getMessages().stream().anyMatch(m -> "block.order".equals(m.getRuleId())));
         }
     }
-    
+
     @Nested
     @DisplayName("complex validation scenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple rules together")
         void shouldValidateMultipleRulesTogether() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(1)
-                .max(2)
-                .severity(Severity.ERROR)
-                .build();
-            
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
-            TableBlock tableConfig = TableBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(paragraphConfig, tableConfig))
-                .build();
-            
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(1).max(2).severity(Severity.ERROR)
+                    .build();
+
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
+
+            TableBlock tableConfig = TableBlock.builder().severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Section")
+                    .allowedBlocks(Arrays.asList(paragraphConfig, tableConfig)).build();
+
             // Setup blocks: table, then paragraph
             Block tableBlock = mock(Block.class);
             when(tableBlock.getContext()).thenReturn("table");
-            
+
             Block paragraphBlock = mock(Block.class);
             when(paragraphBlock.getContext()).thenReturn("paragraph");
-            
+
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(tableBlock, paragraphBlock));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             // Should succeed - no specific validation rules for these blocks
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should handle sections with mixed block types")
         void shouldHandleSectionsWithMixedBlockTypes() {
             // Given
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock tableConfig = TableBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Mixed Content")
-                .allowedBlocks(Arrays.asList(paragraphConfig, tableConfig))
-                .build();
-            
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().severity(Severity.ERROR).build();
+            TableBlock tableConfig = TableBlock.builder().severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Mixed Content")
+                    .allowedBlocks(Arrays.asList(paragraphConfig, tableConfig)).build();
+
             // Mix of configured and unconfigured block types
             Block para1 = mock(Block.class);
             Block table1 = mock(Block.class);
             Block listing1 = mock(Block.class); // Not configured
             Block para2 = mock(Block.class);
-            
+
             when(para1.getContext()).thenReturn("paragraph");
             when(table1.getContext()).thenReturn("table");
             when(listing1.getContext()).thenReturn("listing");
             when(para2.getContext()).thenReturn("paragraph");
-            
+
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(para1, table1, listing1, para2));
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             // The listing block is not allowed because it's not in the allowed blocks list
             assertTrue(result.hasErrors());
             assertEquals(1, result.getErrorCount()); // Only the listing block should error
-            assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Block type not allowed")));
+            assertTrue(
+                    result.getMessages().stream().anyMatch(msg -> msg.getMessage().contains("Block type not allowed")));
         }
-        
+
         @Test
         @DisplayName("should handle null section config gracefully")
         void shouldHandleNullSectionConfigGracefully() {
@@ -320,57 +268,48 @@ class BlockValidatorTest {
             Block block = mock(Block.class);
             when(block.getContext()).thenReturn("paragraph");
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(block));
-            
+
             // When/Then
-            assertThrows(NullPointerException.class, () -> 
-                validator.validate(mockSection, null, "test.adoc"));
+            assertThrows(NullPointerException.class, () -> validator.validate(mockSection, null, "test.adoc"));
         }
     }
-    
+
     @Nested
     @DisplayName("error handling")
     class ErrorHandling {
-        
+
         @Test
         @DisplayName("should handle validation exceptions gracefully")
         void shouldHandleValidationExceptionsGracefully() {
             // Given
-            ParagraphBlock paragraphConfig = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(paragraphConfig))
-                .build();
-            
+            ParagraphBlock paragraphConfig = ParagraphBlock.builder().severity(Severity.ERROR).build();
+
+            SectionConfig config = SectionConfig.builder().name("Section").allowedBlocks(Arrays.asList(paragraphConfig))
+                    .build();
+
             Block block = mock(Block.class);
             when(block.getContext()).thenThrow(new RuntimeException("Test exception"));
             when(mockSection.getBlocks()).thenReturn(Arrays.asList(block));
-            
+
             // When/Then - should not throw
             assertDoesNotThrow(() -> {
                 ValidationResult result = validator.validate(mockSection, config, "test.adoc");
                 assertTrue(result.hasErrors());
             });
         }
-        
+
         @Test
         @DisplayName("should handle null blocks list")
         void shouldHandleNullBlocksList() {
             // Given
-            SectionConfig config = SectionConfig.builder()
-                .name("Section")
-                .allowedBlocks(Arrays.asList(ParagraphBlock.builder()
-                    .severity(Severity.ERROR)
-                    .build()))
-                .build();
-            
+            SectionConfig config = SectionConfig.builder().name("Section")
+                    .allowedBlocks(Arrays.asList(ParagraphBlock.builder().severity(Severity.ERROR).build())).build();
+
             when(mockSection.getBlocks()).thenReturn(null);
-            
+
             // When
             ValidationResult result = validator.validate(mockSection, config, "test.adoc");
-            
+
             // Then
             assertFalse(result.hasErrors());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/EnhancedValidationMessageTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/EnhancedValidationMessageTest.java
@@ -21,46 +21,27 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
  */
 @DisplayName("Enhanced ValidationMessage Tests")
 class EnhancedValidationMessageTest {
-    
+
     @Nested
     @DisplayName("Enhanced Fields Tests")
     class EnhancedFieldsTests {
-        
+
         @Test
         @DisplayName("should create message with all enhanced fields")
         void shouldCreateMessageWithAllEnhancedFields() {
             // Given
-            List<Suggestion> suggestions = Arrays.asList(
-                Suggestion.builder()
-                    .description("Fix suggestion 1")
-                    .addExample("Example code")
-                    .build()
-            );
-            
-            List<String> contextLines = Arrays.asList(
-                "Line before",
-                "Error line",
-                "Line after"
-            );
-            
+            List<Suggestion> suggestions = Arrays
+                    .asList(Suggestion.builder().description("Fix suggestion 1").addExample("Example code").build());
+
+            List<String> contextLines = Arrays.asList("Line before", "Error line", "Line after");
+
             // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .startColumn(5)
-                    .build())
-                .errorType(ErrorType.MISSING_VALUE)
-                .actualValue("actual")
-                .expectedValue("expected")
-                .missingValueHint("id")
-                .suggestions(suggestions)
-                .contextLines(contextLines)
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error")
+                    .location(SourceLocation.builder().filename("test.adoc").line(10).startColumn(5).build())
+                    .errorType(ErrorType.MISSING_VALUE).actualValue("actual").expectedValue("expected")
+                    .missingValueHint("id").suggestions(suggestions).contextLines(contextLines).build();
+
             // Then
             assertEquals(ErrorType.MISSING_VALUE, message.getErrorType());
             assertEquals("actual", message.getActualValue().orElse(null));
@@ -70,21 +51,15 @@ class EnhancedValidationMessageTest {
             assertEquals(contextLines, message.getContextLines());
             assertTrue(message.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should handle null enhanced fields")
         void shouldHandleNullEnhancedFields() {
             // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                    .build();
+
             // Then
             assertEquals(ErrorType.GENERIC, message.getErrorType()); // Defaults to GENERIC
             assertTrue(message.getActualValue().isEmpty());
@@ -95,93 +70,66 @@ class EnhancedValidationMessageTest {
             assertFalse(message.hasSuggestions());
         }
     }
-    
+
     @Nested
     @DisplayName("Suggestion Tests")
     class SuggestionTests {
-        
+
     }
-    
+
     @Nested
     @DisplayName("Error Type Tests")
     class ErrorTypeTests {
-        
+
         @Test
         @DisplayName("should support all error types")
         void shouldSupportAllErrorTypes() {
             for (ErrorType type : ErrorType.values()) {
                 // When
-                ValidationMessage message = ValidationMessage.builder()
-                    .severity(Severity.ERROR)
-                    .ruleId("test.rule")
-                    .message("Test error")
-                    .location(SourceLocation.builder()
-                        .filename("test.adoc")
-                        .line(10)
-                        .build())
-                    .errorType(type)
-                    .build();
-                
+                ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                        .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                        .errorType(type).build();
+
                 // Then
                 assertEquals(type, message.getErrorType());
             }
         }
     }
-    
+
     @Nested
     @DisplayName("Builder Defense Tests")
     class BuilderDefenseTests {
-        
+
         @Test
         @DisplayName("should make defensive copies of lists")
         void shouldMakeDefensiveCopiesOfLists() {
             // Given
-            List<Suggestion> mutableSuggestions = Arrays.asList(
-                Suggestion.builder()
-                    .description("Suggestion")
-                    .build()
-            );
+            List<Suggestion> mutableSuggestions = Arrays.asList(Suggestion.builder().description("Suggestion").build());
             List<String> mutableContext = Arrays.asList("Line 1", "Line 2");
-            
+
             // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .suggestions(mutableSuggestions)
-                .contextLines(mutableContext)
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                    .suggestions(mutableSuggestions).contextLines(mutableContext).build();
+
             // Then - returned lists should be defensive copies (mutable but separate)
             List<Suggestion> suggestions = message.getSuggestions();
             suggestions.add(Suggestion.builder().description("new").build());
             assertEquals(1, message.getSuggestions().size()); // Original unchanged
-            
+
             List<String> contextLines = message.getContextLines();
             contextLines.add("new line");
             assertEquals(2, message.getContextLines().size()); // Original unchanged
         }
-        
+
         @Test
         @DisplayName("should handle null lists in builder")
         void shouldHandleNullListsInBuilder() {
             // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .suggestions(null)
-                .contextLines(null)
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                    .suggestions(null).contextLines(null).build();
+
             // Then
             assertNotNull(message.getSuggestions());
             assertNotNull(message.getContextLines());
@@ -189,51 +137,28 @@ class EnhancedValidationMessageTest {
             assertTrue(message.getContextLines().isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Equals and HashCode Tests")
     class EqualsHashCodeTests {
-        
+
         @Test
         @DisplayName("should consider enhanced fields in equals")
         void shouldConsiderEnhancedFieldsInEquals() {
             // Given
-            ValidationMessage message1 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .errorType(ErrorType.MISSING_VALUE)
-                .actualValue("actual")
-                .build();
-            
-            ValidationMessage message2 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .errorType(ErrorType.MISSING_VALUE)
-                .actualValue("actual")
-                .build();
-            
-            ValidationMessage message3 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("test.rule")
-                .message("Test error")
-                .location(SourceLocation.builder()
-                    .filename("test.adoc")
-                    .line(10)
-                    .build())
-                .errorType(ErrorType.INVALID_PATTERN)  // Different
-                .actualValue("actual")
-                .build();
-            
+            ValidationMessage message1 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                    .errorType(ErrorType.MISSING_VALUE).actualValue("actual").build();
+
+            ValidationMessage message2 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                    .errorType(ErrorType.MISSING_VALUE).actualValue("actual").build();
+
+            ValidationMessage message3 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.rule")
+                    .message("Test error").location(SourceLocation.builder().filename("test.adoc").line(10).build())
+                    .errorType(ErrorType.INVALID_PATTERN) // Different
+                    .actualValue("actual").build();
+
             // Then
             assertEquals(message1, message2);
             assertNotEquals(message1, message3);

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/MetadataValidatorIntegrationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/MetadataValidatorIntegrationTest.java
@@ -32,38 +32,18 @@ class MetadataValidatorIntegrationTest {
     void setUp() throws IOException {
         asciidoctor = Asciidoctor.Factory.create();
         tempDir = Files.createTempDirectory("asciidoc-test");
-        
-        MetadataConfiguration config = MetadataConfiguration.builder()
-            .attributes(Arrays.asList(
-                AttributeConfig.builder()
-                    .name("author")
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .pattern("^[A-Z][a-zA-Z\\s\\.]+$")
-                    .severity(Severity.ERROR)
-                    .build(),
-                AttributeConfig.builder()
-                    .name("revdate")
-                    .required(true)
-                    .pattern("^\\d{4}-\\d{2}-\\d{2}$")
-                    .severity(Severity.ERROR)
-                    .build(),
-                AttributeConfig.builder()
-                    .name("version")
-                    .required(true)
-                    .pattern("^\\d+\\.\\d+(\\.\\d+)?$")
-                    .severity(Severity.ERROR)
-                    .build(),
-                AttributeConfig.builder()
-                    .name("email")
-                    .required(false)
-                    .pattern("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
-                    .severity(Severity.WARN)
-                    .build()
-            ))
-            .build();
-        
+
+        MetadataConfiguration config = MetadataConfiguration.builder().attributes(Arrays.asList(
+                AttributeConfig.builder().name("author").required(true).minLength(5).maxLength(50)
+                        .pattern("^[A-Z][a-zA-Z\\s\\.]+$").severity(Severity.ERROR).build(),
+                AttributeConfig.builder().name("revdate").required(true).pattern("^\\d{4}-\\d{2}-\\d{2}$")
+                        .severity(Severity.ERROR).build(),
+                AttributeConfig.builder().name("version").required(true).pattern("^\\d+\\.\\d+(\\.\\d+)?$")
+                        .severity(Severity.ERROR).build(),
+                AttributeConfig.builder().name("email").required(false)
+                        .pattern("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$").severity(Severity.WARN).build()))
+                .build();
+
         validator = MetadataValidator.fromConfiguration(config).build();
     }
 
@@ -72,21 +52,21 @@ class MetadataValidatorIntegrationTest {
     void shouldPassValidationWhenDocumentHasAllValidMetadata() throws IOException {
         // Given
         String content = """
-            = Valid Document Title
-            :author: John Doe
-            :revdate: 2024-01-15
-            :version: 1.0.0
-            :email: john.doe@example.com
-            
-            == Introduction
-            This is a valid document.
-            """;
+                = Valid Document Title
+                :author: John Doe
+                :revdate: 2024-01-15
+                :version: 1.0.0
+                :email: john.doe@example.com
+
+                == Introduction
+                This is a valid document.
+                """;
         File docFile = createTempFile("valid-doc.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertFalse(result.hasErrors());
         assertFalse(result.hasWarnings());
@@ -98,26 +78,26 @@ class MetadataValidatorIntegrationTest {
     void shouldReportErrorsWhenRequiredAttributesAreMissing() throws IOException {
         // Given
         String content = """
-            = Valid Title
-            :email: test@example.com
-            
-            Content without required metadata.
-            """;
+                = Valid Title
+                :email: test@example.com
+
+                Content without required metadata.
+                """;
         File docFile = createTempFile("missing-attrs.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertTrue(result.hasErrors());
         assertEquals(3, result.getErrorCount()); // missing author, revdate, version
         assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'author'")));
+                .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'author'")));
         assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'revdate'")));
+                .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'revdate'")));
         assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'version'")));
+                .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'version'")));
     }
 
     @Test
@@ -125,37 +105,38 @@ class MetadataValidatorIntegrationTest {
     void shouldReportViolationsWhenAttributesDontMatchPatterns() throws IOException {
         // Given
         String content = """
-            = invalid title
-            :author: john
-            :revdate: 15.01.2024
-            :version: 1.0-SNAPSHOT
-            :email: invalid-email
-            
-            Content with invalid metadata patterns.
-            """;
+                = invalid title
+                :author: john
+                :revdate: 15.01.2024
+                :version: 1.0-SNAPSHOT
+                :email: invalid-email
+
+                Content with invalid metadata patterns.
+                """;
         File docFile = createTempFile("invalid-patterns.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertTrue(result.hasErrors());
         assertTrue(result.hasWarnings());
         // Author pattern and length errors
-        assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Attribute 'author' does not match required pattern: actual 'john', expected pattern '^[A-Z][a-zA-Z\\s\\.]+$'") ||
-                       msg.getMessage().equals("Attribute 'author' is too short: actual 'john' (4 characters), expected minimum 5 characters")));
+        assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getMessage().equals(
+                "Attribute 'author' does not match required pattern: actual 'john', expected pattern '^[A-Z][a-zA-Z\\s\\.]+$'")
+                || msg.getMessage().equals(
+                        "Attribute 'author' is too short: actual 'john' (4 characters), expected minimum 5 characters")));
         // Date format error
-        assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Attribute 'revdate' does not match required pattern: actual '15.01.2024', expected pattern '^\\d{4}-\\d{2}-\\d{2}$'")));
+        assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getMessage().equals(
+                "Attribute 'revdate' does not match required pattern: actual '15.01.2024', expected pattern '^\\d{4}-\\d{2}-\\d{2}$'")));
         // Version format error
-        assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Attribute 'version' does not match required pattern: actual '1.0-SNAPSHOT', expected pattern '^\\d+\\.\\d+(\\.\\d+)?$'")));
+        assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getMessage().equals(
+                "Attribute 'version' does not match required pattern: actual '1.0-SNAPSHOT', expected pattern '^\\d+\\.\\d+(\\.\\d+)?$'")));
         // Email warning
-        assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Attribute 'email' does not match required pattern: actual 'invalid-email', expected pattern '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'") &&
-                       msg.getSeverity() == Severity.WARN));
+        assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getMessage().equals(
+                "Attribute 'email' does not match required pattern: actual 'invalid-email', expected pattern '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'")
+                && msg.getSeverity() == Severity.WARN));
     }
 
     @Test
@@ -163,24 +144,24 @@ class MetadataValidatorIntegrationTest {
     void shouldReportErrorsWhenAttributesViolateLengthConstraints() throws IOException {
         // Given
         String content = """
-            = Doc
-            :author: Jo
-            :revdate: 2024-01-15
-            :version: 1.0.0
-            
-            Short title and author.
-            """;
+                = Doc
+                :author: Jo
+                :revdate: 2024-01-15
+                :version: 1.0.0
+
+                Short title and author.
+                """;
         File docFile = createTempFile("length-violations.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertTrue(result.hasErrors());
         // Author too short
-        assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Attribute 'author' is too short: actual 'Jo' (2 characters), expected minimum 5 characters")));
+        assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getMessage()
+                .equals("Attribute 'author' is too short: actual 'Jo' (2 characters), expected minimum 5 characters")));
     }
 
     @Test
@@ -188,19 +169,19 @@ class MetadataValidatorIntegrationTest {
     void shouldAcceptAttributesInAnyOrder() throws IOException {
         // Given
         String content = """
-            = Valid Document Title
-            :version: 1.0.0
-            :revdate: 2024-01-15
-            :author: John Doe
-            
-            Attributes can be in any order.
-            """;
+                = Valid Document Title
+                :version: 1.0.0
+                :revdate: 2024-01-15
+                :author: John Doe
+
+                Attributes can be in any order.
+                """;
         File docFile = createTempFile("any-order.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertFalse(result.hasErrors());
         assertEquals(0, result.getErrorCount());
@@ -213,10 +194,10 @@ class MetadataValidatorIntegrationTest {
         String content = "";
         File docFile = createTempFile("empty.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertTrue(result.hasErrors());
         assertEquals(3, result.getErrorCount()); // All required attributes missing (author, revdate, version)
@@ -227,26 +208,26 @@ class MetadataValidatorIntegrationTest {
     void shouldGenerateReadableReportWhenPrintingValidationResult() throws IOException {
         // Given
         String content = """
-            = test
-            :author: j
-            
-            Invalid document.
-            """;
+                = test
+                :author: j
+
+                Invalid document.
+                """;
         File docFile = createTempFile("report-test.adoc", content);
         Document document = asciidoctor.loadFile(docFile, Options.builder().sourcemap(true).toFile(false).build());
         ValidationResult result = validator.validate(document);
-        
+
         // When
         java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
         java.io.PrintStream ps = new java.io.PrintStream(baos);
         java.io.PrintStream old = System.out;
         System.setOut(ps);
-        
+
         result.printReport();
-        
+
         System.out.flush();
         System.setOut(old);
-        
+
         // Then
         String report = baos.toString();
         assertTrue(report.contains("Validation Report"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/MetadataValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/MetadataValidatorTest.java
@@ -28,14 +28,9 @@ class MetadataValidatorTest {
     @BeforeEach
     void setUp() {
         testConfig = MetadataConfiguration.builder()
-            .attributes(Arrays.asList(
-                AttributeConfig.builder()
-                    .name("author")
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build()
-            ))
-            .build();
+                .attributes(Arrays.asList(
+                        AttributeConfig.builder().name("author").required(true).severity(Severity.ERROR).build()))
+                .build();
     }
 
     @Test
@@ -43,10 +38,10 @@ class MetadataValidatorTest {
     void shouldBuildValidatorWhenGivenConfiguration() {
         // Given
         // testConfig is already set up in @BeforeEach
-        
+
         // When
         MetadataValidator validator = MetadataValidator.fromConfiguration(testConfig).build();
-        
+
         // Then
         assertNotNull(validator);
     }
@@ -57,17 +52,17 @@ class MetadataValidatorTest {
         // Given
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
         String content = """
-            = Test Document
-            :author: Test Author
-            
-            Content here.
-            """;
+                = Test Document
+                :author: Test Author
+
+                Content here.
+                """;
         Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
         MetadataValidator validator = MetadataValidator.fromConfiguration(testConfig).build();
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertNotNull(result);
         assertFalse(result.hasErrors());
@@ -79,23 +74,24 @@ class MetadataValidatorTest {
         // Given
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
         String content = """
-            = Document Title
-            
-            Document without author.
-            """;
+                = Document Title
+
+                Document without author.
+                """;
         Path tempFile = Files.createTempFile("test", ".adoc");
         Files.writeString(tempFile, content);
-        Document document = asciidoctor.loadFile(tempFile.toFile(), Options.builder().sourcemap(true).toFile(false).build());
+        Document document = asciidoctor.loadFile(tempFile.toFile(),
+                Options.builder().sourcemap(true).toFile(false).build());
         MetadataValidator validator = MetadataValidator.fromConfiguration(testConfig).build();
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertTrue(result.hasErrors());
         assertTrue(result.getMessages().stream()
-            .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'author'")));
-        
+                .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'author'")));
+
         // Cleanup
         Files.deleteIfExists(tempFile);
     }
@@ -106,32 +102,23 @@ class MetadataValidatorTest {
         // Given
         Asciidoctor asciidoctor = Asciidoctor.Factory.create();
         String content = """
-            = Test Title
-            :author: John Doe
-            :version: 1.0
-            
-            Content.
-            """;
+                = Test Title
+                :author: John Doe
+                :version: 1.0
+
+                Content.
+                """;
         Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
         MetadataConfiguration config = MetadataConfiguration.builder()
-            .attributes(Arrays.asList(
-                AttributeConfig.builder()
-                    .name("author")
-                    .order(1)
-                    .severity(Severity.ERROR)
-                    .build(),
-                AttributeConfig.builder()
-                    .name("version")
-                    .order(2)
-                    .severity(Severity.ERROR)
-                    .build()
-            ))
-            .build();
+                .attributes(Arrays.asList(
+                        AttributeConfig.builder().name("author").order(1).severity(Severity.ERROR).build(),
+                        AttributeConfig.builder().name("version").order(2).severity(Severity.ERROR).build()))
+                .build();
         MetadataValidator validator = MetadataValidator.fromConfiguration(config).build();
-        
+
         // When
         ValidationResult result = validator.validate(document);
-        
+
         // Then
         assertNotNull(result);
         result.getMessages().forEach(msg -> {

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/MetadataValidatorUnderlineTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/MetadataValidatorUnderlineTest.java
@@ -24,51 +24,46 @@ import com.dataliquid.asciidoc.linter.config.rule.AttributeConfig;
  */
 @DisplayName("MetadataValidator Underline Test")
 class MetadataValidatorUnderlineTest {
-    
+
     private Asciidoctor asciidoctor;
-    
+
     @BeforeEach
     void setUp() {
         asciidoctor = Asciidoctor.Factory.create();
     }
-    
+
     @Test
     @DisplayName("should report correct column position for attribute value")
     void shouldReportCorrectColumnPositionForAttributeValue(@TempDir Path tempDir) throws IOException {
         // Given
         String content = """
-            = Test Document
-            :author: john doe
-            :version: 1.0
-            """;
-        
+                = Test Document
+                :author: john doe
+                :version: 1.0
+                """;
+
         Path testFile = tempDir.resolve("test.adoc");
         Files.writeString(testFile, content);
-        
-        Document document = asciidoctor.loadFile(testFile.toFile(), 
-            Options.builder().sourcemap(true).toFile(false).build());
-        
+
+        Document document = asciidoctor.loadFile(testFile.toFile(),
+                Options.builder().sourcemap(true).toFile(false).build());
+
         MetadataConfiguration config = MetadataConfiguration.builder()
-            .attributes(java.util.Arrays.asList(
-                AttributeConfig.builder()
-                    .name("author")
-                    .pattern("^[A-Z][a-z]+ [A-Z][a-z]+$")
-                    .severity(Severity.ERROR)
-                    .build()
-            ))
-            .build();
-        
+                .attributes(java.util.Arrays.asList(AttributeConfig.builder().name("author")
+                        .pattern("^[A-Z][a-z]+ [A-Z][a-z]+$").severity(Severity.ERROR).build()))
+                .build();
+
         MetadataValidator validator = MetadataValidator.fromConfiguration(config).build();
-        
+
         // When
         ValidationResult result = validator.validate(document, testFile.toString());
-        
+
         // Then
         assertFalse(result.getMessages().isEmpty(), "Should have validation errors");
-        
+
         ValidationMessage message = result.getMessages().get(0);
         assertEquals("author", message.getAttributeName().orElse(""));
-        
+
         // Check location
         SourceLocation location = message.getLocation();
         assertEquals(2, location.getStartLine(), "Should be on line 2");

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/SectionValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/SectionValidatorTest.java
@@ -21,266 +21,204 @@ import com.dataliquid.asciidoc.linter.config.rule.SectionConfig;
 import com.dataliquid.asciidoc.linter.config.rule.TitleConfig;
 
 class SectionValidatorTest {
-    
+
     private Asciidoctor asciidoctor;
-    
+
     @BeforeEach
     void setUp() {
         asciidoctor = Asciidoctor.Factory.create();
     }
-    
+
     @Nested
     @DisplayName("Document Title Validation (Level 0)")
     class DocumentTitleValidation {
-        
+
         @Test
         @DisplayName("should validate document title pattern")
         void shouldValidateDocumentTitlePattern() {
             // Given
             String content = """
-                = my document
-                
-                Content here.
-                """;
-            
-            SectionConfig titleConfig = SectionConfig.builder()
-                .level(0)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration docConfig = DocumentConfiguration.builder()
-                .sections(Arrays.asList(titleConfig))
-                .build();
-            
+                    = my document
+
+                    Content here.
+                    """;
+
+            SectionConfig titleConfig = SectionConfig.builder().level(0)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^[A-Z].*").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration docConfig = DocumentConfiguration.builder().sections(Arrays.asList(titleConfig))
+                    .build();
+
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             SectionValidator validator = SectionValidator.fromConfiguration(docConfig).build();
-            
+
             // When
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(1, result.getErrorCount());
-            assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getRuleId().equals("section.title.pattern")));
+            assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getRuleId().equals("section.title.pattern")));
         }
-        
+
         @Test
         @DisplayName("should detect missing document title")
         void shouldDetectMissingDocumentTitle() {
             // Given
             String content = """
-                Content without title.
-                """;
-            
-            SectionConfig titleConfig = SectionConfig.builder()
-                .level(0)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .build();
-            
-            DocumentConfiguration docConfig = DocumentConfiguration.builder()
-                .sections(Arrays.asList(titleConfig))
-                .build();
-            
+                    Content without title.
+                    """;
+
+            SectionConfig titleConfig = SectionConfig.builder().level(0)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build()).build();
+
+            DocumentConfiguration docConfig = DocumentConfiguration.builder().sections(Arrays.asList(titleConfig))
+                    .build();
+
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             SectionValidator validator = SectionValidator.fromConfiguration(docConfig).build();
-            
+
             // When
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals("Document title is required", result.getMessages().get(0).getMessage());
         }
-        
+
         @Test
         @DisplayName("should accept valid document title")
         void shouldAcceptValidDocumentTitle() {
             // Given
             String content = """
-                = Valid Document Title
-                
-                Content here.
-                """;
-            
-            SectionConfig titleConfig = SectionConfig.builder()
-                .level(0)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration docConfig = DocumentConfiguration.builder()
-                .sections(Arrays.asList(titleConfig))
-                .build();
-            
+                    = Valid Document Title
+
+                    Content here.
+                    """;
+
+            SectionConfig titleConfig = SectionConfig.builder().level(0)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^[A-Z].*").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration docConfig = DocumentConfiguration.builder().sections(Arrays.asList(titleConfig))
+                    .build();
+
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             SectionValidator validator = SectionValidator.fromConfiguration(docConfig).build();
-            
+
             // When
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.hasErrors());
         }
     }
-    
+
     @Nested
     @DisplayName("Basic Section Validation")
     class BasicSectionValidation {
-        
+
         @Test
         @DisplayName("should validate document with matching sections")
         void shouldValidateDocumentWithMatchingSections() {
             // Given
             String content = """
-                = Document Title
-                
-                == Introduction
-                This is the introduction.
-                
-                == Getting Started
-                This is how to get started.
-                """;
-            
-            SectionConfig introSection = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Introduction$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig gettingStartedSection = SectionConfig.builder()
-                .name("getting-started")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Getting Started$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+                    = Document Title
+
+                    == Introduction
+                    This is the introduction.
+
+                    == Getting Started
+                    This is how to get started.
+                    """;
+
+            SectionConfig introSection = SectionConfig.builder().name("introduction").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Introduction$").severity(Severity.ERROR).build()).build();
+
+            SectionConfig gettingStartedSection = SectionConfig.builder().name("getting-started").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Getting Started$").severity(Severity.ERROR).build()).build();
+
             DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(introSection, gettingStartedSection))
-                .build();
-            
+                    .sections(Arrays.asList(introSection, gettingStartedSection)).build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid());
             assertEquals(0, result.getMessages().size());
         }
-        
+
         @Test
         @DisplayName("should detect missing required sections")
         void shouldDetectMissingRequiredSections() {
             // Given
             String content = """
-                = Document Title
-                
-                == Getting Started
-                This is how to get started.
-                """;
-            
-            SectionConfig requiredSection = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Introduction$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(requiredSection))
-                .build();
-            
+                    = Document Title
+
+                    == Getting Started
+                    This is how to get started.
+                    """;
+
+            SectionConfig requiredSection = SectionConfig.builder().name("introduction").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Introduction$").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(requiredSection))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
-            
+
             // The validator finds a section at level 1 ("Getting Started") but it doesn't match
             // the required pattern "^Introduction$", so it reports a pattern mismatch
             assertEquals(1, result.getMessages().size());
-            
+
             ValidationMessage message = result.getMessages().get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("Section title does not match required pattern", message.getMessage());
             assertEquals("Getting Started", message.getActualValue().orElse(null));
             assertTrue(message.getExpectedValue().orElse("").contains("Introduction"));
         }
-        
+
         @Test
         @DisplayName("should detect too many section occurrences")
         void shouldDetectTooManySectionOccurrences() {
             // Given
             String content = """
-                = Document Title
-                
-                == Introduction
-                First intro.
-                
-                == Introduction
-                Second intro.
-                """;
-            
-            SectionConfig section = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(section))
-                .build();
-            
+                    = Document Title
+
+                    == Introduction
+                    First intro.
+
+                    == Introduction
+                    Second intro.
+                    """;
+
+            SectionConfig section = SectionConfig.builder().name("introduction").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(section)).build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
             assertEquals(1, result.getMessages().size());
-            
+
             ValidationMessage message = result.getMessages().get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("Too many occurrences of section: introduction", message.getMessage());
@@ -288,357 +226,266 @@ class SectionValidatorTest {
             assertEquals("At most 1", message.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("Title Pattern Validation")
     class TitlePatternValidation {
-        
+
         @Test
         @DisplayName("should provide specific error for pattern mismatch vs level mismatch")
         void shouldProvideSpecificErrorForPatternMismatch() {
             // Given
             String content = """
-                = Document Title
-                
-                == Conclusion
-                This is the conclusion section.
-                
-                === Unexpected Subsection
-                This is at level 2.
-                """;
-            
-            SectionConfig conclusionSection = SectionConfig.builder()
-                .name("conclusion")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Conclusion$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(conclusionSection))
-                .build();
-            
+                    = Document Title
+
+                    == Conclusion
+                    This is the conclusion section.
+
+                    === Unexpected Subsection
+                    This is at level 2.
+                    """;
+
+            SectionConfig conclusionSection = SectionConfig.builder().name("conclusion").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Conclusion$").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(conclusionSection))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid()); // "Conclusion" matches the pattern
-            
+
             // The subsection should generate a "not allowed at level" error
             ValidationMessage levelError = result.getMessages().stream()
-                .filter(msg -> msg.getMessage().contains("Section not allowed at level 2"))
-                .findFirst()
-                .orElse(null);
-            
+                    .filter(msg -> msg.getMessage().contains("Section not allowed at level 2")).findFirst()
+                    .orElse(null);
+
             if (levelError != null) {
                 assertEquals("Section not allowed at level 2: 'Unexpected Subsection'", levelError.getMessage());
                 assertEquals("No sections configured for level 2", levelError.getExpectedValue().orElse(null));
             }
         }
-        
+
         @Test
         @DisplayName("should show pattern mismatch error when level matches but title doesn't")
         void shouldShowPatternMismatchError() {
             // Given
             String content = """
-                = Document Title
-                
-                == conclusion
-                This is the conclusion with lowercase title.
-                """;
-            
-            SectionConfig conclusionSection = SectionConfig.builder()
-                .name("conclusion")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Conclusion$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(conclusionSection))
-                .build();
-            
+                    = Document Title
+
+                    == conclusion
+                    This is the conclusion with lowercase title.
+                    """;
+
+            SectionConfig conclusionSection = SectionConfig.builder().name("conclusion").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Conclusion$").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(conclusionSection))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
-            
+
             ValidationMessage message = result.getMessages().stream()
-                .filter(msg -> msg.getMessage().contains("Section title does not match required pattern"))
-                .findFirst()
-                .orElseThrow();
-            
+                    .filter(msg -> msg.getMessage().contains("Section title does not match required pattern"))
+                    .findFirst().orElseThrow();
+
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("Section title does not match required pattern", message.getMessage());
             assertEquals("conclusion", message.getActualValue().orElse(null));
             assertEquals("Pattern: ^Conclusion$", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate section title with pattern")
         void shouldValidateSectionTitleWithPattern() {
             // Given
             String content = """
-                = Document Title
-                
-                == Chapter 1: Introduction
-                This is chapter 1.
-                
-                == Chapter 2: Implementation
-                This is chapter 2.
-                """;
-            
-            SectionConfig chapterSection = SectionConfig.builder()
-                .name("chapter")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(10)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("Chapter \\d+: .*")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(chapterSection))
-                .build();
-            
+                    = Document Title
+
+                    == Chapter 1: Introduction
+                    This is chapter 1.
+
+                    == Chapter 2: Implementation
+                    This is chapter 2.
+                    """;
+
+            SectionConfig chapterSection = SectionConfig.builder().name("chapter").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(10).build())
+                    .title(TitleConfig.builder().pattern("Chapter \\d+: .*").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(chapterSection))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid());
             assertEquals(0, result.getMessages().size());
         }
-        
+
         @Test
         @DisplayName("should detect title pattern mismatch")
         void shouldDetectTitlePatternMismatch() {
             // Given
             String content = """
-                = Document Title
-                
-                == Introduction
-                This doesn't match the pattern.
-                """;
-            
-            SectionConfig section = SectionConfig.builder()
-                .name("chapter")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(10)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("Chapter \\d+: .*")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(section))
-                .build();
-            
+                    = Document Title
+
+                    == Introduction
+                    This doesn't match the pattern.
+                    """;
+
+            SectionConfig section = SectionConfig.builder().name("chapter").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(10).build())
+                    .title(TitleConfig.builder().pattern("Chapter \\d+: .*").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(section)).build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
-            
+
             ValidationMessage message = result.getMessages().stream()
-                .filter(msg -> msg.getMessage().contains("Section title does not match required pattern"))
-                .findFirst()
-                .orElseThrow();
-            
+                    .filter(msg -> msg.getMessage().contains("Section title does not match required pattern"))
+                    .findFirst().orElseThrow();
+
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("Section title does not match required pattern", message.getMessage());
             assertEquals("Introduction", message.getActualValue().orElse(null));
             assertEquals("Pattern: Chapter \\d+: .*", message.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("Level Validation")
     class LevelValidation {
-        
+
         @Test
         @DisplayName("should detect incorrect section level")
         void shouldDetectIncorrectSectionLevel() {
             // Given
             String content = """
-                = Document Title
-                
-                === Introduction
-                This is at level 2 instead of level 1.
-                """;
-            
-            SectionConfig section = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(section))
-                .build();
-            
+                    = Document Title
+
+                    === Introduction
+                    This is at level 2 instead of level 1.
+                    """;
+
+            SectionConfig section = SectionConfig.builder().name("introduction").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(section)).build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
-            
+
             ValidationMessage unexpectedMessage = result.getMessages().stream()
-                .filter(msg -> msg.getMessage().contains("Section not allowed at level"))
-                .findFirst()
-                .orElseThrow();
-            
+                    .filter(msg -> msg.getMessage().contains("Section not allowed at level")).findFirst().orElseThrow();
+
             assertEquals("Section not allowed at level 2: 'Introduction'", unexpectedMessage.getMessage());
             assertEquals("Introduction", unexpectedMessage.getActualValue().orElse(null));
             assertEquals("No sections configured for level 2", unexpectedMessage.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("Order Constraints Validation")
     class OrderConstraintsValidation {
-        
+
         @Test
         @DisplayName("should validate correct section order")
         void shouldValidateCorrectSectionOrder() {
             // Given
             String content = """
-                = Document Title
-                
-                == Introduction
-                This is the introduction.
-                
-                == Prerequisites
-                These are the prerequisites.
-                
-                == Installation
-                This is how to install.
-                """;
-            
-            SectionConfig intro = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .order(1)
-                .title(TitleConfig.builder()
-                    .pattern("^Introduction$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig prereq = SectionConfig.builder()
-                .name("prerequisites")
-                .level(1)
-                .order(2)
-                .title(TitleConfig.builder()
-                    .pattern("^Prerequisites$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig install = SectionConfig.builder()
-                .name("installation")
-                .level(1)
-                .order(3)
-                .title(TitleConfig.builder()
-                    .pattern("^Installation$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+                    = Document Title
+
+                    == Introduction
+                    This is the introduction.
+
+                    == Prerequisites
+                    These are the prerequisites.
+
+                    == Installation
+                    This is how to install.
+                    """;
+
+            SectionConfig intro = SectionConfig.builder().name("introduction").level(1).order(1)
+                    .title(TitleConfig.builder().pattern("^Introduction$").severity(Severity.ERROR).build()).build();
+
+            SectionConfig prereq = SectionConfig.builder().name("prerequisites").level(1).order(2)
+                    .title(TitleConfig.builder().pattern("^Prerequisites$").severity(Severity.ERROR).build()).build();
+
+            SectionConfig install = SectionConfig.builder().name("installation").level(1).order(3)
+                    .title(TitleConfig.builder().pattern("^Installation$").severity(Severity.ERROR).build()).build();
+
             DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(intro, prereq, install))
-                .build();
-            
+                    .sections(Arrays.asList(intro, prereq, install)).build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid());
             assertEquals(0, result.getMessages().size());
         }
-        
+
         @Test
         @DisplayName("should detect incorrect section order")
         void shouldDetectIncorrectSectionOrder() {
             // Given
             String content = """
-                = Document Title
-                
-                == Installation
-                This is how to install.
-                
-                == Introduction
-                This is the introduction.
-                """;
-            
-            SectionConfig intro = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .order(1)
-                .title(TitleConfig.builder()
-                    .pattern("^Introduction$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig install = SectionConfig.builder()
-                .name("installation")
-                .level(1)
-                .order(2)
-                .title(TitleConfig.builder()
-                    .pattern("^Installation$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(intro, install))
-                .build();
-            
+                    = Document Title
+
+                    == Installation
+                    This is how to install.
+
+                    == Introduction
+                    This is the introduction.
+                    """;
+
+            SectionConfig intro = SectionConfig.builder().name("introduction").level(1).order(1)
+                    .title(TitleConfig.builder().pattern("^Introduction$").severity(Severity.ERROR).build()).build();
+
+            SectionConfig install = SectionConfig.builder().name("installation").level(1).order(2)
+                    .title(TitleConfig.builder().pattern("^Installation$").severity(Severity.ERROR).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(intro, install))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
             assertEquals(1, result.getMessages().size());
-            
+
             ValidationMessage message = result.getMessages().get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("Section order violation", message.getMessage());
@@ -646,139 +493,93 @@ class SectionValidatorTest {
             assertEquals("introduction should appear before installation", message.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("Subsection Validation")
     class SubsectionValidation {
-        
+
         @Test
         @DisplayName("should validate nested subsections")
         void shouldValidateNestedSubsections() {
             // Given
             String content = """
-                = Document Title
-                
-                == Features
-                Main features section.
-                
-                === Core Features
-                These are core features.
-                
-                === Advanced Features
-                These are advanced features.
-                """;
-            
-            SectionConfig coreFeatures = SectionConfig.builder()
-                .name("core-features")
-                .level(2)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Core Features$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig advancedFeatures = SectionConfig.builder()
-                .name("advanced-features")
-                .level(2)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Advanced Features$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig featuresSection = SectionConfig.builder()
-                .name("features")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Features$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .subsections(Arrays.asList(coreFeatures, advancedFeatures))
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(featuresSection))
-                .build();
-            
+                    = Document Title
+
+                    == Features
+                    Main features section.
+
+                    === Core Features
+                    These are core features.
+
+                    === Advanced Features
+                    These are advanced features.
+                    """;
+
+            SectionConfig coreFeatures = SectionConfig.builder().name("core-features").level(2)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Core Features$").severity(Severity.ERROR).build()).build();
+
+            SectionConfig advancedFeatures = SectionConfig.builder().name("advanced-features").level(2)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Advanced Features$").severity(Severity.ERROR).build())
+                    .build();
+
+            SectionConfig featuresSection = SectionConfig.builder().name("features").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Features$").severity(Severity.ERROR).build())
+                    .subsections(Arrays.asList(coreFeatures, advancedFeatures)).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(featuresSection))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid());
             assertEquals(0, result.getMessages().size());
         }
-        
+
         @Test
         @DisplayName("should detect missing required subsections")
         void shouldDetectMissingRequiredSubsections() {
             // Given
             String content = """
-                = Document Title
-                
-                == Features
-                Main features section.
-                
-                === Advanced Features
-                These are advanced features.
-                """;
-            
-            SectionConfig coreFeatures = SectionConfig.builder()
-                .name("core-features")
-                .level(2)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Core Features$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
-            SectionConfig featuresSection = SectionConfig.builder()
-                .name("features")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(1)
-                    .max(1)
-                    .build())
-                .title(TitleConfig.builder()
-                    .pattern("^Features$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .subsections(Arrays.asList(coreFeatures))
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(featuresSection))
-                .build();
-            
+                    = Document Title
+
+                    == Features
+                    Main features section.
+
+                    === Advanced Features
+                    These are advanced features.
+                    """;
+
+            SectionConfig coreFeatures = SectionConfig.builder().name("core-features").level(2)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Core Features$").severity(Severity.ERROR).build()).build();
+
+            SectionConfig featuresSection = SectionConfig.builder().name("features").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(1).max(1).build())
+                    .title(TitleConfig.builder().pattern("^Features$").severity(Severity.ERROR).build())
+                    .subsections(Arrays.asList(coreFeatures)).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(featuresSection))
+                    .build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertFalse(result.isValid());
-            
+
             // The validator finds a subsection at level 2 ("Advanced Features") but it doesn't match
             // the required pattern "^Core Features$", so it reports a pattern mismatch
             assertEquals(1, result.getMessages().size());
-            
+
             ValidationMessage message = result.getMessages().get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("Section title does not match required pattern", message.getMessage());
@@ -786,58 +587,50 @@ class SectionValidatorTest {
             assertTrue(message.getExpectedValue().orElse("").contains("Core Features"));
         }
     }
-    
+
     @Nested
     @DisplayName("Edge Cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should handle empty document")
         void shouldHandleEmptyDocument() {
             // Given
             String content = "= Document Title\n";
-            
-            SectionConfig section = SectionConfig.builder()
-                .name("introduction")
-                .level(1)
-                .occurrence(OccurrenceConfig.builder()
-                    .min(0)
-                    .max(1)
-                    .build())
-                .build();
-            
-            DocumentConfiguration config = DocumentConfiguration.builder()
-                .sections(Arrays.asList(section))
-                .build();
-            
+
+            SectionConfig section = SectionConfig.builder().name("introduction").level(1)
+                    .occurrence(OccurrenceConfig.builder().min(0).max(1).build()).build();
+
+            DocumentConfiguration config = DocumentConfiguration.builder().sections(Arrays.asList(section)).build();
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid());
             assertEquals(0, result.getMessages().size());
         }
-        
+
         @Test
         @DisplayName("should handle document with no configured sections")
         void shouldHandleDocumentWithNoConfiguredSections() {
             // Given
             String content = """
-                = Document Title
-                
-                == Some Section
-                Content here.
-                """;
-            
+                    = Document Title
+
+                    == Some Section
+                    Content here.
+                    """;
+
             DocumentConfiguration config = DocumentConfiguration.builder().build();
-            
+
             // When
             SectionValidator validator = SectionValidator.fromConfiguration(config).build();
             Document document = asciidoctor.load(content, Options.builder().sourcemap(true).toFile(false).build());
             ValidationResult result = validator.validate(document);
-            
+
             // Then
             assertTrue(result.isValid());
             assertEquals(0, result.getMessages().size());

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/SourceLocationTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/SourceLocationTest.java
@@ -16,7 +16,7 @@ class SourceLocationTest {
     @Nested
     @DisplayName("Builder")
     class BuilderTest {
-        
+
         @Test
         @DisplayName("should create location with all fields")
         void shouldCreateLocationWithAllFields() {
@@ -27,17 +27,11 @@ class SourceLocationTest {
             int endLine = 12;
             int endColumn = 15;
             String sourceLine = "= Test Document";
-            
+
             // When
-            SourceLocation location = SourceLocation.builder()
-                .filename(filename)
-                .startLine(startLine)
-                .startColumn(startColumn)
-                .endLine(endLine)
-                .endColumn(endColumn)
-                .sourceLine(sourceLine)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename(filename).startLine(startLine)
+                    .startColumn(startColumn).endLine(endLine).endColumn(endColumn).sourceLine(sourceLine).build();
+
             // Then
             assertEquals(filename, location.getFilename());
             assertEquals(startLine, location.getStartLine());
@@ -46,7 +40,7 @@ class SourceLocationTest {
             assertEquals(endColumn, location.getEndColumn());
             assertEquals(sourceLine, location.getSourceLine());
         }
-        
+
         @Test
         @DisplayName("should create single line location")
         void shouldCreateSingleLineLocation() {
@@ -55,14 +49,11 @@ class SourceLocationTest {
             int line = 5;
             int startColumn = 10;
             int endColumn = 20;
-            
+
             // When
-            SourceLocation location = SourceLocation.builder()
-                .filename(filename)
-                .line(line)
-                .columns(startColumn, endColumn)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename(filename).line(line)
+                    .columns(startColumn, endColumn).build();
+
             // Then
             assertEquals(line, location.getStartLine());
             assertEquals(line, location.getEndLine());
@@ -70,92 +61,74 @@ class SourceLocationTest {
             assertEquals(endColumn, location.getEndColumn());
             assertFalse(location.isMultiLine());
         }
-        
+
         @Test
         @DisplayName("should require filename")
         void shouldRequireFilename() {
             // Given
             SourceLocation.Builder builder = SourceLocation.builder();
-            
+
             // When/Then
-            assertThrows(NullPointerException.class, () -> 
-                builder.build()
-            );
+            assertThrows(NullPointerException.class, () -> builder.build());
         }
     }
 
     @Nested
     @DisplayName("Formatting")
     class FormattingTest {
-        
+
         @Test
         @DisplayName("should format single line with column range")
         void shouldFormatSingleLineWithColumnRange() {
             // Given
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .line(10)
-                .columns(5, 15)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").line(10).columns(5, 15).build();
+
             // When
             String formatted = location.formatLocation();
-            
+
             // Then
             assertEquals("test.adoc:10:5-15", formatted);
         }
-        
+
         @Test
         @DisplayName("should format single line with single column")
         void shouldFormatSingleLineWithSingleColumn() {
             // Given
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .line(10)
-                .startColumn(5)
-                .endColumn(5)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").line(10).startColumn(5)
+                    .endColumn(5).build();
+
             // When
             String formatted = location.formatLocation();
-            
+
             // Then
             assertEquals("test.adoc:10:5", formatted);
         }
-        
+
         @Test
         @DisplayName("should format multi-line location")
         void shouldFormatMultiLineLocation() {
             // Given
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .startLine(10)
-                .endLine(15)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").startLine(10).endLine(15).build();
+
             // When
             String formatted = location.formatLocation();
             boolean isMultiLine = location.isMultiLine();
-            
+
             // Then
             assertEquals("test.adoc:10-15", formatted);
             assertTrue(isMultiLine);
         }
-        
+
         @Test
         @DisplayName("should format line only location")
         void shouldFormatLineOnlyLocation() {
             // Given
-            SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .line(10)
-                .startColumn(0)
-                .endColumn(0)
-                .build();
-            
+            SourceLocation location = SourceLocation.builder().filename("test.adoc").line(10).startColumn(0)
+                    .endColumn(0).build();
+
             // When
             String formatted = location.formatLocation();
-            
+
             // Then
             assertEquals("test.adoc:10", formatted);
         }
@@ -164,47 +137,35 @@ class SourceLocationTest {
     @Nested
     @DisplayName("Equals and HashCode")
     class EqualsHashCodeTest {
-        
+
         @Test
         @DisplayName("should be equal for same values")
         void shouldBeEqualForSameValues() {
             // Given
             String filename = "test.adoc";
             int line = 10;
-            
+
             // When
-            SourceLocation location1 = SourceLocation.builder()
-                .filename(filename)
-                .line(line)
-                .build();
-            
-            SourceLocation location2 = SourceLocation.builder()
-                .filename(filename)
-                .line(line)
-                .build();
-            
+            SourceLocation location1 = SourceLocation.builder().filename(filename).line(line).build();
+
+            SourceLocation location2 = SourceLocation.builder().filename(filename).line(line).build();
+
             // Then
             assertEquals(location1, location2);
             assertEquals(location1.hashCode(), location2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should not be equal for different filenames")
         void shouldNotBeEqualForDifferentFilenames() {
             // Given
             int sameLine = 10;
-            
+
             // When
-            SourceLocation location1 = SourceLocation.builder()
-                .filename("test1.adoc")
-                .line(sameLine)
-                .build();
-            
-            SourceLocation location2 = SourceLocation.builder()
-                .filename("test2.adoc")
-                .line(sameLine)
-                .build();
-            
+            SourceLocation location1 = SourceLocation.builder().filename("test1.adoc").line(sameLine).build();
+
+            SourceLocation location2 = SourceLocation.builder().filename("test2.adoc").line(sameLine).build();
+
             // Then
             assertNotEquals(location1, location2);
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/ValidationMessageTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/ValidationMessageTest.java
@@ -20,16 +20,13 @@ class ValidationMessageTest {
 
     @BeforeEach
     void setUp() {
-        testLocation = SourceLocation.builder()
-            .filename("test.adoc")
-            .line(10)
-            .build();
+        testLocation = SourceLocation.builder().filename("test.adoc").line(10).build();
     }
 
     @Nested
     @DisplayName("Builder")
     class BuilderTest {
-        
+
         @Test
         @DisplayName("should create message with required fields")
         void shouldCreateMessageWhenAllRequiredFieldsProvided() {
@@ -37,22 +34,18 @@ class ValidationMessageTest {
             Severity severity = Severity.ERROR;
             String ruleId = "metadata.required";
             String message = "Missing required attribute";
-            
+
             // When
-            ValidationMessage validationMessage = ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(ruleId)
-                .message(message)
-                .location(testLocation)
-                .build();
-            
+            ValidationMessage validationMessage = ValidationMessage.builder().severity(severity).ruleId(ruleId)
+                    .message(message).location(testLocation).build();
+
             // Then
             assertEquals(severity, validationMessage.getSeverity());
             assertEquals(ruleId, validationMessage.getRuleId());
             assertEquals(message, validationMessage.getMessage());
             assertEquals(testLocation, validationMessage.getLocation());
         }
-        
+
         @Test
         @DisplayName("should create message with all fields")
         void shouldCreateMessageWhenAllFieldsProvided() {
@@ -63,18 +56,12 @@ class ValidationMessageTest {
             String attributeName = "author";
             String actualValue = "john";
             String expectedValue = "Pattern '^[A-Z].*'";
-            
+
             // When
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(ruleId)
-                .message(messageText)
-                .location(testLocation)
-                .attributeName(attributeName)
-                .actualValue(actualValue)
-                .expectedValue(expectedValue)
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(severity).ruleId(ruleId)
+                    .message(messageText).location(testLocation).attributeName(attributeName).actualValue(actualValue)
+                    .expectedValue(expectedValue).build();
+
             // Then
             assertTrue(message.getAttributeName().isPresent());
             assertEquals(attributeName, message.getAttributeName().get());
@@ -83,24 +70,19 @@ class ValidationMessageTest {
             assertTrue(message.getExpectedValue().isPresent());
             assertEquals(expectedValue, message.getExpectedValue().get());
         }
-        
+
         @Test
         @DisplayName("should require severity")
         void shouldThrowExceptionWhenSeverityNotProvided() {
             // Given
             String ruleId = "test";
             String message = "test";
-            
+
             // When & Then
-            assertThrows(NullPointerException.class, () ->
-                ValidationMessage.builder()
-                    .ruleId(ruleId)
-                    .message(message)
-                    .location(testLocation)
-                    .build()
-            );
+            assertThrows(NullPointerException.class,
+                    () -> ValidationMessage.builder().ruleId(ruleId).message(message).location(testLocation).build());
         }
-        
+
         @Test
         @DisplayName("should require location")
         void shouldThrowExceptionWhenLocationNotProvided() {
@@ -108,78 +90,60 @@ class ValidationMessageTest {
             Severity severity = Severity.ERROR;
             String ruleId = "test";
             String message = "test";
-            
+
             // When & Then
-            assertThrows(NullPointerException.class, () ->
-                ValidationMessage.builder()
-                    .severity(severity)
-                    .ruleId(ruleId)
-                    .message(message)
-                    .build()
-            );
+            assertThrows(NullPointerException.class,
+                    () -> ValidationMessage.builder().severity(severity).ruleId(ruleId).message(message).build());
         }
     }
 
     @Nested
     @DisplayName("Formatting")
     class FormattingTest {
-        
+
         @Test
         @DisplayName("should format simple message")
         void shouldFormatMessageWhenOnlyRequiredFieldsProvided() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("metadata.required")
-                .message("Missing required attribute 'author': actual not present, expected non-empty value")
-                .location(testLocation)
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.ERROR).ruleId("metadata.required")
+                    .message("Missing required attribute 'author': actual not present, expected non-empty value")
+                    .location(testLocation).build();
+
             // When
             String formatted = message.format();
-            
+
             // Then
             assertTrue(formatted.contains("test.adoc:10"));
             assertTrue(formatted.contains("[ERROR]"));
             assertTrue(formatted.contains("Missing required attribute 'author'"));
         }
-        
+
         @Test
         @DisplayName("should format message with actual and expected values")
         void shouldFormatMessageWhenActualAndExpectedValuesProvided() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .ruleId("metadata.pattern")
-                .message("Invalid format")
-                .location(testLocation)
-                .actualValue("john")
-                .expectedValue("Pattern '^[A-Z].*'")
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.WARN).ruleId("metadata.pattern")
+                    .message("Invalid format").location(testLocation).actualValue("john")
+                    .expectedValue("Pattern '^[A-Z].*'").build();
+
             // When
             String formatted = message.format();
-            
+
             // Then
             assertTrue(formatted.contains("Found: \"john\""));
             assertTrue(formatted.contains("Expected: Pattern '^[A-Z].*'"));
         }
-        
+
         @Test
         @DisplayName("should format message with only actual value")
         void shouldFormatMessageWhenOnlyActualValueProvided() {
             // Given
-            ValidationMessage message = ValidationMessage.builder()
-                .severity(Severity.INFO)
-                .ruleId("metadata.length")
-                .message("Value detected")
-                .location(testLocation)
-                .actualValue("Some long text...")
-                .build();
-            
+            ValidationMessage message = ValidationMessage.builder().severity(Severity.INFO).ruleId("metadata.length")
+                    .message("Value detected").location(testLocation).actualValue("Some long text...").build();
+
             // When
             String formatted = message.format();
-            
+
             // Then
             assertTrue(formatted.contains("Found: \"Some long text...\""));
             assertFalse(formatted.contains("Expected:"));
@@ -189,7 +153,7 @@ class ValidationMessageTest {
     @Nested
     @DisplayName("Equals and HashCode")
     class EqualsHashCodeTest {
-        
+
         @Test
         @DisplayName("should be equal for same values")
         void shouldBeEqualWhenAllFieldsAreSame() {
@@ -197,49 +161,33 @@ class ValidationMessageTest {
             Severity severity = Severity.ERROR;
             String ruleId = "test.rule";
             String messageText = "Test message";
-            
+
             // When
-            ValidationMessage message1 = ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(ruleId)
-                .message(messageText)
-                .location(testLocation)
-                .build();
-            
-            ValidationMessage message2 = ValidationMessage.builder()
-                .severity(severity)
-                .ruleId(ruleId)
-                .message(messageText)
-                .location(testLocation)
-                .build();
-            
+            ValidationMessage message1 = ValidationMessage.builder().severity(severity).ruleId(ruleId)
+                    .message(messageText).location(testLocation).build();
+
+            ValidationMessage message2 = ValidationMessage.builder().severity(severity).ruleId(ruleId)
+                    .message(messageText).location(testLocation).build();
+
             // Then
             assertEquals(message1, message2);
             assertEquals(message1.hashCode(), message2.hashCode());
         }
-        
+
         @Test
         @DisplayName("should not be equal for different severities")
         void shouldNotBeEqualWhenSeveritiesDiffer() {
             // Given
             String ruleId = "test.rule";
             String messageText = "Test message";
-            
+
             // When
-            ValidationMessage message1 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId(ruleId)
-                .message(messageText)
-                .location(testLocation)
-                .build();
-            
-            ValidationMessage message2 = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .ruleId(ruleId)
-                .message(messageText)
-                .location(testLocation)
-                .build();
-            
+            ValidationMessage message1 = ValidationMessage.builder().severity(Severity.ERROR).ruleId(ruleId)
+                    .message(messageText).location(testLocation).build();
+
+            ValidationMessage message2 = ValidationMessage.builder().severity(Severity.WARN).ruleId(ruleId)
+                    .message(messageText).location(testLocation).build();
+
             // Then
             assertNotEquals(message1, message2);
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/ValidationResultTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/ValidationResultTest.java
@@ -21,60 +21,39 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("ValidationResult")
 class ValidationResultTest {
-    
+
     private ValidationMessage errorMessage;
     private ValidationMessage warnMessage;
     private ValidationMessage infoMessage;
     private SourceLocation location1;
     private SourceLocation location2;
-    
+
     @BeforeEach
     void setUp() {
-        location1 = SourceLocation.builder()
-            .filename("test1.adoc")
-            .startLine(10)
-            .startColumn(5)
-            .build();
-            
-        location2 = SourceLocation.builder()
-            .filename("test2.adoc")
-            .startLine(20)
-            .build();
-            
-        errorMessage = ValidationMessage.builder()
-            .severity(Severity.ERROR)
-            .ruleId("test.error")
-            .location(location1)
-            .message("Test error message")
-            .actualValue("actual")
-            .expectedValue("expected")
-            .build();
-            
-        warnMessage = ValidationMessage.builder()
-            .severity(Severity.WARN)
-            .ruleId("test.warn")
-            .location(location2)
-            .message("Test warning message")
-            .build();
-            
-        infoMessage = ValidationMessage.builder()
-            .severity(Severity.INFO)
-            .ruleId("test.info")
-            .location(location1)
-            .message("Test info message")
-            .build();
+        location1 = SourceLocation.builder().filename("test1.adoc").startLine(10).startColumn(5).build();
+
+        location2 = SourceLocation.builder().filename("test2.adoc").startLine(20).build();
+
+        errorMessage = ValidationMessage.builder().severity(Severity.ERROR).ruleId("test.error").location(location1)
+                .message("Test error message").actualValue("actual").expectedValue("expected").build();
+
+        warnMessage = ValidationMessage.builder().severity(Severity.WARN).ruleId("test.warn").location(location2)
+                .message("Test warning message").build();
+
+        infoMessage = ValidationMessage.builder().severity(Severity.INFO).ruleId("test.info").location(location1)
+                .message("Test info message").build();
     }
-    
+
     @Nested
     @DisplayName("Builder")
     class BuilderTests {
-        
+
         @Test
         @DisplayName("should create empty result")
         void shouldCreateEmptyResult() {
             // When
             ValidationResult result = ValidationResult.builder().build();
-            
+
             // Then
             assertNotNull(result);
             assertTrue(result.getMessages().isEmpty());
@@ -83,181 +62,159 @@ class ValidationResultTest {
             assertFalse(result.hasErrors());
             assertFalse(result.hasWarnings());
         }
-        
+
         @Test
         @DisplayName("should add single message")
         void shouldAddSingleMessage() {
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(errorMessage)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addMessage(errorMessage).build();
+
             // Then
             assertEquals(1, result.getMessages().size());
             assertEquals(errorMessage, result.getMessages().get(0));
         }
-        
+
         @Test
         @DisplayName("should add multiple messages")
         void shouldAddMultipleMessages() {
             // Given
             List<ValidationMessage> messages = Arrays.asList(errorMessage, warnMessage, infoMessage);
-            
+
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addMessages(messages)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addMessages(messages).build();
+
             // Then
             assertEquals(3, result.getMessages().size());
             assertTrue(result.getMessages().containsAll(messages));
         }
-        
+
         @Test
         @DisplayName("should track timing automatically")
         void shouldTrackTimingAutomatically() throws InterruptedException {
             // Given
             ValidationResult.Builder builder = ValidationResult.builder();
             Thread.sleep(10); // Ensure some time passes
-            
+
             // When
             ValidationResult result = builder.complete().build();
-            
+
             // Then
             assertTrue(result.getValidationTimeMillis() >= 10);
         }
-        
+
         @Test
         @DisplayName("should allow custom timing")
         void shouldAllowCustomTiming() {
             // Given
             long startTime = System.currentTimeMillis() - 1000;
             long endTime = System.currentTimeMillis();
-            
+
             // When
-            ValidationResult result = ValidationResult.builder()
-                .startTime(startTime)
-                .endTime(endTime)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().startTime(startTime).endTime(endTime).build();
+
             // Then
             assertEquals(endTime - startTime, result.getValidationTimeMillis());
         }
-        
+
         @Test
         @DisplayName("should throw on null message")
         void shouldThrowOnNullMessage() {
             // When/Then
-            assertThrows(NullPointerException.class, () ->
-                ValidationResult.builder().addMessage(null));
+            assertThrows(NullPointerException.class, () -> ValidationResult.builder().addMessage(null));
         }
-        
+
         @Test
         @DisplayName("should throw on null messages collection")
         void shouldThrowOnNullMessagesCollection() {
             // When/Then
-            assertThrows(NullPointerException.class, () ->
-                ValidationResult.builder().addMessages(null));
+            assertThrows(NullPointerException.class, () -> ValidationResult.builder().addMessages(null));
         }
-        
+
         @Test
         @DisplayName("should add scanned file")
         void shouldAddScannedFile() {
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addScannedFile("test.adoc")
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addScannedFile("test.adoc").build();
+
             // Then
             assertEquals(1, result.getScannedFileCount());
             assertTrue(result.getScannedFiles().contains("test.adoc"));
         }
-        
+
         @Test
         @DisplayName("should add multiple scanned files")
         void shouldAddMultipleScannedFiles() {
             // Given
             List<String> files = Arrays.asList("file1.adoc", "file2.adoc", "file3.adoc");
-            
+
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addScannedFiles(files)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addScannedFiles(files).build();
+
             // Then
             assertEquals(3, result.getScannedFileCount());
             assertTrue(result.getScannedFiles().containsAll(files));
         }
-        
+
         @Test
         @DisplayName("should handle duplicate scanned files")
         void shouldHandleDuplicateScannedFiles() {
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addScannedFile("test.adoc")
-                .addScannedFile("test.adoc")
-                .addScannedFile("other.adoc")
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addScannedFile("test.adoc").addScannedFile("test.adoc")
+                    .addScannedFile("other.adoc").build();
+
             // Then
             assertEquals(2, result.getScannedFileCount());
             assertTrue(result.getScannedFiles().contains("test.adoc"));
             assertTrue(result.getScannedFiles().contains("other.adoc"));
         }
-        
+
         @Test
         @DisplayName("should throw on null scanned file")
         void shouldThrowOnNullScannedFile() {
             // When/Then
-            assertThrows(NullPointerException.class, () ->
-                ValidationResult.builder().addScannedFile(null));
+            assertThrows(NullPointerException.class, () -> ValidationResult.builder().addScannedFile(null));
         }
-        
+
         @Test
         @DisplayName("should throw on null scanned files collection")
         void shouldThrowOnNullScannedFilesCollection() {
             // When/Then
-            assertThrows(NullPointerException.class, () ->
-                ValidationResult.builder().addScannedFiles(null));
+            assertThrows(NullPointerException.class, () -> ValidationResult.builder().addScannedFiles(null));
         }
     }
-    
+
     @Nested
     @DisplayName("Message Retrieval")
     class MessageRetrievalTests {
-        
+
         private ValidationResult result;
-        
+
         @BeforeEach
         void setUp() {
-            result = ValidationResult.builder()
-                .addMessage(errorMessage)
-                .addMessage(warnMessage)
-                .addMessage(infoMessage)
-                .build();
+            result = ValidationResult.builder().addMessage(errorMessage).addMessage(warnMessage).addMessage(infoMessage)
+                    .build();
         }
-        
+
         @Test
         @DisplayName("should return all messages")
         void shouldReturnAllMessages() {
             // When
             List<ValidationMessage> messages = result.getMessages();
-            
+
             // Then
             assertEquals(3, messages.size());
             assertTrue(messages.contains(errorMessage));
             assertTrue(messages.contains(warnMessage));
             assertTrue(messages.contains(infoMessage));
         }
-        
+
         @Test
         @DisplayName("should return immutable message list")
         void shouldReturnImmutableMessageList() {
             // When/Then
-            assertThrows(UnsupportedOperationException.class, () ->
-                result.getMessages().add(errorMessage));
+            assertThrows(UnsupportedOperationException.class, () -> result.getMessages().add(errorMessage));
         }
-        
+
         @Test
         @DisplayName("should filter messages by severity")
         void shouldFilterMessagesBySeverity() {
@@ -265,262 +222,228 @@ class ValidationResultTest {
             List<ValidationMessage> errors = result.getMessagesBySeverity(Severity.ERROR);
             List<ValidationMessage> warnings = result.getMessagesBySeverity(Severity.WARN);
             List<ValidationMessage> infos = result.getMessagesBySeverity(Severity.INFO);
-            
+
             // Then
             assertEquals(1, errors.size());
             assertEquals(errorMessage, errors.get(0));
-            
+
             assertEquals(1, warnings.size());
             assertEquals(warnMessage, warnings.get(0));
-            
+
             assertEquals(1, infos.size());
             assertEquals(infoMessage, infos.get(0));
         }
     }
-    
+
     @Nested
     @DisplayName("Message Grouping")
     class MessageGroupingTests {
-        
+
         private ValidationResult result;
         private ValidationMessage anotherErrorInFile1;
         private ValidationMessage errorInFile2;
-        
+
         @BeforeEach
         void setUp() {
-            anotherErrorInFile1 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("another.error")
-                .location(SourceLocation.builder()
-                    .filename("test1.adoc")
-                    .startLine(15)
-                    .build())
-                .message("Another error")
-                .build();
-                
-            errorInFile2 = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("file2.error")
-                .location(location2)
-                .message("Error in file 2")
-                .build();
-                
-            result = ValidationResult.builder()
-                .addMessage(errorMessage)
-                .addMessage(anotherErrorInFile1)
-                .addMessage(errorInFile2)
-                .addMessage(infoMessage)
-                .build();
+            anotherErrorInFile1 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("another.error")
+                    .location(SourceLocation.builder().filename("test1.adoc").startLine(15).build())
+                    .message("Another error").build();
+
+            errorInFile2 = ValidationMessage.builder().severity(Severity.ERROR).ruleId("file2.error")
+                    .location(location2).message("Error in file 2").build();
+
+            result = ValidationResult.builder().addMessage(errorMessage).addMessage(anotherErrorInFile1)
+                    .addMessage(errorInFile2).addMessage(infoMessage).build();
         }
-        
+
         @Test
         @DisplayName("should group messages by file")
         void shouldGroupMessagesByFile() {
             // When
             Map<String, List<ValidationMessage>> messagesByFile = result.getMessagesByFile();
-            
+
             // Then
             assertEquals(2, messagesByFile.size());
             assertTrue(messagesByFile.containsKey("test1.adoc"));
             assertTrue(messagesByFile.containsKey("test2.adoc"));
-            
+
             List<ValidationMessage> file1Messages = messagesByFile.get("test1.adoc");
             assertEquals(3, file1Messages.size());
             assertTrue(file1Messages.contains(errorMessage));
             assertTrue(file1Messages.contains(anotherErrorInFile1));
             assertTrue(file1Messages.contains(infoMessage));
-            
+
             List<ValidationMessage> file2Messages = messagesByFile.get("test2.adoc");
             assertEquals(1, file2Messages.size());
             assertEquals(errorInFile2, file2Messages.get(0));
         }
-        
+
         @Test
         @DisplayName("should return sorted map by filename")
         void shouldReturnSortedMapByFilename() {
             // When
             Map<String, List<ValidationMessage>> messagesByFile = result.getMessagesByFile();
-            
+
             // Then
             List<String> filenames = messagesByFile.keySet().stream().toList();
             assertEquals("test1.adoc", filenames.get(0));
             assertEquals("test2.adoc", filenames.get(1));
         }
-        
+
         @Test
         @DisplayName("should group messages by line")
         void shouldGroupMessagesByLine() {
             // When
             Map<Integer, List<ValidationMessage>> messagesByLine = result.getMessagesByLine("test1.adoc");
-            
+
             // Then
             assertEquals(2, messagesByLine.size());
             assertTrue(messagesByLine.containsKey(10));
             assertTrue(messagesByLine.containsKey(15));
-            
+
             assertEquals(2, messagesByLine.get(10).size()); // error and info
             assertEquals(1, messagesByLine.get(15).size()); // anotherError
         }
-        
+
         @Test
         @DisplayName("should return empty map for unknown file")
         void shouldReturnEmptyMapForUnknownFile() {
             // When
             Map<Integer, List<ValidationMessage>> messagesByLine = result.getMessagesByLine("unknown.adoc");
-            
+
             // Then
             assertTrue(messagesByLine.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Status Checks")
     class StatusChecksTests {
-        
+
         @Test
         @DisplayName("should detect errors")
         void shouldDetectErrors() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(errorMessage)
-                .addMessage(warnMessage)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addMessage(errorMessage).addMessage(warnMessage)
+                    .build();
+
             // Then
             assertTrue(result.hasErrors());
             assertTrue(result.hasWarnings());
         }
-        
+
         @Test
         @DisplayName("should detect warnings without errors")
         void shouldDetectWarningsWithoutErrors() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(warnMessage)
-                .addMessage(infoMessage)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addMessage(warnMessage).addMessage(infoMessage)
+                    .build();
+
             // Then
             assertFalse(result.hasErrors());
             assertTrue(result.hasWarnings());
         }
-        
+
         @Test
         @DisplayName("should handle empty result")
         void shouldHandleEmptyResult() {
             // Given
             ValidationResult result = ValidationResult.builder().build();
-            
+
             // Then
             assertFalse(result.hasErrors());
             assertFalse(result.hasWarnings());
         }
     }
-    
+
     @Nested
     @DisplayName("Counting")
     class CountingTests {
-        
+
         private ValidationResult result;
-        
+
         @BeforeEach
         void setUp() {
-            ValidationMessage anotherError = ValidationMessage.builder()
-                .severity(Severity.ERROR)
-                .ruleId("another.error")
-                .location(location1)
-                .message("Another error")
-                .build();
-                
-            ValidationMessage anotherWarn = ValidationMessage.builder()
-                .severity(Severity.WARN)
-                .ruleId("another.warn")
-                .location(location2)
-                .message("Another warning")
-                .build();
-                
-            result = ValidationResult.builder()
-                .addMessage(errorMessage)
-                .addMessage(anotherError)
-                .addMessage(warnMessage)
-                .addMessage(anotherWarn)
-                .addMessage(infoMessage)
-                .build();
+            ValidationMessage anotherError = ValidationMessage.builder().severity(Severity.ERROR)
+                    .ruleId("another.error").location(location1).message("Another error").build();
+
+            ValidationMessage anotherWarn = ValidationMessage.builder().severity(Severity.WARN).ruleId("another.warn")
+                    .location(location2).message("Another warning").build();
+
+            result = ValidationResult.builder().addMessage(errorMessage).addMessage(anotherError)
+                    .addMessage(warnMessage).addMessage(anotherWarn).addMessage(infoMessage).build();
         }
-        
+
         @Test
         @DisplayName("should count errors correctly")
         void shouldCountErrorsCorrectly() {
             assertEquals(2, result.getErrorCount());
         }
-        
+
         @Test
         @DisplayName("should count warnings correctly")
         void shouldCountWarningsCorrectly() {
             assertEquals(2, result.getWarningCount());
         }
-        
+
         @Test
         @DisplayName("should count info messages correctly")
         void shouldCountInfoMessagesCorrectly() {
             assertEquals(1, result.getInfoCount());
         }
-        
+
         @Test
         @DisplayName("should handle empty result")
         void shouldHandleEmptyResult() {
             // Given
             ValidationResult emptyResult = ValidationResult.builder().build();
-            
+
             // Then
             assertEquals(0, emptyResult.getErrorCount());
             assertEquals(0, emptyResult.getWarningCount());
             assertEquals(0, emptyResult.getInfoCount());
         }
     }
-    
+
     @Nested
     @DisplayName("Report Printing")
     class ReportPrintingTests {
-        
+
         private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         private final PrintStream originalOut = System.out;
-        
+
         @BeforeEach
         void setUp() {
             System.setOut(new PrintStream(outputStream));
         }
-        
+
         @Test
         @DisplayName("should print empty report")
         void shouldPrintEmptyReport() {
             // Given
             ValidationResult result = ValidationResult.builder().build();
-            
+
             // When
             result.printReport();
             String output = outputStream.toString();
-            
+
             // Then
             assertTrue(output.contains("Validation Report"));
             assertTrue(output.contains("No validation issues found"));
             assertTrue(output.contains("0 errors, 0 warnings, 0 info messages"));
         }
-        
+
         @Test
         @DisplayName("should print report with messages")
         void shouldPrintReportWithMessages() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .addMessage(errorMessage)
-                .addMessage(warnMessage)
-                .addMessage(infoMessage)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addMessage(errorMessage).addMessage(warnMessage)
+                    .addMessage(infoMessage).build();
+
             // When
             result.printReport();
             String output = outputStream.toString();
-            
+
             // Then
             assertTrue(output.contains("Validation Report"));
             assertTrue(output.contains("test1.adoc"));
@@ -530,74 +453,63 @@ class ValidationResultTest {
             assertTrue(output.contains("Test info message"));
             assertTrue(output.contains("1 errors, 1 warnings, 1 info messages"));
         }
-        
+
         @Test
         @DisplayName("should include timing in report")
         void shouldIncludeTimingInReport() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .startTime(System.currentTimeMillis() - 500)
-                .complete()
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().startTime(System.currentTimeMillis() - 500).complete()
+                    .build();
+
             // When
             result.printReport();
             String output = outputStream.toString();
-            
+
             // Then
             assertTrue(output.contains("Validation completed in"));
             assertTrue(output.contains("ms"));
         }
-        
+
         @org.junit.jupiter.api.AfterEach
         void tearDown() {
             System.setOut(originalOut);
         }
     }
-    
+
     @Nested
     @DisplayName("Scanned Files")
     class ScannedFilesTests {
-        
+
         @Test
         @DisplayName("should return immutable scanned files set")
         void shouldReturnImmutableScannedFilesSet() {
             // Given
-            ValidationResult result = ValidationResult.builder()
-                .addScannedFile("test.adoc")
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addScannedFile("test.adoc").build();
+
             // When/Then
-            assertThrows(UnsupportedOperationException.class, () ->
-                result.getScannedFiles().add("another.adoc"));
+            assertThrows(UnsupportedOperationException.class, () -> result.getScannedFiles().add("another.adoc"));
         }
-        
+
         @Test
         @DisplayName("should handle result with messages and scanned files")
         void shouldHandleResultWithMessagesAndScannedFiles() {
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addScannedFile("file1.adoc")
-                .addScannedFile("file2.adoc")
-                .addMessage(errorMessage)
-                .addMessage(warnMessage)
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addScannedFile("file1.adoc")
+                    .addScannedFile("file2.adoc").addMessage(errorMessage).addMessage(warnMessage).build();
+
             // Then
             assertEquals(2, result.getScannedFileCount());
             assertEquals(2, result.getMessages().size());
             assertTrue(result.getScannedFiles().contains("file1.adoc"));
             assertTrue(result.getScannedFiles().contains("file2.adoc"));
         }
-        
+
         @Test
         @DisplayName("should preserve scanned files without messages")
         void shouldPreserveScannedFilesWithoutMessages() {
             // When
-            ValidationResult result = ValidationResult.builder()
-                .addScannedFile("clean-file.adoc")
-                .build();
-            
+            ValidationResult result = ValidationResult.builder().addScannedFile("clean-file.adoc").build();
+
             // Then
             assertEquals(1, result.getScannedFileCount());
             assertEquals(0, result.getMessages().size());

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/AdmonitionBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/AdmonitionBlockValidatorTest.java
@@ -24,133 +24,117 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("AdmonitionBlockValidator Tests")
 class AdmonitionBlockValidatorTest {
-    
+
     private AdmonitionBlockValidator validator;
     private BlockValidationContext context;
     private StructuralNode mockBlock;
     private Document mockDocument;
-    
+
     @BeforeEach
     void setUp() {
         validator = new AdmonitionBlockValidator();
         context = mock(BlockValidationContext.class);
         mockBlock = mock(StructuralNode.class);
         mockDocument = mock(Document.class);
-        
+
         when(mockBlock.getDocument()).thenReturn(mockDocument);
-        when(context.createLocation(any())).thenReturn(mock(com.dataliquid.asciidoc.linter.validator.SourceLocation.class));
+        when(context.createLocation(any()))
+                .thenReturn(mock(com.dataliquid.asciidoc.linter.validator.SourceLocation.class));
         when(context.getFilename()).thenReturn("test.adoc");
     }
-    
+
     @Test
     @DisplayName("should support ADMONITION block type")
     void shouldSupportAdmonitionBlockType() {
         assertEquals(BlockType.ADMONITION, validator.getSupportedType());
     }
-    
+
     @Nested
     @DisplayName("Title Validation")
     class TitleValidation {
-        
+
         @Test
         @DisplayName("should validate required title")
         void shouldValidateRequiredTitle() {
             // Given
             when(mockBlock.getTitle()).thenReturn(null);
             when(mockBlock.getStyle()).thenReturn("NOTE");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .title(AdmonitionBlock.TitleConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .title(AdmonitionBlock.TitleConfig.builder().required(true).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.title.required", messages.get(0).getRuleId());
         }
-        
+
         @Test
         @DisplayName("should validate title pattern")
         void shouldValidateTitlePattern() {
             // Given
             when(mockBlock.getTitle()).thenReturn("invalid title");
             when(mockBlock.getStyle()).thenReturn("WARNING");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .title(AdmonitionBlock.TitleConfig.builder()
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .title(AdmonitionBlock.TitleConfig.builder().pattern("^[A-Z].*").severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.title.pattern", messages.get(0).getRuleId());
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should validate title length constraints")
         void shouldValidateTitleLength() {
             // Given
             when(mockBlock.getTitle()).thenReturn("Hi");
             when(mockBlock.getStyle()).thenReturn("TIP");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .title(AdmonitionBlock.TitleConfig.builder()
-                    .minLength(3)
-                    .maxLength(50)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .title(AdmonitionBlock.TitleConfig.builder().minLength(3).maxLength(50).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.title.minLength", messages.get(0).getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("Content Validation")
     class ContentValidation {
-        
+
         @Test
         @DisplayName("should validate content min length")
         void shouldValidateContentMinLength() {
             // Given
             when(mockBlock.getContent()).thenReturn("Short");
             when(mockBlock.getStyle()).thenReturn("IMPORTANT");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .minLength(10)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .content(AdmonitionBlock.ContentConfig.builder().minLength(10).severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.content.minLength", messages.get(0).getRuleId());
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should validate content max length")
         void shouldValidateContentMaxLength() {
@@ -158,82 +142,68 @@ class AdmonitionBlockValidatorTest {
             String longContent = "This is a very long content that exceeds the maximum allowed length";
             when(mockBlock.getContent()).thenReturn(longContent);
             when(mockBlock.getStyle()).thenReturn("CAUTION");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .maxLength(50)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .content(AdmonitionBlock.ContentConfig.builder().maxLength(50).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.content.maxLength", messages.get(0).getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("Line Count Validation")
     class LineCountValidation {
-        
+
         @Test
         @DisplayName("should validate minimum lines")
         void shouldValidateMinLines() {
             // Given
             when(mockBlock.getContent()).thenReturn("Single line");
             when(mockBlock.getStyle()).thenReturn("NOTE");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .lines(LineConfig.builder()
-                        .min(2)
-                        .severity(Severity.INFO)
-                        .build())
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .content(AdmonitionBlock.ContentConfig.builder()
+                            .lines(LineConfig.builder().min(2).severity(Severity.INFO).build()).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.content.lines.min", messages.get(0).getRuleId());
             assertEquals(Severity.INFO, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should validate maximum lines")
         void shouldValidateMaxLines() {
             // Given
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2\nLine 3\nLine 4");
             when(mockBlock.getStyle()).thenReturn("TIP");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .lines(LineConfig.builder()
-                        .max(3)
-                        .build())
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .content(AdmonitionBlock.ContentConfig.builder().lines(LineConfig.builder().max(3).build()).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.content.lines.max", messages.get(0).getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("Icon Validation")
     class IconValidation {
-        
+
         @Test
         @DisplayName("should validate icon is required")
         void shouldValidateIconRequired() {
@@ -241,23 +211,18 @@ class AdmonitionBlockValidatorTest {
             when(mockDocument.getAttribute("icons")).thenReturn(null);
             when(mockBlock.getAttribute("icon")).thenReturn(null);
             when(mockBlock.getStyle()).thenReturn("WARNING");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .icon(AdmonitionBlock.IconConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .icon(AdmonitionBlock.IconConfig.builder().required(true).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.icon.required", messages.get(0).getRuleId());
         }
-        
+
         @Test
         @DisplayName("should validate icon pattern")
         void shouldValidateIconPattern() {
@@ -265,65 +230,53 @@ class AdmonitionBlockValidatorTest {
             when(mockDocument.getAttribute("icons")).thenReturn("font");
             when(mockBlock.getAttribute("icon")).thenReturn("invalid-icon");
             when(mockBlock.getStyle()).thenReturn("NOTE");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .icon(AdmonitionBlock.IconConfig.builder()
-                    .pattern("^(info|warning|caution|tip|note)$")
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .icon(AdmonitionBlock.IconConfig.builder().pattern("^(info|warning|caution|tip|note)$").build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.icon.pattern", messages.get(0).getRuleId());
         }
-        
+
         @Test
         @DisplayName("should detect icon from document level")
         void shouldDetectIconFromDocument() {
             // Given
             when(mockDocument.getAttribute("icons")).thenReturn("font");
             when(mockBlock.getStyle()).thenReturn("TIP");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .icon(AdmonitionBlock.IconConfig.builder()
-                    .required(true)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .icon(AdmonitionBlock.IconConfig.builder().required(true).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Type Validation")
     class TypeValidation {
-        
+
         @Test
         @DisplayName("should validate type is required")
         void shouldValidateTypeRequired() {
             // Given
             when(mockBlock.getStyle()).thenReturn(null);
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .type(AdmonitionBlock.TypeConfig.builder()
-                    .required(true)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .type(AdmonitionBlock.TypeConfig.builder().required(true).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.type.required", messages.get(0).getRuleId());
@@ -331,24 +284,22 @@ class AdmonitionBlockValidatorTest {
             assertTrue(messages.get(0).getActualValue().isPresent());
             assertEquals("No type", messages.get(0).getActualValue().get());
         }
-        
+
         @Test
         @DisplayName("should validate allowed types")
         void shouldValidateAllowedTypes() {
             // Given
             when(mockBlock.getStyle()).thenReturn("CUSTOM");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .type(AdmonitionBlock.TypeConfig.builder()
-                    .allowed(List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"))
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .type(AdmonitionBlock.TypeConfig.builder()
+                            .allowed(List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION")).severity(Severity.ERROR)
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.type.allowed", messages.get(0).getRuleId());
@@ -358,206 +309,181 @@ class AdmonitionBlockValidatorTest {
             assertTrue(messages.get(0).getExpectedValue().isPresent());
             assertTrue(messages.get(0).getExpectedValue().get().contains("NOTE"));
         }
-        
+
         @Test
         @DisplayName("should accept valid types")
         void shouldAcceptValidTypes() {
             // Given
             when(mockBlock.getStyle()).thenReturn("NOTE");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .type(AdmonitionBlock.TypeConfig.builder()
-                    .required(true)
-                    .allowed(List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"))
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .type(AdmonitionBlock.TypeConfig.builder().required(true)
+                            .allowed(List.of("NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION")).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Admonition Type Detection")
     class AdmonitionTypeDetection {
-        
+
         @Test
         @DisplayName("should detect admonition type from style")
         void shouldDetectTypeFromStyle() {
             // Given
             when(mockBlock.getStyle()).thenReturn("warning");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR).build();
+
             // When
             validator.validate(mockBlock, config, context);
-            
+
             // Then
             verify(mockBlock).getStyle();
         }
-        
+
         @Test
         @DisplayName("should detect admonition type from role as fallback")
         void shouldDetectTypeFromRole() {
             // Given
             when(mockBlock.getStyle()).thenReturn(null);
             when(mockBlock.getAttribute("role")).thenReturn("caution");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR).build();
+
             // When
             validator.validate(mockBlock, config, context);
-            
+
             // Then
             verify(mockBlock).getAttribute("role");
         }
-        
+
         @Test
         @DisplayName("should convert type to uppercase")
         void shouldConvertTypeToUppercase() {
             // Given
             when(mockBlock.getStyle()).thenReturn("note");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .type(AdmonitionBlock.TypeConfig.builder()
-                    .required(true)
-                    .allowed(List.of("NOTE"))
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .type(AdmonitionBlock.TypeConfig.builder().required(true).allowed(List.of("NOTE")).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then - should accept lowercase "note" as valid "NOTE"
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Severity Override and Fallback")
     class SeverityOverrideTests {
-        
+
         @Test
         @DisplayName("should use nested severity when specified")
         void shouldUseNestedSeverity() {
             // Given
             when(mockBlock.getStyle()).thenReturn("INVALID");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR) // Block-level severity
-                .type(AdmonitionBlock.TypeConfig.builder()
-                    .required(true)
-                    .allowed(List.of("NOTE", "TIP"))
-                    .severity(Severity.WARN) // Nested severity overrides
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR) // Block-level severity
+                    .type(AdmonitionBlock.TypeConfig.builder().required(true).allowed(List.of("NOTE", "TIP"))
+                            .severity(Severity.WARN) // Nested severity overrides
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.WARN, messages.get(0).getSeverity()); // Should use nested severity
         }
-        
+
         @Test
         @DisplayName("should fallback to block severity when nested severity is null")
         void shouldFallbackToBlockSeverity() {
             // Given
             when(mockBlock.getTitle()).thenReturn(null);
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.INFO) // Block-level severity
-                .title(AdmonitionBlock.TitleConfig.builder()
-                    .required(true)
-                    // No severity specified, should fallback
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.INFO) // Block-level severity
+                    .title(AdmonitionBlock.TitleConfig.builder().required(true)
+                            // No severity specified, should fallback
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.INFO, messages.get(0).getSeverity()); // Should use block severity
         }
-        
+
         @Test
         @DisplayName("should handle line severity override with double fallback")
         void shouldHandleLineSeverityWithDoubleFallback() {
             // Given
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2\nLine 3\nLine 4");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR) // Block-level severity
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .severity(Severity.WARN) // Content-level severity
-                    .lines(LineConfig.builder()
-                        .max(3)
-                        .severity(Severity.INFO) // Line-level severity overrides all
-                        .build())
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR) // Block-level severity
+                    .content(AdmonitionBlock.ContentConfig.builder().severity(Severity.WARN) // Content-level severity
+                            .lines(LineConfig.builder().max(3).severity(Severity.INFO) // Line-level severity overrides
+                                                                                       // all
+                                    .build())
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.content.lines.max", messages.get(0).getRuleId());
             assertEquals(Severity.INFO, messages.get(0).getSeverity()); // Should use line severity
         }
-        
+
         @Test
         @DisplayName("should fallback through hierarchy when line severity is null")
         void shouldFallbackThroughHierarchy() {
             // Given
             when(mockBlock.getContent()).thenReturn("Short");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR) // Block-level severity
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .minLength(10)
-                    // No content severity, should fallback to block
-                    .lines(LineConfig.builder()
-                        .min(2)
-                        // No line severity, should fallback to content, then block
-                        .build())
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR) // Block-level severity
+                    .content(AdmonitionBlock.ContentConfig.builder().minLength(10)
+                            // No content severity, should fallback to block
+                            .lines(LineConfig.builder().min(2)
+                                    // No line severity, should fallback to content, then block
+                                    .build())
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(2, messages.size());
             // Content validation should use block severity
             ValidationMessage contentMsg = messages.stream()
-                .filter(m -> m.getRuleId().equals("admonition.content.minLength"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("admonition.content.minLength")).findFirst().orElseThrow();
             assertEquals(Severity.ERROR, contentMsg.getSeverity());
-            
+
             // Line validation should also fallback to block severity
             ValidationMessage lineMsg = messages.stream()
-                .filter(m -> m.getRuleId().equals("admonition.content.lines.min"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("admonition.content.lines.min")).findFirst().orElseThrow();
             assertEquals(Severity.ERROR, lineMsg.getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Edge Cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should handle null content")
         void shouldHandleNullContent() {
@@ -565,35 +491,29 @@ class AdmonitionBlockValidatorTest {
             when(mockBlock.getContent()).thenReturn(null);
             when(mockBlock.getBlocks()).thenReturn(null);
             when(mockBlock.getStyle()).thenReturn("IMPORTANT");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .content(AdmonitionBlock.ContentConfig.builder()
-                    .minLength(10)
-                    .build())
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR)
+                    .content(AdmonitionBlock.ContentConfig.builder().minLength(10).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("admonition.content.minLength", messages.get(0).getRuleId());
         }
-        
+
         @Test
         @DisplayName("should handle empty configuration")
         void shouldHandleEmptyConfiguration() {
             // Given
             when(mockBlock.getStyle()).thenReturn("NOTE");
-            
-            AdmonitionBlock config = AdmonitionBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            AdmonitionBlock config = AdmonitionBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/AudioBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/AudioBlockValidatorTest.java
@@ -23,35 +23,40 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
  * Unit tests for {@link AudioBlockValidator}.
- * 
- * <p>This test class validates the behavior of the audio block validator,
- * which processes audio elements in AsciiDoc documents. The tests cover
- * validation rules for audio URLs, playback options, and titles.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the audio block validator, which processes audio elements in AsciiDoc
+ * documents. The tests cover validation rules for audio URLs, playback options, and titles.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality and type checking</li>
- *   <li>UrlValidation - URL requirements and pattern matching with severity support</li>
- *   <li>OptionsValidation - Autoplay, controls, and loop option constraints</li>
- *   <li>TitleValidation - Title requirements and length constraints</li>
- *   <li>SeverityHierarchy - Nested severity support for all configurations</li>
- *   <li>ComplexScenarios - Combined validation scenarios</li>
+ * <li>Validate - Basic validator functionality and type checking</li>
+ * <li>UrlValidation - URL requirements and pattern matching with severity support</li>
+ * <li>OptionsValidation - Autoplay, controls, and loop option constraints</li>
+ * <li>TitleValidation - Title requirements and length constraints</li>
+ * <li>SeverityHierarchy - Nested severity support for all configurations</li>
+ * <li>ComplexScenarios - Combined validation scenarios</li>
  * </ul>
- * 
- * <p>Note: AudioBlock supports individual severity levels for all nested rules.
- * If not specified, they fall back to the block-level severity.</p>
- * 
+ *
+ * <p>
+ * Note: AudioBlock supports individual severity levels for all nested rules. If not specified, they fall back to the
+ * block-level severity.
+ * </p>
+ *
  * @see AudioBlockValidator
  * @see AudioBlock
  */
 @DisplayName("AudioBlockValidator")
 class AudioBlockValidatorTest {
-    
+
     private AudioBlockValidator validator;
     private BlockValidationContext context;
     private Block mockBlock;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new AudioBlockValidator();
@@ -59,76 +64,67 @@ class AudioBlockValidatorTest {
         context = new BlockValidationContext(mockSection, "test.adoc");
         mockBlock = mock(Block.class);
     }
-    
+
     @Test
     @DisplayName("should return AUDIO as supported type")
     void shouldReturnAudioAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.AUDIO, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when block is not Audio instance")
         void shouldReturnEmptyListWhenNotAudioInstance() {
             // Given
             StructuralNode notAnAudio = mock(StructuralNode.class);
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            AudioBlock config = AudioBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notAnAudio, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            AudioBlock config = AudioBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("UrlValidation")
     class UrlValidation {
-        
+
         @Test
         @DisplayName("should validate required URL")
         void shouldValidateRequiredUrl() {
             // Given
-            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder()
-                .required(true)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.ERROR)
-                .url(urlConfig)
-                .build();
-            
+            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder().required(true).build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.ERROR).url(urlConfig).build();
+
             when(mockBlock.getAttribute("target")).thenReturn(null);
             when(mockBlock.getContent()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -138,27 +134,21 @@ class AudioBlockValidatorTest {
             assertTrue(message.getActualValue().isEmpty());
             assertTrue(message.getExpectedValue().isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate URL pattern")
         void shouldValidateUrlPattern() {
             // Given
             Pattern pattern = Pattern.compile("^(https?://|\\./|/).*\\.(mp3|ogg|wav|m4a)$");
-            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder()
-                .required(true)
-                .pattern(pattern)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.WARN)
-                .url(urlConfig)
-                .build();
-            
+            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder().required(true).pattern(pattern).build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.WARN).url(urlConfig).build();
+
             when(mockBlock.getAttribute("target")).thenReturn("http://example.com/audio.txt");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -167,59 +157,48 @@ class AudioBlockValidatorTest {
             assertEquals("Audio URL does not match required pattern", message.getMessage());
             assertEquals("http://example.com/audio.txt", message.getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use URL-specific severity when configured")
         void shouldUseUrlSpecificSeverity() {
             // Given
-            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.INFO)
-                .url(urlConfig)
-                .build();
-            
+            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder().required(true).severity(Severity.ERROR)
+                    .build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.INFO).url(urlConfig).build();
+
             when(mockBlock.getAttribute("target")).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.ERROR, messages.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("OptionsValidation")
     class OptionsValidation {
-        
+
         @Test
         @DisplayName("should validate autoplay not allowed")
         void shouldValidateAutoplayNotAllowed() {
             // Given
-            AudioBlock.AutoplayConfig autoplayConfig = AudioBlock.AutoplayConfig.builder()
-                .allowed(false)
-                .severity(Severity.ERROR)
-                .build();
-            
-            AudioBlock.OptionsConfig optionsConfig = AudioBlock.OptionsConfig.builder()
-                .autoplay(autoplayConfig)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.INFO)
-                .options(optionsConfig)
-                .build();
-            
+            AudioBlock.AutoplayConfig autoplayConfig = AudioBlock.AutoplayConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock.OptionsConfig optionsConfig = AudioBlock.OptionsConfig.builder().autoplay(autoplayConfig)
+                    .build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.INFO).options(optionsConfig).build();
+
             when(mockBlock.getAttribute("opts")).thenReturn("autoplay");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -227,29 +206,23 @@ class AudioBlockValidatorTest {
             assertEquals("audio.options.autoplay.notAllowed", message.getRuleId());
             assertEquals("Audio autoplay is not allowed", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate controls required")
         void shouldValidateControlsRequired() {
             // Given
-            AudioBlock.ControlsConfig controlsConfig = AudioBlock.ControlsConfig.builder()
-                .required(true)
-                .build();
-            
-            AudioBlock.OptionsConfig optionsConfig = AudioBlock.OptionsConfig.builder()
-                .controls(controlsConfig)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.WARN)
-                .options(optionsConfig)
-                .build();
-            
+            AudioBlock.ControlsConfig controlsConfig = AudioBlock.ControlsConfig.builder().required(true).build();
+
+            AudioBlock.OptionsConfig optionsConfig = AudioBlock.OptionsConfig.builder().controls(controlsConfig)
+                    .build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.WARN).options(optionsConfig).build();
+
             when(mockBlock.getAttribute("opts")).thenReturn("nocontrols");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -257,59 +230,47 @@ class AudioBlockValidatorTest {
             assertEquals("audio.options.controls.required", message.getRuleId());
             assertEquals("Audio controls are required but not enabled", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate loop allowed")
         void shouldValidateLoopAllowed() {
             // Given
-            AudioBlock.LoopConfig loopConfig = AudioBlock.LoopConfig.builder()
-                .allowed(true)
-                .severity(Severity.INFO)
-                .build();
-            
-            AudioBlock.OptionsConfig optionsConfig = AudioBlock.OptionsConfig.builder()
-                .loop(loopConfig)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.ERROR)
-                .options(optionsConfig)
-                .build();
-            
+            AudioBlock.LoopConfig loopConfig = AudioBlock.LoopConfig.builder().allowed(true).severity(Severity.INFO)
+                    .build();
+
+            AudioBlock.OptionsConfig optionsConfig = AudioBlock.OptionsConfig.builder().loop(loopConfig).build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.ERROR).options(optionsConfig).build();
+
             when(mockBlock.getAttribute("opts")).thenReturn("loop");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("TitleValidation")
     class TitleValidation {
-        
+
         @Test
         @DisplayName("should validate required title")
         void shouldValidateRequiredTitle() {
             // Given
-            AudioBlock.TitleConfig titleConfig = AudioBlock.TitleConfig.builder()
-                .required(true)
-                .severity(Severity.WARN)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.ERROR)
-                .title(titleConfig)
-                .build();
-            
+            AudioBlock.TitleConfig titleConfig = AudioBlock.TitleConfig.builder().required(true).severity(Severity.WARN)
+                    .build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.ERROR).title(titleConfig).build();
+
             when(mockBlock.getTitle()).thenReturn(null);
             when(mockBlock.getAttribute("caption")).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -317,27 +278,21 @@ class AudioBlockValidatorTest {
             assertEquals("audio.title.required", message.getRuleId());
             assertEquals("Audio title is required but not provided", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate title length constraints")
         void shouldValidateTitleLengthConstraints() {
             // Given
-            AudioBlock.TitleConfig titleConfig = AudioBlock.TitleConfig.builder()
-                .required(true)
-                .minLength(10)
-                .maxLength(100)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.INFO)
-                .title(titleConfig)
-                .build();
-            
+            AudioBlock.TitleConfig titleConfig = AudioBlock.TitleConfig.builder().required(true).minLength(10)
+                    .maxLength(100).build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.INFO).title(titleConfig).build();
+
             when(mockBlock.getTitle()).thenReturn("Short");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -348,120 +303,95 @@ class AudioBlockValidatorTest {
             assertEquals("At least 10 characters", message.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("SeverityHierarchy")
     class SeverityHierarchy {
-        
+
         @Test
         @DisplayName("should use block severity when nested severity not specified")
         void shouldUseBlockSeverityWhenNestedSeverityNotSpecified() {
             // Given
-            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder()
-                .required(true)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.WARN)
-                .url(urlConfig)
-                .build();
-            
+            AudioBlock.UrlConfig urlConfig = AudioBlock.UrlConfig.builder().required(true).build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.WARN).url(urlConfig).build();
+
             when(mockBlock.getAttribute("target")).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should prefer nested severity over block severity")
         void shouldPreferNestedSeverityOverBlockSeverity() {
             // Given
-            AudioBlock.TitleConfig titleConfig = AudioBlock.TitleConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.INFO)
-                .title(titleConfig)
-                .build();
-            
+            AudioBlock.TitleConfig titleConfig = AudioBlock.TitleConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            AudioBlock config = AudioBlock.builder().severity(Severity.INFO).title(titleConfig).build();
+
             when(mockBlock.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.ERROR, messages.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("ComplexScenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate all configured rules")
         void shouldValidateAllConfiguredRules() {
             // Given
-            AudioBlock config = AudioBlock.builder()
-                .severity(Severity.INFO)
-                .url(AudioBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern("^https?://.*\\.mp3$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .options(AudioBlock.OptionsConfig.builder()
-                    .autoplay(AudioBlock.AutoplayConfig.builder()
-                        .allowed(false)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .controls(AudioBlock.ControlsConfig.builder()
-                        .required(true)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build())
-                .title(AudioBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+            AudioBlock config = AudioBlock.builder().severity(Severity.INFO)
+                    .url(AudioBlock.UrlConfig.builder().required(true).pattern("^https?://.*\\.mp3$")
+                            .severity(Severity.ERROR).build())
+                    .options(AudioBlock.OptionsConfig.builder()
+                            .autoplay(
+                                    AudioBlock.AutoplayConfig.builder().allowed(false).severity(Severity.ERROR).build())
+                            .controls(
+                                    AudioBlock.ControlsConfig.builder().required(true).severity(Severity.ERROR).build())
+                            .build())
+                    .title(AudioBlock.TitleConfig.builder().required(true).minLength(10).severity(Severity.WARN)
+                            .build())
+                    .build();
+
             when(mockBlock.getAttribute("target")).thenReturn("file://audio.wav");
             when(mockBlock.getAttribute("opts")).thenReturn("autoplay,nocontrols");
             when(mockBlock.getTitle()).thenReturn("Short");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(4, messages.size());
-            
+
             // URL pattern validation
-            assertTrue(messages.stream().anyMatch(m -> 
-                "audio.url.pattern".equals(m.getRuleId()) && 
-                Severity.ERROR.equals(m.getSeverity())));
-            
+            assertTrue(messages.stream().anyMatch(
+                    m -> "audio.url.pattern".equals(m.getRuleId()) && Severity.ERROR.equals(m.getSeverity())));
+
             // Autoplay not allowed
-            assertTrue(messages.stream().anyMatch(m -> 
-                "audio.options.autoplay.notAllowed".equals(m.getRuleId()) && 
-                Severity.ERROR.equals(m.getSeverity())));
-            
+            assertTrue(messages.stream().anyMatch(m -> "audio.options.autoplay.notAllowed".equals(m.getRuleId())
+                    && Severity.ERROR.equals(m.getSeverity())));
+
             // Controls required
-            assertTrue(messages.stream().anyMatch(m -> 
-                "audio.options.controls.required".equals(m.getRuleId()) && 
-                Severity.ERROR.equals(m.getSeverity())));
-            
+            assertTrue(messages.stream().anyMatch(m -> "audio.options.controls.required".equals(m.getRuleId())
+                    && Severity.ERROR.equals(m.getSeverity())));
+
             // Title too short
-            assertTrue(messages.stream().anyMatch(m -> 
-                "audio.title.minLength".equals(m.getRuleId()) && 
-                Severity.WARN.equals(m.getSeverity())));
+            assertTrue(messages.stream().anyMatch(
+                    m -> "audio.title.minLength".equals(m.getRuleId()) && Severity.WARN.equals(m.getSeverity())));
         }
     }
 }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockOccurrenceValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockOccurrenceValidatorTest.java
@@ -26,98 +26,88 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("BlockOccurrenceValidator")
 class BlockOccurrenceValidatorTest {
-    
+
     private BlockOccurrenceValidator validator;
     private BlockValidationContext context;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new BlockOccurrenceValidator();
         mockSection = mock(Section.class);
         context = new BlockValidationContext(mockSection, "test.adoc");
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when no blocks configured")
         void shouldReturnEmptyListWhenNoBlocksConfigured() {
             // Given
             List<Block> blocks = new ArrayList<>();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no occurrence rules configured")
         void shouldReturnEmptyListWhenNoOccurrenceRulesConfigured() {
             // Given
-            ParagraphBlock block = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
+            ParagraphBlock block = ParagraphBlock.builder().severity(Severity.ERROR).build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should throw when context is null")
         void shouldThrowWhenContextIsNull() {
             // Given
             List<Block> blocks = new ArrayList<>();
-            
+
             // When/Then
-            assertThrows(NullPointerException.class, () -> 
-                validator.validate(null, blocks));
+            assertThrows(NullPointerException.class, () -> validator.validate(null, blocks));
         }
-        
+
         @Test
         @DisplayName("should throw when blocks is null")
         void shouldThrowWhenBlocksIsNull() {
             // Given/When/Then
-            assertThrows(NullPointerException.class, () -> 
-                validator.validate(context, null));
+            assertThrows(NullPointerException.class, () -> validator.validate(context, null));
         }
     }
-    
+
     @Nested
     @DisplayName("minimum occurrence validation")
     class MinimumOccurrenceValidation {
-        
+
         @Test
         @DisplayName("should validate minimum occurrences not met")
         void shouldValidateMinimumOccurrencesNotMet() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(2)
-                .max(5)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .name("introduction")
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(2).max(5).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().name("introduction").occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Add only one occurrence to context
             StructuralNode node = mock(StructuralNode.class);
             context.trackBlock(block, node);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -127,57 +117,45 @@ class BlockOccurrenceValidatorTest {
             assertEquals("1", msg.getActualValue().orElse(null));
             assertEquals("At least 2 occurrences", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate minimum occurrences met")
         void shouldValidateMinimumOccurrencesMet() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(2)
-                .max(5)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .name("introduction")
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(2).max(5).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().name("introduction").occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Add two occurrences to context
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
             context.trackBlock(block, node1);
             context.trackBlock(block, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate zero occurrences when minimum required")
         void shouldValidateZeroOccurrencesWhenMinimumRequired() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(1)
-                .max(3)
-                .severity(Severity.WARN)
-                .build();
-            TableBlock block = TableBlock.builder()
-                .name("summary")
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(1).max(3).severity(Severity.WARN)
+                    .build();
+            TableBlock block = TableBlock.builder().name("summary").occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // No blocks tracked in context
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -186,27 +164,21 @@ class BlockOccurrenceValidatorTest {
             assertEquals("At least 1 occurrences", msg.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("maximum occurrence validation")
     class MaximumOccurrenceValidation {
-        
+
         @Test
         @DisplayName("should validate maximum occurrences exceeded")
         void shouldValidateMaximumOccurrencesExceeded() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(1)
-                .max(2)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .name("note")
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(1).max(2).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().name("note").occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Add three occurrences to context
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
@@ -214,10 +186,10 @@ class BlockOccurrenceValidatorTest {
             context.trackBlock(block, node1);
             context.trackBlock(block, node2);
             context.trackBlock(block, node3);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -227,22 +199,17 @@ class BlockOccurrenceValidatorTest {
             assertEquals("3", msg.getActualValue().orElse(null));
             assertEquals("At most 2 occurrences", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate maximum occurrences not exceeded")
         void shouldValidateMaximumOccurrencesNotExceeded() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(0)
-                .max(3)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(0).max(3).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().occurrence(occurrenceConfig).severity(Severity.ERROR)
+                    .build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Add three occurrences to context (exactly at max)
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
@@ -250,101 +217,79 @@ class BlockOccurrenceValidatorTest {
             context.trackBlock(block, node1);
             context.trackBlock(block, node2);
             context.trackBlock(block, node3);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("multiple blocks validation")
     class MultipleBlocksValidation {
-        
+
         @Test
         @DisplayName("should validate multiple blocks with different occurrence rules")
         void shouldValidateMultipleBlocksWithDifferentOccurrenceRules() {
             // Given
-            OccurrenceConfig paragraphOccurrence = OccurrenceConfig.builder()
-                .min(1)
-                .max(3)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock paragraphBlock = ParagraphBlock.builder()
-                .name("intro")
-                .occurrence(paragraphOccurrence)
-                .severity(Severity.ERROR)
-                .build();
-            
-            OccurrenceConfig tableOccurrence = OccurrenceConfig.builder()
-                .min(2)
-                .max(2)
-                .severity(Severity.WARN)
-                .build();
-            TableBlock tableBlock = TableBlock.builder()
-                .name("data")
-                .occurrence(tableOccurrence)
-                .severity(Severity.ERROR)
-                .build();
-            
+            OccurrenceConfig paragraphOccurrence = OccurrenceConfig.builder().min(1).max(3).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock paragraphBlock = ParagraphBlock.builder().name("intro").occurrence(paragraphOccurrence)
+                    .severity(Severity.ERROR).build();
+
+            OccurrenceConfig tableOccurrence = OccurrenceConfig.builder().min(2).max(2).severity(Severity.WARN).build();
+            TableBlock tableBlock = TableBlock.builder().name("data").occurrence(tableOccurrence)
+                    .severity(Severity.ERROR).build();
+
             List<Block> blocks = Arrays.asList(paragraphBlock, tableBlock);
-            
+
             // Add no paragraph blocks (violates min)
             // Add one table block (violates min)
             StructuralNode tableNode = mock(StructuralNode.class);
             context.trackBlock(tableBlock, tableNode);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertEquals(2, messages.size());
-            
+
             // Check paragraph violation
-            ValidationMessage paragraphMsg = messages.stream()
-                .filter(m -> m.getMessage().contains("paragraph"))
-                .findFirst()
-                .orElse(null);
+            ValidationMessage paragraphMsg = messages.stream().filter(m -> m.getMessage().contains("paragraph"))
+                    .findFirst().orElse(null);
             assertNotNull(paragraphMsg);
             assertEquals(Severity.ERROR, paragraphMsg.getSeverity());
             assertEquals("0", paragraphMsg.getActualValue().orElse(null));
-            
+
             // Check table violation
-            ValidationMessage tableMsg = messages.stream()
-                .filter(m -> m.getMessage().contains("table"))
-                .findFirst()
-                .orElse(null);
+            ValidationMessage tableMsg = messages.stream().filter(m -> m.getMessage().contains("table")).findFirst()
+                    .orElse(null);
             assertNotNull(tableMsg);
             assertEquals(Severity.WARN, tableMsg.getSeverity());
             assertEquals("1", tableMsg.getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle blocks without names using type")
         void shouldHandleBlocksWithoutNamesUsingType() {
             // Given
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(1)
-                .max(1)
-                .severity(Severity.INFO)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(1).max(1).severity(Severity.INFO)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().occurrence(occurrenceConfig).severity(Severity.ERROR)
+                    .build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Add two occurrences (violates max)
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
             context.trackBlock(block, node1);
             context.trackBlock(block, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -352,27 +297,21 @@ class BlockOccurrenceValidatorTest {
             assertTrue(msg.getMessage().contains("paragraph")); // Uses type name
         }
     }
-    
+
     @Nested
     @DisplayName("edge cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should handle exact occurrence count")
         void shouldHandleExactOccurrenceCount() {
             // Given - exactly 3 occurrences required
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(3)
-                .max(3)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .name("section")
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(3).max(3).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().name("section").occurrence(occurrenceConfig)
+                    .severity(Severity.ERROR).build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Test with exactly 3 occurrences
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
@@ -380,38 +319,33 @@ class BlockOccurrenceValidatorTest {
             context.trackBlock(block, node1);
             context.trackBlock(block, node2);
             context.trackBlock(block, node3);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate when both min and max violations occur")
         void shouldValidateWhenBothMinAndMaxViolationsOccur() {
             // Given - impossible constraint (min > max)
-            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder()
-                .min(5)
-                .max(3)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock block = ParagraphBlock.builder()
-                .occurrence(occurrenceConfig)
-                .severity(Severity.ERROR)
-                .build();
+            OccurrenceConfig occurrenceConfig = OccurrenceConfig.builder().min(5).max(3).severity(Severity.ERROR)
+                    .build();
+            ParagraphBlock block = ParagraphBlock.builder().occurrence(occurrenceConfig).severity(Severity.ERROR)
+                    .build();
             List<Block> blocks = Arrays.asList(block);
-            
+
             // Add 4 occurrences
             for (int i = 0; i < 4; i++) {
                 StructuralNode node = mock(StructuralNode.class);
                 context.trackBlock(block, node);
             }
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
-            
+
             // Then
             assertEquals(2, messages.size()); // Both min and max violations
             assertTrue(messages.stream().anyMatch(m -> m.getRuleId().equals("block.occurrence.min")));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockOrderValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockOrderValidatorTest.java
@@ -23,133 +23,110 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("BlockOrderValidator")
 class BlockOrderValidatorTest {
-    
+
     private BlockOrderValidator validator;
     private BlockValidationContext context;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new BlockOrderValidator();
         mockSection = mock(Section.class);
         context = new BlockValidationContext(mockSection, "test.adoc");
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when context is null")
         void shouldReturnEmptyListWhenContextIsNull() {
             // Given
-            OrderConfig orderConfig = OrderConfig.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig orderConfig = OrderConfig.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(null, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when order config is null")
         void shouldReturnEmptyListWhenOrderConfigIsNull() {
             // Given/When
             List<ValidationMessage> messages = validator.validate(context, null);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no order rules configured")
         void shouldReturnEmptyListWhenNoOrderRulesConfigured() {
             // Given
-            OrderConfig orderConfig = OrderConfig.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig orderConfig = OrderConfig.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("fixed order validation")
     class FixedOrderValidation {
-        
+
         @Test
         @DisplayName("should validate correct fixed order")
         void shouldValidateCorrectFixedOrder() {
             // Given
-            OrderConfig orderConfig = OrderConfig.builder()
-                .fixedOrder(Arrays.asList("intro", "content", "summary"))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig orderConfig = OrderConfig.builder().fixedOrder(Arrays.asList("intro", "content", "summary"))
+                    .severity(Severity.ERROR).build();
+
             // Add blocks in correct order
-            ParagraphBlock introBlock = ParagraphBlock.builder()
-                .name("intro")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock contentBlock = ParagraphBlock.builder()
-                .name("content")
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock summaryBlock = TableBlock.builder()
-                .name("summary")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock introBlock = ParagraphBlock.builder().name("intro").severity(Severity.ERROR).build();
+            ParagraphBlock contentBlock = ParagraphBlock.builder().name("content").severity(Severity.ERROR).build();
+            TableBlock summaryBlock = TableBlock.builder().name("summary").severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
             StructuralNode node3 = mock(StructuralNode.class);
-            
+
             context.trackBlock(introBlock, node1);
             context.trackBlock(contentBlock, node2);
             context.trackBlock(summaryBlock, node3);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate incorrect fixed order")
         void shouldValidateIncorrectFixedOrder() {
             // Given
-            OrderConfig orderConfig = OrderConfig.builder()
-                .fixedOrder(Arrays.asList("intro", "content", "summary"))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig orderConfig = OrderConfig.builder().fixedOrder(Arrays.asList("intro", "content", "summary"))
+                    .severity(Severity.ERROR).build();
+
             // Add blocks in wrong order (content before intro)
-            ParagraphBlock introBlock = ParagraphBlock.builder()
-                .name("intro")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock contentBlock = ParagraphBlock.builder()
-                .name("content")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock introBlock = ParagraphBlock.builder().name("intro").severity(Severity.ERROR).build();
+            ParagraphBlock contentBlock = ParagraphBlock.builder().name("content").severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
-            
+
             context.trackBlock(contentBlock, node1); // Wrong: content first
-            context.trackBlock(introBlock, node2);   // Wrong: intro second
-            
+            context.trackBlock(introBlock, node2); // Wrong: intro second
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -159,114 +136,89 @@ class BlockOrderValidatorTest {
             assertEquals("Position 2", msg.getActualValue().orElse(null));
             assertEquals("Should appear after 'content'", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle partial fixed order")
         void shouldHandlePartialFixedOrder() {
             // Given
-            OrderConfig orderConfig = OrderConfig.builder()
-                .fixedOrder(Arrays.asList("header", "content"))
-                .severity(Severity.WARN)
-                .build();
-            
+            OrderConfig orderConfig = OrderConfig.builder().fixedOrder(Arrays.asList("header", "content"))
+                    .severity(Severity.WARN).build();
+
             // Add blocks including some not in fixed order
-            ParagraphBlock headerBlock = ParagraphBlock.builder()
-                .name("header")
-                .severity(Severity.ERROR)
-                .build();
-            ImageBlock imageBlock = ImageBlock.builder()
-                .name("diagram")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock contentBlock = ParagraphBlock.builder()
-                .name("content")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock headerBlock = ParagraphBlock.builder().name("header").severity(Severity.ERROR).build();
+            ImageBlock imageBlock = ImageBlock.builder().name("diagram").severity(Severity.ERROR).build();
+            ParagraphBlock contentBlock = ParagraphBlock.builder().name("content").severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
             StructuralNode node3 = mock(StructuralNode.class);
-            
+
             context.trackBlock(headerBlock, node1);
-            context.trackBlock(imageBlock, node2);   // Not in fixed order - OK
+            context.trackBlock(imageBlock, node2); // Not in fixed order - OK
             context.trackBlock(contentBlock, node3);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // Image block doesn't affect order
         }
     }
-    
+
     @Nested
     @DisplayName("before constraint validation")
     class BeforeConstraintValidation {
-        
+
         @Test
         @DisplayName("should validate satisfied before constraint")
         void shouldValidateSatisfiedBeforeConstraint() {
             // Given
-            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(
-                "introduction", "conclusion", Severity.ERROR);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .before(Arrays.asList(constraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of("introduction", "conclusion",
+                    Severity.ERROR);
+            OrderConfig orderConfig = OrderConfig.builder().before(Arrays.asList(constraint)).severity(Severity.ERROR)
+                    .build();
+
             // Add blocks in correct order
-            ParagraphBlock introBlock = ParagraphBlock.builder()
-                .name("introduction")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock conclusionBlock = ParagraphBlock.builder()
-                .name("conclusion")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock introBlock = ParagraphBlock.builder().name("introduction").severity(Severity.ERROR).build();
+            ParagraphBlock conclusionBlock = ParagraphBlock.builder().name("conclusion").severity(Severity.ERROR)
+                    .build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
-            
+
             context.trackBlock(introBlock, node1);
             context.trackBlock(conclusionBlock, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate violated before constraint")
         void shouldValidateViolatedBeforeConstraint() {
             // Given
-            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(
-                "introduction", "conclusion", Severity.ERROR);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .before(Arrays.asList(constraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of("introduction", "conclusion",
+                    Severity.ERROR);
+            OrderConfig orderConfig = OrderConfig.builder().before(Arrays.asList(constraint)).severity(Severity.ERROR)
+                    .build();
+
             // Add blocks in wrong order
-            ParagraphBlock introBlock = ParagraphBlock.builder()
-                .name("introduction")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock conclusionBlock = ParagraphBlock.builder()
-                .name("conclusion")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock introBlock = ParagraphBlock.builder().name("introduction").severity(Severity.ERROR).build();
+            ParagraphBlock conclusionBlock = ParagraphBlock.builder().name("conclusion").severity(Severity.ERROR)
+                    .build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
-            
-            context.trackBlock(conclusionBlock, node1);  // Wrong order
+
+            context.trackBlock(conclusionBlock, node1); // Wrong order
             context.trackBlock(introBlock, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -276,103 +228,81 @@ class BlockOrderValidatorTest {
             assertEquals("'introduction' at position 2, 'conclusion' at position 1", msg.getActualValue().orElse(null));
             assertEquals("'introduction' before 'conclusion'", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle missing blocks in before constraint")
         void shouldHandleMissingBlocksInBeforeConstraint() {
             // Given
-            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(
-                "introduction", "conclusion", Severity.WARN);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .before(Arrays.asList(constraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of("introduction", "conclusion",
+                    Severity.WARN);
+            OrderConfig orderConfig = OrderConfig.builder().before(Arrays.asList(constraint)).severity(Severity.ERROR)
+                    .build();
+
             // Add only one of the blocks
-            ParagraphBlock introBlock = ParagraphBlock.builder()
-                .name("introduction")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock introBlock = ParagraphBlock.builder().name("introduction").severity(Severity.ERROR).build();
+
             StructuralNode node = mock(StructuralNode.class);
             context.trackBlock(introBlock, node);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // Constraint not applicable if one block missing
         }
     }
-    
+
     @Nested
     @DisplayName("after constraint validation")
     class AfterConstraintValidation {
-        
+
         @Test
         @DisplayName("should validate satisfied after constraint")
         void shouldValidateSatisfiedAfterConstraint() {
             // Given
-            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(
-                "summary", "header", Severity.ERROR);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .after(Arrays.asList(constraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of("summary", "header",
+                    Severity.ERROR);
+            OrderConfig orderConfig = OrderConfig.builder().after(Arrays.asList(constraint)).severity(Severity.ERROR)
+                    .build();
+
             // Add blocks in correct order (summary after header)
-            ParagraphBlock headerBlock = ParagraphBlock.builder()
-                .name("header")
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock summaryBlock = TableBlock.builder()
-                .name("summary")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock headerBlock = ParagraphBlock.builder().name("header").severity(Severity.ERROR).build();
+            TableBlock summaryBlock = TableBlock.builder().name("summary").severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
-            
+
             context.trackBlock(headerBlock, node1);
             context.trackBlock(summaryBlock, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate violated after constraint")
         void shouldValidateViolatedAfterConstraint() {
             // Given
-            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(
-                "summary", "header", Severity.INFO);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .after(Arrays.asList(constraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of("summary", "header", Severity.INFO);
+            OrderConfig orderConfig = OrderConfig.builder().after(Arrays.asList(constraint)).severity(Severity.ERROR)
+                    .build();
+
             // Add blocks in wrong order (summary before header)
-            ParagraphBlock headerBlock = ParagraphBlock.builder()
-                .name("header")
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock summaryBlock = TableBlock.builder()
-                .name("summary")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock headerBlock = ParagraphBlock.builder().name("header").severity(Severity.ERROR).build();
+            TableBlock summaryBlock = TableBlock.builder().name("summary").severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
-            
-            context.trackBlock(summaryBlock, node1);  // Wrong order
+
+            context.trackBlock(summaryBlock, node1); // Wrong order
             context.trackBlock(headerBlock, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -381,87 +311,69 @@ class BlockOrderValidatorTest {
             assertEquals("Block 'summary' must appear after 'header'", msg.getMessage());
         }
     }
-    
+
     @Nested
     @DisplayName("complex order scenarios")
     class ComplexOrderScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple constraints together")
         void shouldValidateMultipleConstraintsTogether() {
             // Given
-            OrderConfig.OrderConstraint beforeConstraint = OrderConfig.OrderConstraint.of(
-                "header", "footer", Severity.ERROR);
-            OrderConfig.OrderConstraint afterConstraint = OrderConfig.OrderConstraint.of(
-                "content", "header", Severity.WARN);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .fixedOrder(Arrays.asList("header", "content"))
-                .before(Arrays.asList(beforeConstraint))
-                .after(Arrays.asList(afterConstraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint beforeConstraint = OrderConfig.OrderConstraint.of("header", "footer",
+                    Severity.ERROR);
+            OrderConfig.OrderConstraint afterConstraint = OrderConfig.OrderConstraint.of("content", "header",
+                    Severity.WARN);
+            OrderConfig orderConfig = OrderConfig.builder().fixedOrder(Arrays.asList("header", "content"))
+                    .before(Arrays.asList(beforeConstraint)).after(Arrays.asList(afterConstraint))
+                    .severity(Severity.ERROR).build();
+
             // Add blocks violating multiple constraints
-            ParagraphBlock headerBlock = ParagraphBlock.builder()
-                .name("header")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock contentBlock = ParagraphBlock.builder()
-                .name("content")
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock footerBlock = ParagraphBlock.builder()
-                .name("footer")
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock headerBlock = ParagraphBlock.builder().name("header").severity(Severity.ERROR).build();
+            ParagraphBlock contentBlock = ParagraphBlock.builder().name("content").severity(Severity.ERROR).build();
+            ParagraphBlock footerBlock = ParagraphBlock.builder().name("footer").severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
             StructuralNode node3 = mock(StructuralNode.class);
-            
+
             // Wrong order: footer, content, header
             context.trackBlock(footerBlock, node1);
             context.trackBlock(contentBlock, node2);
             context.trackBlock(headerBlock, node3);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertTrue(messages.size() >= 2); // Multiple violations
             assertTrue(messages.stream().anyMatch(m -> m.getRuleId().equals("block.order.fixed")));
             assertTrue(messages.stream().anyMatch(m -> m.getRuleId().equals("block.order.before")));
         }
-        
+
         @Test
         @DisplayName("should use block type when name is not available")
         void shouldUseBlockTypeWhenNameIsNotAvailable() {
             // Given
-            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of(
-                "paragraph", "table", Severity.ERROR);
-            OrderConfig orderConfig = OrderConfig.builder()
-                .before(Arrays.asList(constraint))
-                .severity(Severity.ERROR)
-                .build();
-            
+            OrderConfig.OrderConstraint constraint = OrderConfig.OrderConstraint.of("paragraph", "table",
+                    Severity.ERROR);
+            OrderConfig orderConfig = OrderConfig.builder().before(Arrays.asList(constraint)).severity(Severity.ERROR)
+                    .build();
+
             // Add blocks without names (uses type)
-            ParagraphBlock paragraphBlock = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock tableBlock = TableBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            ParagraphBlock paragraphBlock = ParagraphBlock.builder().severity(Severity.ERROR).build();
+            TableBlock tableBlock = TableBlock.builder().severity(Severity.ERROR).build();
+
             StructuralNode node1 = mock(StructuralNode.class);
             StructuralNode node2 = mock(StructuralNode.class);
-            
+
             // Wrong order
             context.trackBlock(tableBlock, node1);
             context.trackBlock(paragraphBlock, node2);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(context, orderConfig);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.get(0).getMessage().contains("paragraph"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetectorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockTypeDetectorTest.java
@@ -17,220 +17,220 @@ import com.dataliquid.asciidoc.linter.config.blocks.BlockType;
 
 @DisplayName("BlockTypeDetector")
 class BlockTypeDetectorTest {
-    
+
     private BlockTypeDetector detector;
     private StructuralNode mockNode;
-    
+
     @BeforeEach
     void setUp() {
         detector = new BlockTypeDetector();
         mockNode = mock(StructuralNode.class);
     }
-    
+
     @Nested
     @DisplayName("detectType")
     class DetectType {
-        
+
         @Test
         @DisplayName("should return null when node is null")
         void shouldReturnNullWhenNodeIsNull() {
             // Given
             StructuralNode nullNode = null;
-            
+
             // When
             BlockType result = detector.detectType(nullNode);
-            
+
             // Then
             assertNull(result);
         }
-        
+
         @Test
         @DisplayName("should return null when context is null")
         void shouldReturnNullWhenContextIsNull() {
             // Given
             when(mockNode.getContext()).thenReturn(null);
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertNull(result);
         }
-        
+
         @Test
         @DisplayName("should detect paragraph block")
         void shouldDetectParagraphBlock() {
             // Given
             when(mockNode.getContext()).thenReturn("paragraph");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.PARAGRAPH, result);
         }
-        
+
         @Test
         @DisplayName("should detect listing block from listing context")
         void shouldDetectListingBlockFromListingContext() {
             // Given
             when(mockNode.getContext()).thenReturn("listing");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.LISTING, result);
         }
-        
+
         @Test
         @DisplayName("should detect literal block from literal context")
         void shouldDetectLiteralBlockFromLiteralContext() {
             // Given
             when(mockNode.getContext()).thenReturn("literal");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.LITERAL, result);
         }
-        
+
         @Test
         @DisplayName("should detect table block")
         void shouldDetectTableBlock() {
             // Given
             when(mockNode.getContext()).thenReturn("table");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.TABLE, result);
         }
-        
+
         @Test
         @DisplayName("should detect image block")
         void shouldDetectImageBlock() {
             // Given
             when(mockNode.getContext()).thenReturn("image");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.IMAGE, result);
         }
-        
+
         @Test
         @DisplayName("should detect verse block from verse context")
         void shouldDetectVerseBlockFromVerseContext() {
             // Given
             when(mockNode.getContext()).thenReturn("verse");
             when(mockNode.getStyle()).thenReturn("verse");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.VERSE, result);
         }
-        
+
         @Test
         @DisplayName("should detect quote block from quote with attribution")
         void shouldDetectQuoteBlockFromQuoteWithAttribution() {
             // Given
             when(mockNode.getContext()).thenReturn("quote");
             when(mockNode.getAttribute("attribution")).thenReturn("Some Author");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.QUOTE, result);
         }
-        
+
         @Test
         @DisplayName("should detect example block even with source style")
         void shouldDetectExampleBlockEvenWithSourceStyle() {
             // Given
             when(mockNode.getContext()).thenReturn("example");
             when(mockNode.getStyle()).thenReturn("source");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.EXAMPLE, result);
         }
-        
+
         @Test
         @DisplayName("should detect image block from open with image role")
         void shouldDetectImageBlockFromOpenWithImageRole() {
             // Given
             when(mockNode.getContext()).thenReturn("open");
             when(mockNode.hasRole("image")).thenReturn(true);
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertEquals(BlockType.IMAGE, result);
         }
-        
+
         @Test
         @DisplayName("should return null for unknown context")
         void shouldReturnNullForUnknownContext() {
             // Given
             when(mockNode.getContext()).thenReturn("unknown");
-            
+
             // When
             BlockType result = detector.detectType(mockNode);
-            
+
             // Then
             assertNull(result);
         }
     }
-    
+
     @Nested
     @DisplayName("isBlockType")
     class IsBlockType {
-        
+
         @Test
         @DisplayName("should return true when block matches type")
         void shouldReturnTrueWhenBlockMatchesType() {
             // Given
             when(mockNode.getContext()).thenReturn("paragraph");
-            
+
             // When
             boolean result = detector.isBlockType(mockNode, BlockType.PARAGRAPH);
-            
+
             // Then
             assertTrue(result);
         }
-        
+
         @Test
         @DisplayName("should return false when block does not match type")
         void shouldReturnFalseWhenBlockDoesNotMatchType() {
             // Given
             when(mockNode.getContext()).thenReturn("paragraph");
-            
+
             // When
             boolean result = detector.isBlockType(mockNode, BlockType.TABLE);
-            
+
             // Then
             assertFalse(result);
         }
-        
+
         @Test
         @DisplayName("should return false when node is null")
         void shouldReturnFalseWhenNodeIsNull() {
             // Given
             StructuralNode nullNode = null;
-            
+
             // When
             boolean result = detector.isBlockType(nullNode, BlockType.PARAGRAPH);
-            
+
             // Then
             assertFalse(result);
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidationContextTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidationContextTest.java
@@ -23,59 +23,57 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 
 @DisplayName("BlockValidationContext")
 class BlockValidationContextTest {
-    
+
     private BlockValidationContext context;
     private Section mockSection;
     private String filename = "test.adoc";
-    
+
     @BeforeEach
     void setUp() {
         mockSection = mock(Section.class);
         context = new BlockValidationContext(mockSection, filename);
     }
-    
+
     @Nested
     @DisplayName("constructor")
     class Constructor {
-        
+
         @Test
         @DisplayName("should require non-null section")
         void shouldRequireNonNullSection() {
             // Given
             Section nullSection = null;
-            
+
             // When/Then
-            assertThrows(NullPointerException.class, 
-                () -> new BlockValidationContext(nullSection, filename));
+            assertThrows(NullPointerException.class, () -> new BlockValidationContext(nullSection, filename));
         }
-        
+
         @Test
         @DisplayName("should require non-null filename")
         void shouldRequireNonNullFilename() {
             // Given
             String nullFilename = null;
-            
+
             // When/Then
-            assertThrows(NullPointerException.class, 
-                () -> new BlockValidationContext(mockSection, nullFilename));
+            assertThrows(NullPointerException.class, () -> new BlockValidationContext(mockSection, nullFilename));
         }
-        
+
         @Test
         @DisplayName("should store section and filename")
         void shouldStoreSectionAndFilename() {
             // Given/When
             BlockValidationContext ctx = new BlockValidationContext(mockSection, filename);
-            
+
             // Then
             assertEquals(mockSection, ctx.getSection());
             assertEquals(filename, ctx.getFilename());
         }
     }
-    
+
     @Nested
     @DisplayName("createLocation")
     class CreateLocation {
-        
+
         @Test
         @DisplayName("should create location with line number from source location")
         void shouldCreateLocationWithLineNumberFromSourceLocation() {
@@ -84,35 +82,35 @@ class BlockValidationContextTest {
             Cursor mockCursor = mock(Cursor.class);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockCursor.getLineNumber()).thenReturn(42);
-            
+
             // When
             SourceLocation location = context.createLocation(mockBlock);
-            
+
             // Then
             assertEquals(filename, location.getFilename());
             assertEquals(42, location.getStartLine());
         }
-        
+
         @Test
         @DisplayName("should create location with line 1 when source location is null")
         void shouldCreateLocationWithLine1WhenSourceLocationIsNull() {
             // Given
             StructuralNode mockBlock = mock(StructuralNode.class);
             when(mockBlock.getSourceLocation()).thenReturn(null);
-            
+
             // When
             SourceLocation location = context.createLocation(mockBlock);
-            
+
             // Then
             assertEquals(filename, location.getFilename());
             assertEquals(1, location.getStartLine());
         }
     }
-    
+
     @Nested
     @DisplayName("trackBlock")
     class TrackBlock {
-        
+
         @Test
         @DisplayName("should track block occurrence")
         void shouldTrackBlockOccurrence() {
@@ -121,14 +119,14 @@ class BlockValidationContextTest {
             StructuralNode mockBlock = mock(StructuralNode.class);
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
-            
+
             // When
             context.trackBlock(mockConfig, mockBlock);
-            
+
             // Then
             assertEquals(1, context.getOccurrenceCount(mockConfig));
         }
-        
+
         @Test
         @DisplayName("should track multiple occurrences of same block")
         void shouldTrackMultipleOccurrencesOfSameBlock() {
@@ -138,15 +136,15 @@ class BlockValidationContextTest {
             StructuralNode mockBlock2 = mock(StructuralNode.class);
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
-            
+
             // When
             context.trackBlock(mockConfig, mockBlock1);
             context.trackBlock(mockConfig, mockBlock2);
-            
+
             // Then
             assertEquals(2, context.getOccurrenceCount(mockConfig));
         }
-        
+
         @Test
         @DisplayName("should track block order")
         void shouldTrackBlockOrder() {
@@ -159,11 +157,11 @@ class BlockValidationContextTest {
             when(config2.getName()).thenReturn("second");
             when(config1.getType()).thenReturn(BlockType.PARAGRAPH);
             when(config2.getType()).thenReturn(BlockType.PARAGRAPH);
-            
+
             // When
             context.trackBlock(config1, block1);
             context.trackBlock(config2, block2);
-            
+
             // Then
             List<BlockValidationContext.BlockPosition> order = context.getBlockOrder();
             assertEquals(2, order.size());
@@ -171,11 +169,11 @@ class BlockValidationContextTest {
             assertEquals(1, order.get(1).getIndex());
         }
     }
-    
+
     @Nested
     @DisplayName("getOccurrences")
     class GetOccurrences {
-        
+
         @Test
         @DisplayName("should return empty list when no occurrences tracked")
         void shouldReturnEmptyListWhenNoOccurrencesTracked() {
@@ -183,15 +181,14 @@ class BlockValidationContextTest {
             Block mockConfig = mock(ParagraphBlock.class);
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
-            
+
             // When
-            List<BlockValidationContext.BlockOccurrence> occurrences = 
-                context.getOccurrences(mockConfig);
-            
+            List<BlockValidationContext.BlockOccurrence> occurrences = context.getOccurrences(mockConfig);
+
             // Then
             assertTrue(occurrences.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return tracked occurrences")
         void shouldReturnTrackedOccurrences() {
@@ -201,11 +198,10 @@ class BlockValidationContextTest {
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
             context.trackBlock(mockConfig, mockBlock);
-            
+
             // When
-            List<BlockValidationContext.BlockOccurrence> occurrences = 
-                context.getOccurrences(mockConfig);
-            
+            List<BlockValidationContext.BlockOccurrence> occurrences = context.getOccurrences(mockConfig);
+
             // Then
             assertEquals(1, occurrences.size());
             assertEquals(mockConfig, occurrences.get(0).getConfig());
@@ -213,25 +209,25 @@ class BlockValidationContextTest {
             assertEquals(0, occurrences.get(0).getPosition());
         }
     }
-    
+
     @Nested
     @DisplayName("getBlockName")
     class GetBlockName {
-        
+
         @Test
         @DisplayName("should return named block identifier")
         void shouldReturnNamedBlockIdentifier() {
             // Given
             Block mockConfig = mock(ParagraphBlock.class);
             when(mockConfig.getName()).thenReturn("intro");
-            
+
             // When
             String name = context.getBlockName(mockConfig);
-            
+
             // Then
             assertEquals("block 'intro'", name);
         }
-        
+
         @Test
         @DisplayName("should return type-based identifier when name is null")
         void shouldReturnTypeBasedIdentifierWhenNameIsNull() {
@@ -239,10 +235,10 @@ class BlockValidationContextTest {
             Block mockConfig = mock(ParagraphBlock.class);
             when(mockConfig.getName()).thenReturn(null);
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
-            
+
             // When
             String name = context.getBlockName(mockConfig);
-            
+
             // Then
             assertEquals("paragraph block", name);
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidatorFactoryTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/BlockValidatorFactoryTest.java
@@ -17,153 +17,147 @@ import com.dataliquid.asciidoc.linter.config.blocks.BlockType;
 
 @DisplayName("BlockValidatorFactory")
 class BlockValidatorFactoryTest {
-    
+
     private BlockValidatorFactory factory;
-    
+
     @BeforeEach
     void setUp() {
         factory = new BlockValidatorFactory();
     }
-    
+
     @Nested
     @DisplayName("getValidator")
     class GetValidator {
-        
+
         @Test
         @DisplayName("should return ParagraphBlockValidator for PARAGRAPH type")
         void shouldReturnParagraphBlockValidatorForParagraphType() {
             // Given
             BlockType type = BlockType.PARAGRAPH;
-            
+
             // When
             BlockTypeValidator validator = factory.getValidator(type);
-            
+
             // Then
             assertNotNull(validator);
             assertInstanceOf(ParagraphBlockValidator.class, validator);
             assertEquals(BlockType.PARAGRAPH, validator.getSupportedType());
         }
-        
+
         @Test
         @DisplayName("should return TableBlockValidator for TABLE type")
         void shouldReturnTableBlockValidatorForTableType() {
             // Given
             BlockType type = BlockType.TABLE;
-            
+
             // When
             BlockTypeValidator validator = factory.getValidator(type);
-            
+
             // Then
             assertNotNull(validator);
             assertInstanceOf(TableBlockValidator.class, validator);
             assertEquals(BlockType.TABLE, validator.getSupportedType());
         }
-        
+
         @Test
         @DisplayName("should return ImageBlockValidator for IMAGE type")
         void shouldReturnImageBlockValidatorForImageType() {
             // Given
             BlockType type = BlockType.IMAGE;
-            
+
             // When
             BlockTypeValidator validator = factory.getValidator(type);
-            
+
             // Then
             assertNotNull(validator);
             assertInstanceOf(ImageBlockValidator.class, validator);
             assertEquals(BlockType.IMAGE, validator.getSupportedType());
         }
-        
+
         @Test
         @DisplayName("should return ListingBlockValidator for LISTING type")
         void shouldReturnListingBlockValidatorForListingType() {
             // Given
             BlockType type = BlockType.LISTING;
-            
+
             // When
             BlockTypeValidator validator = factory.getValidator(type);
-            
+
             // Then
             assertNotNull(validator);
             assertInstanceOf(ListingBlockValidator.class, validator);
             assertEquals(BlockType.LISTING, validator.getSupportedType());
         }
-        
+
         @Test
         @DisplayName("should return VerseBlockValidator for VERSE type")
         void shouldReturnVerseBlockValidatorForVerseType() {
             // Given
             BlockType type = BlockType.VERSE;
-            
+
             // When
             BlockTypeValidator validator = factory.getValidator(type);
-            
+
             // Then
             assertNotNull(validator);
             assertInstanceOf(VerseBlockValidator.class, validator);
             assertEquals(BlockType.VERSE, validator.getSupportedType());
         }
-        
+
         @Test
         @DisplayName("should return null for null type")
         void shouldReturnNullForNullType() {
             // Given
             BlockType type = null;
-            
+
             // When
             BlockTypeValidator validator = factory.getValidator(type);
-            
+
             // Then
             assertNull(validator);
         }
-        
+
         @Test
         @DisplayName("should return same instance for same type")
         void shouldReturnSameInstanceForSameType() {
             // Given
             BlockType type = BlockType.PARAGRAPH;
-            
+
             // When
             BlockTypeValidator validator1 = factory.getValidator(type);
             BlockTypeValidator validator2 = factory.getValidator(type);
-            
+
             // Then
             assertSame(validator1, validator2);
         }
     }
-    
+
     @Nested
     @DisplayName("hasValidator")
     class HasValidator {
-        
+
         @Test
         @DisplayName("should return true for supported types")
         void shouldReturnTrueForSupportedTypes() {
             // Given
-            BlockType[] supportedTypes = {
-                BlockType.PARAGRAPH,
-                BlockType.TABLE,
-                BlockType.IMAGE,
-                BlockType.LISTING,
-                BlockType.VERSE
-            };
-            
+            BlockType[] supportedTypes = {BlockType.PARAGRAPH, BlockType.TABLE, BlockType.IMAGE, BlockType.LISTING,
+                    BlockType.VERSE};
+
             // When/Then
             for (BlockType type : supportedTypes) {
-                assertTrue(factory.hasValidator(type), 
-                    "Should have validator for " + type);
+                assertTrue(factory.hasValidator(type), "Should have validator for " + type);
             }
         }
-        
+
         @Test
         @DisplayName("should return false for null type")
         void shouldReturnFalseForNullType() {
             // Given
             BlockType type = null;
-            
+
             // When
             boolean result = factory.hasValidator(type);
-            
+
             // Then
             assertFalse(result);
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/DlistBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/DlistBlockValidatorTest.java
@@ -26,33 +26,36 @@ import org.asciidoctor.ast.Cursor;
 
 /**
  * Unit tests for {@link DlistBlockValidator}.
- * 
- * <p>This test class validates the behavior of the definition list block validator,
- * which processes dlist blocks in AsciiDoc documents. The tests cover all
- * validation rules including term count, description validation, nesting level, 
- * and delimiter style.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the definition list block validator, which processes dlist blocks in
+ * AsciiDoc documents. The tests cover all validation rules including term count, description validation, nesting level,
+ * and delimiter style.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality</li>
- *   <li>TermsValidation - Term count and pattern constraints</li>
- *   <li>DescriptionsValidation - Description presence and content</li>
- *   <li>NestingLevelValidation - Maximum nesting depth</li>
- *   <li>DelimiterStyleValidation - Delimiter consistency</li>
- *   <li>ComplexScenarios - Combined validation scenarios</li>
+ * <li>Validate - Basic validator functionality</li>
+ * <li>TermsValidation - Term count and pattern constraints</li>
+ * <li>DescriptionsValidation - Description presence and content</li>
+ * <li>NestingLevelValidation - Maximum nesting depth</li>
+ * <li>DelimiterStyleValidation - Delimiter consistency</li>
+ * <li>ComplexScenarios - Combined validation scenarios</li>
  * </ul>
- * 
+ *
  * @see DlistBlockValidator
  * @see DlistBlock
  */
 @DisplayName("DlistBlockValidator")
 class DlistBlockValidatorTest {
-    
+
     private DlistBlockValidator validator;
     private BlockValidationContext context;
     private DescriptionList mockDlist;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new DlistBlockValidator();
@@ -62,79 +65,68 @@ class DlistBlockValidatorTest {
         when(mockDlist.getContext()).thenReturn("dlist");
         when(mockDlist.getSourceLocation()).thenReturn(null);
     }
-    
+
     @Test
     @DisplayName("should return DLIST as supported type")
     void shouldReturnDlistAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.DLIST, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when block is not DescriptionList instance")
         void shouldReturnEmptyListWhenNotDescriptionListInstance() {
             // Given
             Block notADlist = mock(Block.class);
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notADlist, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR).build();
+
             when(mockDlist.getItems()).thenReturn(Arrays.asList());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("TermsValidation")
     class TermsValidation {
-        
+
         @Test
         @DisplayName("should validate minimum term count")
         void shouldValidateMinimumTermCount() {
             // Given
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntry("Term1", "Description1")
-            );
+            List<DescriptionListEntry> entries = Arrays.asList(createMockEntry("Term1", "Description1"));
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .min(2)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().min(2).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -144,29 +136,22 @@ class DlistBlockValidatorTest {
             assertEquals("1", message.getActualValue().orElse(null));
             assertEquals("At least 2 terms", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate maximum term count")
         void shouldValidateMaximumTermCount() {
             // Given
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntry("Term1", "Desc1"),
-                createMockEntry("Term2", "Desc2"),
-                createMockEntry("Term3", "Desc3"),
-                createMockEntry("Term4", "Desc4")
-            );
+            List<DescriptionListEntry> entries = Arrays.asList(createMockEntry("Term1", "Desc1"),
+                    createMockEntry("Term2", "Desc2"), createMockEntry("Term3", "Desc3"),
+                    createMockEntry("Term4", "Desc4"));
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .max(3)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().max(3).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -176,28 +161,24 @@ class DlistBlockValidatorTest {
             assertEquals("4", message.getActualValue().orElse(null));
             assertEquals("At most 3 terms", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate term pattern")
         void shouldValidateTermPattern() {
             // Given
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntry("term", "Description"), // lowercase, should fail
-                createMockEntry("Term", "Description")  // uppercase, should pass
+            List<DescriptionListEntry> entries = Arrays.asList(createMockEntry("term", "Description"), // lowercase,
+                                                                                                       // should fail
+                    createMockEntry("Term", "Description") // uppercase, should pass
             );
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().pattern("^[A-Z].*").severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -207,92 +188,79 @@ class DlistBlockValidatorTest {
             assertEquals("term", message.getActualValue().orElse(null));
             assertEquals("Pattern: ^[A-Z].*", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should highlight exact position for term pattern violation")
         void shouldHighlightExactPositionForTermPatternViolation() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntryWithLocation("term without capital", "description", 53)
-            );
+
+            List<DescriptionListEntry> entries = Arrays
+                    .asList(createMockEntryWithLocation("term without capital", "description", 53));
             when(mockDlist.getItems()).thenReturn(entries);
-            
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(53);
             when(mockDlist.getSourceLocation()).thenReturn(mockCursor);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().pattern("^[A-Z].*").severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals("dlist.terms.pattern", message.getRuleId());
             assertEquals(Severity.WARN, message.getSeverity());
-            
+
             // Since we don't have actual file content in tests, the validator falls back to columns 1,1
             assertEquals(1, message.getLocation().getStartColumn(), "Should point to start of term");
             assertEquals(1, message.getLocation().getEndColumn(), "Falls back to column 1 without file content");
             assertEquals(53, message.getLocation().getStartLine());
             assertEquals(53, message.getLocation().getEndLine());
         }
-        
+
         @Test
         @DisplayName("should validate term length constraints")
         void shouldValidateTermLengthConstraints() {
             // Given
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntry("AB", "Description"),     // too short
-                createMockEntry("ABCDEF", "Description"), // ok
-                createMockEntry("ABCDEFGHIJKLMNOP", "Description") // too long
+            List<DescriptionListEntry> entries = Arrays.asList(createMockEntry("AB", "Description"), // too short
+                    createMockEntry("ABCDEF", "Description"), // ok
+                    createMockEntry("ABCDEFGHIJKLMNOP", "Description") // too long
             );
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .minLength(3)
-                    .maxLength(10)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().minLength(3).maxLength(10).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(2, messages.size());
-            
+
             // Check too short message
             ValidationMessage shortMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("dlist.terms.minLength"))
-                .findFirst().orElse(null);
+                    .filter(m -> m.getRuleId().equals("dlist.terms.minLength")).findFirst().orElse(null);
             assertEquals("Definition list term is too short", shortMessage.getMessage());
             assertEquals("AB (length: 2)", shortMessage.getActualValue().orElse(null));
-            
+
             // Check too long message
-            ValidationMessage longMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("dlist.terms.maxLength"))
-                .findFirst().orElse(null);
+            ValidationMessage longMessage = messages.stream().filter(m -> m.getRuleId().equals("dlist.terms.maxLength"))
+                    .findFirst().orElse(null);
             assertEquals("Definition list term is too long", longMessage.getMessage());
             assertTrue(longMessage.getActualValue().orElse("").contains("length: 16"));
         }
     }
-    
+
     @Nested
     @DisplayName("DescriptionsValidation")
     class DescriptionsValidation {
-        
+
         @Test
         @DisplayName("should validate required descriptions")
         void shouldValidateRequiredDescriptions() {
@@ -300,18 +268,15 @@ class DlistBlockValidatorTest {
             DescriptionListEntry entryWithoutDesc = createMockEntry("Term", null);
             List<DescriptionListEntry> entries = Arrays.asList(entryWithoutDesc);
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .descriptions(DlistBlock.DescriptionsConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .descriptions(
+                            DlistBlock.DescriptionsConfig.builder().required(true).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -321,28 +286,23 @@ class DlistBlockValidatorTest {
             assertEquals("No description", message.getActualValue().orElse(null));
             assertEquals("Description required", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate description pattern")
         void shouldValidateDescriptionPattern() {
             // Given
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntry("Term1", "Description without period"),
-                createMockEntry("Term2", "Description with period.")
-            );
+            List<DescriptionListEntry> entries = Arrays.asList(createMockEntry("Term1", "Description without period"),
+                    createMockEntry("Term2", "Description with period."));
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .descriptions(DlistBlock.DescriptionsConfig.builder()
-                    .pattern(".*\\.$")  // Must end with period
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .descriptions(DlistBlock.DescriptionsConfig.builder().pattern(".*\\.$") // Must end with period
+                            .severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -353,11 +313,11 @@ class DlistBlockValidatorTest {
             assertEquals("Pattern: .*\\.$", message.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("NestingLevelValidation")
     class NestingLevelValidation {
-        
+
         @Test
         @DisplayName("should skip nesting level validation - not implemented")
         void shouldSkipNestingLevelValidation() {
@@ -366,135 +326,112 @@ class DlistBlockValidatorTest {
             DescriptionList grandParent = mock(DescriptionList.class);
             when(grandParent.getContext()).thenReturn("dlist");
             when(grandParent.getParent()).thenReturn(null);
-            
+
             DescriptionList parent = mock(DescriptionList.class);
             when(parent.getContext()).thenReturn("dlist");
             when(parent.getParent()).thenReturn(grandParent);
-            
+
             when(mockDlist.getParent()).thenReturn(parent);
             when(mockDlist.getItems()).thenReturn(Arrays.asList());
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .nestingLevel(DlistBlock.NestingLevelConfig.builder()
-                    .max(1)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .nestingLevel(DlistBlock.NestingLevelConfig.builder().max(1).severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then - nesting validation is not implemented
             assertEquals(0, messages.size());
         }
     }
-    
+
     @Nested
     @DisplayName("DelimiterStyleValidation")
     class DelimiterStyleValidation {
-        
+
         @Test
         @DisplayName("should skip delimiter validation - not implemented")
         void shouldSkipDelimiterValidation() {
             // Given
             when(mockDlist.getAttribute("delimiter")).thenReturn("::::");
             when(mockDlist.getItems()).thenReturn(Arrays.asList());
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .delimiterStyle(DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::", ":::"})
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .delimiterStyle(DlistBlock.DelimiterStyleConfig.builder()
+                            .allowedDelimiters(new String[]{"::", ":::"}).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then - delimiter validation is not implemented
             assertEquals(0, messages.size());
         }
-        
+
         @Test
         @DisplayName("should skip delimiter validation even for allowed delimiters")
         void shouldSkipDelimiterValidationForAllowed() {
             // Given
             when(mockDlist.getAttribute("delimiter")).thenReturn("::");
             when(mockDlist.getItems()).thenReturn(Arrays.asList());
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .delimiterStyle(DlistBlock.DelimiterStyleConfig.builder()
-                    .allowedDelimiters(new String[]{"::", ":::"})
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR).delimiterStyle(
+                    DlistBlock.DelimiterStyleConfig.builder().allowedDelimiters(new String[]{"::", ":::"}).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("ComplexScenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple rules together")
         void shouldValidateMultipleRulesTogether() {
             // Given
-            List<DescriptionListEntry> entries = Arrays.asList(
-                createMockEntry("term", "Description"),  // lowercase term
-                createMockEntry("Term", null)            // missing description
+            List<DescriptionListEntry> entries = Arrays.asList(createMockEntry("term", "Description"), // lowercase term
+                    createMockEntry("Term", null) // missing description
             );
             when(mockDlist.getItems()).thenReturn(entries);
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .pattern("^[A-Z].*")
-                    .severity(Severity.WARN)
-                    .build())
-                .descriptions(DlistBlock.DescriptionsConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().pattern("^[A-Z].*").severity(Severity.WARN).build())
+                    .descriptions(
+                            DlistBlock.DescriptionsConfig.builder().required(true).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(2, messages.size());
-            
+
             // Verify we have one pattern violation and one required description violation
-            assertTrue(messages.stream().anyMatch(m -> 
-                m.getRuleId().equals("dlist.terms.pattern") && 
-                m.getSeverity() == Severity.WARN));
-            assertTrue(messages.stream().anyMatch(m -> 
-                m.getRuleId().equals("dlist.descriptions.required") && 
-                m.getSeverity() == Severity.ERROR));
+            assertTrue(messages.stream()
+                    .anyMatch(m -> m.getRuleId().equals("dlist.terms.pattern") && m.getSeverity() == Severity.WARN));
+            assertTrue(messages.stream().anyMatch(
+                    m -> m.getRuleId().equals("dlist.descriptions.required") && m.getSeverity() == Severity.ERROR));
         }
-        
+
         @Test
         @DisplayName("should handle empty definition list")
         void shouldHandleEmptyDefinitionList() {
             // Given
             when(mockDlist.getItems()).thenReturn(Arrays.asList());
-            
-            DlistBlock config = DlistBlock.builder()
-                .severity(Severity.ERROR)
-                .terms(DlistBlock.TermsConfig.builder()
-                    .min(1)
-                    .build())
-                .build();
-            
+
+            DlistBlock config = DlistBlock.builder().severity(Severity.ERROR)
+                    .terms(DlistBlock.TermsConfig.builder().min(1).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockDlist, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -502,15 +439,15 @@ class DlistBlockValidatorTest {
             assertEquals("0", message.getActualValue().orElse(null));
         }
     }
-    
+
     // Helper method to create mock DescriptionListEntry
     private DescriptionListEntry createMockEntry(String term, String description) {
         DescriptionListEntry entry = mock(DescriptionListEntry.class);
-        
+
         ListItem termItem = mock(ListItem.class);
         when(termItem.getText()).thenReturn(term);
         when(entry.getTerms()).thenReturn(Arrays.asList(termItem));
-        
+
         if (description != null) {
             ListItem descItem = mock(ListItem.class);
             when(descItem.getText()).thenReturn(description);
@@ -518,24 +455,24 @@ class DlistBlockValidatorTest {
         } else {
             when(entry.getDescription()).thenReturn(null);
         }
-        
+
         return entry;
     }
-    
+
     // Helper method to create mock DescriptionListEntry with source location
     private DescriptionListEntry createMockEntryWithLocation(String term, String description, int lineNumber) {
         DescriptionListEntry entry = mock(DescriptionListEntry.class);
-        
+
         ListItem termItem = mock(ListItem.class);
         when(termItem.getText()).thenReturn(term);
-        
+
         // Add source location to termItem
         Cursor termCursor = mock(Cursor.class);
         when(termCursor.getLineNumber()).thenReturn(lineNumber);
         when(termItem.getSourceLocation()).thenReturn(termCursor);
-        
+
         when(entry.getTerms()).thenReturn(Arrays.asList(termItem));
-        
+
         if (description != null) {
             ListItem descItem = mock(ListItem.class);
             when(descItem.getText()).thenReturn(description);
@@ -543,7 +480,7 @@ class DlistBlockValidatorTest {
         } else {
             when(entry.getDescription()).thenReturn(null);
         }
-        
+
         return entry;
     }
 }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ExampleBlockValidatorTest.java
@@ -23,12 +23,12 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("ExampleBlockValidator")
 class ExampleBlockValidatorTest {
-    
+
     private ExampleBlockValidator validator;
     private StructuralNode mockNode;
     private BlockValidationContext mockContext;
     private SourceLocation mockLocation;
-    
+
     @BeforeEach
     void setUp() {
         validator = new ExampleBlockValidator();
@@ -38,394 +38,323 @@ class ExampleBlockValidatorTest {
         when(mockContext.createLocation(any())).thenReturn(mockLocation);
         when(mockContext.getFilename()).thenReturn("test.adoc");
     }
-    
+
     @Test
     @DisplayName("should return EXAMPLE as supported type")
     void shouldReturnExampleAsSupportedType() {
         assertEquals(BlockType.EXAMPLE, validator.getSupportedType());
     }
-    
+
     @Test
     @DisplayName("should return empty list for invalid block config type")
     void shouldReturnEmptyListForInvalidBlockConfigType() {
         // Given
         var invalidBlock = mock(com.dataliquid.asciidoc.linter.config.blocks.Block.class);
-        
+
         // When
         var messages = validator.validate(mockNode, invalidBlock, mockContext);
-        
+
         // Then
         assertTrue(messages.isEmpty());
     }
-    
+
     @Nested
     @DisplayName("Caption Validation")
     class CaptionValidation {
-        
+
         @Test
         @DisplayName("should pass when caption is not configured")
         void shouldPassWhenCaptionIsNotConfigured() {
             // Given
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when caption is required but missing")
         void shouldFailWhenCaptionIsRequiredButMissing() {
             // Given
             when(mockNode.getTitle()).thenReturn(null);
-            
-            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
+
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).caption(captionConfig)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(captionConfig)
-                    .build();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("Example block requires a caption", messages.get(0).getMessage());
             assertEquals(Severity.ERROR, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should pass when caption matches pattern")
         void shouldPassWhenCaptionMatchesPattern() {
             // Given
             when(mockNode.getTitle()).thenReturn("Example 1.2: Basic usage");
-            
-            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
-                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*")
-                    .minLength(15)
-                    .maxLength(100)
-                    .severity(Severity.ERROR)
+
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder().required(true)
+                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*").minLength(15).maxLength(100)
+                    .severity(Severity.ERROR).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).caption(captionConfig)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(captionConfig)
-                    .build();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when caption does not match pattern")
         void shouldFailWhenCaptionDoesNotMatchPattern() {
             // Given
             when(mockNode.getTitle()).thenReturn("Invalid caption format");
-            
+
             ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*")
-                    .severity(Severity.ERROR)
+                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*").severity(Severity.ERROR).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).caption(captionConfig)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(captionConfig)
-                    .build();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.get(0).getMessage().contains("does not match required pattern"));
             assertEquals(Severity.ERROR, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should fail when caption is too short")
         void shouldFailWhenCaptionIsTooShort() {
             // Given
             when(mockNode.getTitle()).thenReturn("Short");
-            
-            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                    .minLength(15)
-                    .severity(Severity.WARN)
+
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder().minLength(15)
+                    .severity(Severity.WARN).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.ERROR).caption(captionConfig)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.ERROR)
-                    .caption(captionConfig)
-                    .build();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.get(0).getMessage().contains("less than required minimum"));
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should fail when caption is too long")
         void shouldFailWhenCaptionIsTooLong() {
             // Given
             String longCaption = "A".repeat(101);
             when(mockNode.getTitle()).thenReturn(longCaption);
-            
-            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                    .maxLength(100)
+
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder().maxLength(100).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).caption(captionConfig)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(captionConfig)
-                    .build();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.get(0).getMessage().contains("exceeds maximum"));
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should use block severity when caption severity is not specified")
         void shouldUseBlockSeverityWhenCaptionSeverityNotSpecified() {
             // Given
             when(mockNode.getTitle()).thenReturn(null);
-            
-            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                    .required(true)
+
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder().required(true).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.INFO).caption(captionConfig)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.INFO)
-                    .caption(captionConfig)
-                    .build();
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.INFO, messages.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Collapsible Validation")
     class CollapsibleValidation {
-        
+
         @Test
         @DisplayName("should pass when collapsible is not configured")
         void shouldPassWhenCollapsibleIsNotConfigured() {
             // Given
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .build();
-            
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when collapsible is required but missing")
         void shouldFailWhenCollapsibleIsRequiredButMissing() {
             // Given
             when(mockNode.getAttribute("collapsible-option")).thenReturn(null);
             when(mockNode.getAttribute("collapsible")).thenReturn(null);
-            
-            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .collapsible(collapsibleConfig)
-                    .build();
-            
+
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN)
+                    .collapsible(collapsibleConfig).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("Example block requires a collapsible attribute", messages.get(0).getMessage());
             assertEquals(Severity.ERROR, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should pass when collapsible value is allowed")
         void shouldPassWhenCollapsibleValueIsAllowed() {
             // Given
             when(mockNode.getAttribute("collapsible-option")).thenReturn(true);
-            
+
             ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                    .allowed(Arrays.asList(true, false))
-                    .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .collapsible(collapsibleConfig)
-                    .build();
-            
+                    .allowed(Arrays.asList(true, false)).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN)
+                    .collapsible(collapsibleConfig).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should handle string boolean values")
         void shouldHandleStringBooleanValues() {
             // Given
             when(mockNode.getAttribute("collapsible-option")).thenReturn("true");
-            
+
             ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                    .allowed(Arrays.asList(true, false))
-                    .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .collapsible(collapsibleConfig)
-                    .build();
-            
+                    .allowed(Arrays.asList(true, false)).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN)
+                    .collapsible(collapsibleConfig).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should handle alternative string boolean values")
         void shouldHandleAlternativeStringBooleanValues() {
             // Given
             when(mockNode.getAttribute("collapsible")).thenReturn("yes");
-            
+
             ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                    .allowed(Arrays.asList(true, false))
-                    .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .collapsible(collapsibleConfig)
-                    .build();
-            
+                    .allowed(Arrays.asList(true, false)).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN)
+                    .collapsible(collapsibleConfig).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when collapsible value is not allowed")
         void shouldFailWhenCollapsibleValueIsNotAllowed() {
             // Given
             when(mockNode.getAttribute("collapsible-option")).thenReturn("invalid");
-            
+
             ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                    .allowed(Arrays.asList(true, false))
-                    .severity(Severity.INFO)
-                    .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .collapsible(collapsibleConfig)
-                    .build();
-            
+                    .allowed(Arrays.asList(true, false)).severity(Severity.INFO).build();
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN)
+                    .collapsible(collapsibleConfig).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.get(0).getMessage().contains("is not in allowed values"));
             assertEquals(Severity.INFO, messages.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should use block severity when collapsible severity is not specified")
         void shouldUseBlockSeverityWhenCollapsibleSeverityNotSpecified() {
             // Given
             when(mockNode.getAttribute("collapsible-option")).thenReturn(null);
-            
-            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                    .required(true)
+
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder().required(true)
                     .build();
-                    
-            ExampleBlock block = ExampleBlock.builder()
-                    .name("test")
-                    .severity(Severity.ERROR)
-                    .collapsible(collapsibleConfig)
-                    .build();
-            
+
+            ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.ERROR)
+                    .collapsible(collapsibleConfig).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.ERROR, messages.get(0).getSeverity());
         }
     }
-    
+
     @Test
     @DisplayName("should validate both caption and collapsible")
     void shouldValidateBothCaptionAndCollapsible() {
         // Given
         when(mockNode.getTitle()).thenReturn(null);
         when(mockNode.getAttribute("collapsible-option")).thenReturn(null);
-        
-        ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
-                .required(true)
+
+        ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder().required(true).build();
+
+        ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder().required(true)
                 .build();
-                
-        ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
-                .required(true)
-                .build();
-                
-        ExampleBlock block = ExampleBlock.builder()
-                .name("test")
-                .severity(Severity.WARN)
-                .caption(captionConfig)
-                .collapsible(collapsibleConfig)
-                .build();
-        
+
+        ExampleBlock block = ExampleBlock.builder().name("test").severity(Severity.WARN).caption(captionConfig)
+                .collapsible(collapsibleConfig).build();
+
         // When
         List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
-        
+
         // Then
         assertEquals(2, messages.size());
         assertTrue(messages.stream().anyMatch(m -> m.getMessage().contains("caption")));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ImageBlockValidatorTest.java
@@ -25,36 +25,40 @@ import org.asciidoctor.ast.Cursor;
 
 /**
  * Unit tests for {@link ImageBlockValidator}.
- * 
- * <p>This test class validates the behavior of the image block validator,
- * which processes image elements in AsciiDoc documents. The tests cover
- * validation rules for image URLs, dimensions, and alternative text.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the image block validator, which processes image elements in AsciiDoc
+ * documents. The tests cover validation rules for image URLs, dimensions, and alternative text.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality and type checking</li>
- *   <li>UrlValidation - URL requirements and pattern matching</li>
- *   <li>DimensionsValidation - Width and height constraints</li>
- *   <li>AltTextValidation - Alternative text requirements and length constraints</li>
- *   <li>SeverityHierarchy - Block-level severity usage (no nested severity support)</li>
- *   <li>ComplexScenarios - Combined validation scenarios</li>
+ * <li>Validate - Basic validator functionality and type checking</li>
+ * <li>UrlValidation - URL requirements and pattern matching</li>
+ * <li>DimensionsValidation - Width and height constraints</li>
+ * <li>AltTextValidation - Alternative text requirements and length constraints</li>
+ * <li>SeverityHierarchy - Block-level severity usage (no nested severity support)</li>
+ * <li>ComplexScenarios - Combined validation scenarios</li>
  * </ul>
- * 
- * <p>Note: Unlike other block validators, ImageBlock configurations do not
- * support individual severity levels for nested rules. All validations use
- * the block-level severity.</p>
- * 
+ *
+ * <p>
+ * Note: Unlike other block validators, ImageBlock configurations do not support individual severity levels for nested
+ * rules. All validations use the block-level severity.
+ * </p>
+ *
  * @see ImageBlockValidator
  * @see ImageBlock
  */
 @DisplayName("ImageBlockValidator")
 class ImageBlockValidatorTest {
-    
+
     private ImageBlockValidator validator;
     private BlockValidationContext context;
     private Block mockBlock;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new ImageBlockValidator();
@@ -62,75 +66,66 @@ class ImageBlockValidatorTest {
         context = new BlockValidationContext(mockSection, "test.adoc");
         mockBlock = mock(Block.class);
     }
-    
+
     @Test
     @DisplayName("should return IMAGE as supported type")
     void shouldReturnImageAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.IMAGE, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when block is not Image instance")
         void shouldReturnEmptyListWhenNotImageInstance() {
             // Given
             StructuralNode notAnImage = mock(StructuralNode.class);
-            ImageBlock config = ImageBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock config = ImageBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notAnImage, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            ImageBlock config = ImageBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
+            ImageBlock config = ImageBlock.builder().severity(Severity.ERROR).build();
             when(mockBlock.hasAttribute("target")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("URL validation")
     class UrlValidation {
-        
+
         @Test
         @DisplayName("should validate required URL")
         void shouldValidateRequiredUrl() {
             // Given
-            ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .url(urlConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().url(urlConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("target")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -140,25 +135,21 @@ class ImageBlockValidatorTest {
             assertEquals("No URL", msg.getActualValue().orElse(null));
             assertEquals("URL required", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate URL pattern")
         void shouldValidateUrlPattern() {
             // Given
             ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder()
-                .pattern(Pattern.compile("^images/.*\\.png$"))
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .url(urlConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile("^images/.*\\.png$")).build();
+            ImageBlock config = ImageBlock.builder().url(urlConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("target")).thenReturn(true);
             when(mockBlock.getAttribute("target")).thenReturn("assets/logo.jpg");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -168,113 +159,99 @@ class ImageBlockValidatorTest {
             assertEquals("assets/logo.jpg", msg.getActualValue().orElse(null));
             assertEquals("Pattern: ^images/.*\\.png$", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should include placeholder for missing URL")
         void shouldIncludePlaceholderForMissingUrl() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
-            ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .url(urlConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().url(urlConfig).severity(Severity.ERROR).build();
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(36);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("target")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.url.required", msg.getRuleId());
             assertEquals(ErrorType.MISSING_VALUE, msg.getErrorType());
             assertEquals("filename.png", msg.getMissingValueHint());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(36, msg.getLocation().getStartLine());
         }
-        
+
         @Test
         @DisplayName("should highlight invalid URL pattern")
         void shouldHighlightInvalidUrlPattern() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
+
             ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder()
-                .pattern(Pattern.compile("^[a-zA-Z0-9/_-]+\\.(png|jpg|jpeg|gif|svg)$"))
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .url(urlConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile("^[a-zA-Z0-9/_-]+\\.(png|jpg|jpeg|gif|svg)$")).build();
+            ImageBlock config = ImageBlock.builder().url(urlConfig).severity(Severity.ERROR).build();
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(38);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("target")).thenReturn(true);
             when(mockBlock.getAttribute("target")).thenReturn("invalid file name.png");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.url.pattern", msg.getRuleId());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(38, msg.getLocation().getStartLine());
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("dimensions validation")
     class DimensionsValidation {
-        
+
         @Test
         @DisplayName("should highlight width too small")
         void shouldHighlightWidthTooSmall() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
-            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder()
-                .minValue(100)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .width(widthConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder().minValue(100).build();
+            ImageBlock config = ImageBlock.builder().width(widthConfig).severity(Severity.ERROR).build();
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(40);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("width")).thenReturn(true);
             when(mockBlock.getAttribute("width")).thenReturn("50");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.width.min", msg.getRuleId());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
@@ -283,97 +260,82 @@ class ImageBlockValidatorTest {
             assertEquals("50px", msg.getActualValue().orElse(null));
             assertEquals("At least 100px", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should include placeholder for missing width")
         void shouldIncludePlaceholderForMissingWidth() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
-            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .width(widthConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().width(widthConfig).severity(Severity.ERROR).build();
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(42);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("width")).thenReturn(true);
             when(mockBlock.getAttribute("width")).thenReturn("");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.width.required", msg.getRuleId());
             assertEquals(ErrorType.MISSING_VALUE, msg.getErrorType());
             assertEquals("640", msg.getMissingValueHint());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(42, msg.getLocation().getStartLine());
         }
-        
+
         @Test
         @DisplayName("should highlight width too large")
         void shouldHighlightWidthTooLarge() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
-            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder()
-                .maxValue(1200)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .width(widthConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder().maxValue(1200).build();
+            ImageBlock config = ImageBlock.builder().width(widthConfig).severity(Severity.ERROR).build();
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(44);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("width")).thenReturn(true);
             when(mockBlock.getAttribute("width")).thenReturn("2000");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.width.max", msg.getRuleId());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(44, msg.getLocation().getStartLine());
         }
-        
+
         @Test
         @DisplayName("should validate maximum width")
         void shouldValidateMaximumWidth() {
             // Given
-            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder()
-                .maxValue(800)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .width(widthConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder().maxValue(800).build();
+            ImageBlock config = ImageBlock.builder().width(widthConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("width")).thenReturn(true);
             when(mockBlock.getAttribute("width")).thenReturn("1000");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -381,51 +343,40 @@ class ImageBlockValidatorTest {
             assertEquals("image.width.max", msg.getRuleId());
             assertEquals("Image width is too large", msg.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate required width")
         void shouldValidateRequiredWidth() {
             // Given
-            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .width(widthConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().width(widthConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("width")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.width.required", msg.getRuleId());
             assertEquals("Image must have width specified", msg.getMessage());
         }
-        
-        
+
         @Test
         @DisplayName("should validate height")
         void shouldValidateHeight() {
             // Given
-            ImageBlock.DimensionConfig heightConfig = ImageBlock.DimensionConfig.builder()
-                .minValue(50)
-                .maxValue(600)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .height(heightConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.DimensionConfig heightConfig = ImageBlock.DimensionConfig.builder().minValue(50).maxValue(600)
+                    .build();
+            ImageBlock config = ImageBlock.builder().height(heightConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("height")).thenReturn(true);
             when(mockBlock.getAttribute("height")).thenReturn("700");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -433,28 +384,23 @@ class ImageBlockValidatorTest {
             assertEquals("Image height is too large", msg.getMessage());
         }
     }
-    
+
     @Nested
     @DisplayName("alt text validation")
     class AltTextValidation {
-        
+
         @Test
         @DisplayName("should validate required alt text")
         void shouldValidateRequiredAltText() {
             // Given
-            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .alt(altConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().alt(altConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("alt")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -463,63 +409,53 @@ class ImageBlockValidatorTest {
             assertEquals("No alt text", msg.getActualValue().orElse(null));
             assertEquals("Alt text required", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should include placeholder and exact position for missing alt text")
         void shouldIncludePlaceholderAndExactPositionForMissingAltText() {
             // Given
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test.adoc");
-            
-            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .alt(altConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().alt(altConfig).severity(Severity.ERROR).build();
+
             // Mock source location for line 32
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(32);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("alt")).thenReturn(false);
             when(mockBlock.getAttribute("target")).thenReturn("missing-image.png");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.alt.required", msg.getRuleId());
             assertEquals(ErrorType.MISSING_VALUE, msg.getErrorType());
             assertEquals("Description of image", msg.getMissingValueHint());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(32, msg.getLocation().getStartLine());
             assertEquals(32, msg.getLocation().getEndLine());
         }
-        
+
         @Test
         @DisplayName("should validate alt text minimum length")
         void shouldValidateAltTextMinLength() {
             // Given
-            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder()
-                .minLength(10)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .alt(altConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder().minLength(10).build();
+            ImageBlock config = ImageBlock.builder().alt(altConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("alt")).thenReturn(true);
             when(mockBlock.getAttribute("alt")).thenReturn("Logo");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -529,142 +465,118 @@ class ImageBlockValidatorTest {
             assertEquals("4 characters", msg.getActualValue().orElse(null));
             assertEquals("At least 10 characters", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate alt text maximum length")
         void shouldValidateAltTextMaxLength() {
             // Given
-            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder()
-                .maxLength(20)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .alt(altConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder().maxLength(20).build();
+            ImageBlock config = ImageBlock.builder().alt(altConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("alt")).thenReturn(true);
             when(mockBlock.getAttribute("alt")).thenReturn("This is a very long alt text description");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("image.alt.maxLength", msg.getRuleId());
             assertEquals("Image alt text is too long", msg.getMessage());
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("severity hierarchy")
     class SeverityHierarchy {
-        
+
         @Test
         @DisplayName("should always use block severity for URL validation")
         void shouldAlwaysUseBlockSeverityForUrl() {
             // Given - ImageBlock.UrlConfig has no severity field
-            ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .url(urlConfig)
-                .severity(Severity.INFO) // Block severity
-                .build();
-            
+            ImageBlock.UrlConfig urlConfig = ImageBlock.UrlConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().url(urlConfig).severity(Severity.INFO) // Block severity
+                    .build();
+
             when(mockBlock.hasAttribute("target")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use block severity (INFO) since UrlConfig has no severity field");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use block severity (INFO) since UrlConfig has no severity field");
             assertEquals("image.url.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should always use block severity for dimension validation")
         void shouldAlwaysUseBlockSeverityForDimension() {
             // Given - ImageBlock.DimensionConfig has no severity field
-            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .width(widthConfig)
-                .severity(Severity.WARN) // Block severity
-                .build();
-            
+            ImageBlock.DimensionConfig widthConfig = ImageBlock.DimensionConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().width(widthConfig).severity(Severity.WARN) // Block severity
+                    .build();
+
             when(mockBlock.hasAttribute("width")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use block severity (WARN) since DimensionConfig has no severity field");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use block severity (WARN) since DimensionConfig has no severity field");
             assertEquals("image.width.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should always use block severity for alt text validation")
         void shouldAlwaysUseBlockSeverityForAltText() {
             // Given - ImageBlock.AltTextConfig has no severity field
-            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder()
-                .required(true)
-                .build();
-            ImageBlock config = ImageBlock.builder()
-                .alt(altConfig)
-                .severity(Severity.ERROR) // Block severity
-                .build();
-            
+            ImageBlock.AltTextConfig altConfig = ImageBlock.AltTextConfig.builder().required(true).build();
+            ImageBlock config = ImageBlock.builder().alt(altConfig).severity(Severity.ERROR) // Block severity
+                    .build();
+
             when(mockBlock.hasAttribute("alt")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.ERROR, msg.getSeverity(), 
-                "Should use block severity (ERROR) since AltTextConfig has no severity field");
+            assertEquals(Severity.ERROR, msg.getSeverity(),
+                    "Should use block severity (ERROR) since AltTextConfig has no severity field");
             assertEquals("image.alt.required", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("complex validation scenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple rules together")
         void shouldValidateMultipleRules() {
             // Given
             ImageBlock config = ImageBlock.builder()
-                .url(ImageBlock.UrlConfig.builder()
-                    .required(true)
-                    .pattern(Pattern.compile("^images/.*"))
-                    .build())
-                .alt(ImageBlock.AltTextConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .build())
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .url(ImageBlock.UrlConfig.builder().required(true).pattern(Pattern.compile("^images/.*")).build())
+                    .alt(ImageBlock.AltTextConfig.builder().required(true).minLength(5).build())
+                    .severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("target")).thenReturn(true);
             when(mockBlock.getAttribute("target")).thenReturn("assets/logo.png");
             when(mockBlock.hasAttribute("alt")).thenReturn(true);
             when(mockBlock.getAttribute("alt")).thenReturn("Log");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(2, messages.size());
             assertTrue(messages.stream().anyMatch(m -> "image.url.pattern".equals(m.getRuleId())));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ListingBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ListingBlockValidatorTest.java
@@ -29,33 +29,36 @@ import org.asciidoctor.ast.Cursor;
 
 /**
  * Unit tests for {@link ListingBlockValidator}.
- * 
- * <p>This test class validates the behavior of the listing block validator,
- * which processes code blocks in AsciiDoc documents. The tests cover all
- * validation rules including language requirements, title patterns, line
- * count constraints, and callout restrictions.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the listing block validator, which processes code blocks in AsciiDoc
+ * documents. The tests cover all validation rules including language requirements, title patterns, line count
+ * constraints, and callout restrictions.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality</li>
- *   <li>LanguageValidation - Language specification and allowed values</li>
- *   <li>TitleValidation - Title requirements and pattern matching</li>
- *   <li>LinesValidation - Line count constraints</li>
- *   <li>CalloutsValidation - Callout annotation rules</li>
- *   <li>ComplexScenarios - Combined validation scenarios</li>
+ * <li>Validate - Basic validator functionality</li>
+ * <li>LanguageValidation - Language specification and allowed values</li>
+ * <li>TitleValidation - Title requirements and pattern matching</li>
+ * <li>LinesValidation - Line count constraints</li>
+ * <li>CalloutsValidation - Callout annotation rules</li>
+ * <li>ComplexScenarios - Combined validation scenarios</li>
  * </ul>
- * 
+ *
  * @see ListingBlockValidator
  * @see ListingBlock
  */
 @DisplayName("ListingBlockValidator")
 class ListingBlockValidatorTest {
-    
+
     private ListingBlockValidator validator;
     private BlockValidationContext context;
     private Block mockBlock;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new ListingBlockValidator();
@@ -63,75 +66,66 @@ class ListingBlockValidatorTest {
         context = new BlockValidationContext(mockSection, "test.adoc");
         mockBlock = mock(Block.class);
     }
-    
+
     @Test
     @DisplayName("should return LISTING as supported type")
     void shouldReturnListingAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.LISTING, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when block is not Block instance")
         void shouldReturnEmptyListWhenNotBlockInstance() {
             // Given
             StructuralNode notABlock = mock(StructuralNode.class);
-            ListingBlock config = ListingBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock config = ListingBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notABlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            ListingBlock config = ListingBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock config = ListingBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("language validation")
     class LanguageValidation {
-        
+
         @Test
         @DisplayName("should validate required language")
         void shouldValidateRequiredLanguage() {
             // Given
-            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("language")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -141,26 +135,21 @@ class ListingBlockValidatorTest {
             assertEquals("No language", msg.getActualValue().orElse(null));
             assertEquals("Language required", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate allowed languages")
         void shouldValidateAllowedLanguages() {
             // Given
             ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .allowed(Arrays.asList("java", "python", "javascript"))
-                .severity(Severity.WARN)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .allowed(Arrays.asList("java", "python", "javascript")).severity(Severity.WARN).build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("language")).thenReturn(true);
             when(mockBlock.getAttribute("language")).thenReturn("ruby");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -170,82 +159,68 @@ class ListingBlockValidatorTest {
             assertEquals("ruby", msg.getActualValue().orElse(null));
             assertEquals("One of: java, python, javascript", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use language severity over block severity")
         void shouldUseLanguageSeverityOverBlockSeverity() {
             // Given - language has WARN, block has ERROR
-            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .required(true)
-                .severity(Severity.WARN)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder().required(true)
+                    .severity(Severity.WARN).build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("language")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use language severity (WARN) instead of block severity (ERROR)");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use language severity (WARN) instead of block severity (ERROR)");
         }
-        
+
         @Test
         @DisplayName("should use block severity when language severity is not defined")
         void shouldUseBlockSeverityWhenLanguageSeverityNotDefined() {
             // Given - language has no severity, block has INFO
-            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .required(true)
-                // No severity set
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.INFO)
-                .build();
-            
+            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder().required(true)
+                    // No severity set
+                    .build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.INFO).build();
+
             when(mockBlock.hasAttribute("language")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use block severity (INFO) when language severity is not defined");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use block severity (INFO) when language severity is not defined");
             assertEquals("listing.language.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should include placeholder and exact position for missing language - based on test-errors.adoc line 17")
         void shouldIncludePlaceholderAndColumnForMissingLanguage() {
             // Given - Based on test-errors.adoc line 17: [source]
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test-errors.adoc");
-            
-            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.ERROR).build();
+
             // Mock source location for line 17 from test-errors.adoc
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(17);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("language")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -253,124 +228,103 @@ class ListingBlockValidatorTest {
             assertEquals(ErrorType.MISSING_VALUE, msg.getErrorType());
             assertEquals("language", msg.getMissingValueHint());
             assertNotNull(msg.getPlaceholderContext());
-            assertEquals(PlaceholderContext.PlaceholderType.LIST_VALUE, 
-                         msg.getPlaceholderContext().getType());
-            
+            assertEquals(PlaceholderContext.PlaceholderType.LIST_VALUE, msg.getPlaceholderContext().getType());
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(17, msg.getLocation().getStartLine());
             assertEquals(17, msg.getLocation().getEndLine());
         }
-        
+
         @Test
         @DisplayName("should include exact position for invalid language - based on test-errors.adoc line 25")
         void shouldIncludeExactPositionForInvalidLanguage() {
             // Given - Based on test-errors.adoc line 25: [source,invalidlang]
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test-errors.adoc");
-            
+
             ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .allowed(Arrays.asList("java", "python", "yaml", "bash"))
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .allowed(Arrays.asList("java", "python", "yaml", "bash")).severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.ERROR).build();
+
             // Mock source location for line 25
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(25);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.hasAttribute("language")).thenReturn(true);
             when(mockBlock.getAttribute("language")).thenReturn("invalidlang");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("listing.language.allowed", msg.getRuleId());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(25, msg.getLocation().getStartLine());
             assertEquals(25, msg.getLocation().getEndLine());
         }
-        
+
         @Test
         @DisplayName("should pass when language is allowed")
         void shouldPassWhenLanguageIsAllowed() {
             // Given
             ListingBlock.LanguageConfig languageConfig = ListingBlock.LanguageConfig.builder()
-                .allowed(Arrays.asList("java", "python"))
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .language(languageConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .allowed(Arrays.asList("java", "python")).severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().language(languageConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("language")).thenReturn(true);
             when(mockBlock.getAttribute("language")).thenReturn("java");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("title validation")
     class TitleValidation {
-        
+
         @Test
         @DisplayName("should validate required title")
         void shouldValidateRequiredTitle() {
             // Given
-            ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .title(titleConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().title(titleConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("listing.title.required", msg.getRuleId());
             assertEquals("Listing block must have a title", msg.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate title pattern")
         void shouldValidateTitlePattern() {
             // Given
             ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder()
-                .pattern(Pattern.compile("^Listing \\d+:.*"))
-                .severity(Severity.INFO)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .title(titleConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile("^Listing \\d+:.*")).severity(Severity.INFO).build();
+            ListingBlock config = ListingBlock.builder().title(titleConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getTitle()).thenReturn("Code Example");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -380,81 +334,67 @@ class ListingBlockValidatorTest {
             assertEquals("Code Example", msg.getActualValue().orElse(null));
             assertEquals("Pattern: ^Listing \\d+:.*", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use title severity over block severity")
         void shouldUseTitleSeverityOverBlockSeverity() {
             // Given - title has INFO, block has ERROR
-            ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder()
-                .required(true)
-                .severity(Severity.INFO)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .title(titleConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder().required(true)
+                    .severity(Severity.INFO).build();
+            ListingBlock config = ListingBlock.builder().title(titleConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use title severity (INFO) instead of block severity (ERROR)");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use title severity (INFO) instead of block severity (ERROR)");
         }
-        
+
         @Test
         @DisplayName("should use block severity when title severity is not defined")
         void shouldUseBlockSeverityWhenTitleSeverityNotDefined() {
             // Given - title has no severity, block has WARN
-            ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder()
-                .required(true)
-                // No severity set
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .title(titleConfig)
-                .severity(Severity.WARN)
-                .build();
-            
+            ListingBlock.TitleConfig titleConfig = ListingBlock.TitleConfig.builder().required(true)
+                    // No severity set
+                    .build();
+            ListingBlock config = ListingBlock.builder().title(titleConfig).severity(Severity.WARN).build();
+
             when(mockBlock.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use block severity (WARN) when title severity is not defined");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use block severity (WARN) when title severity is not defined");
             assertEquals("listing.title.required", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("callouts validation")
     class CalloutsValidation {
-        
+
         @Test
         @DisplayName("should validate callouts not allowed")
         void shouldValidateCalloutsNotAllowed() {
             // Given
-            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder()
-                .allowed(false)
-                .severity(Severity.WARN)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .callouts(calloutsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder().allowed(false)
+                    .severity(Severity.WARN).build();
+            ListingBlock config = ListingBlock.builder().callouts(calloutsConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("public class Test { // <1>\n    // code\n}");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -464,99 +404,79 @@ class ListingBlockValidatorTest {
             assertEquals("1 callouts", msg.getActualValue().orElse(null));
             assertEquals("No callouts allowed", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use callouts severity over block severity")
         void shouldUseCalloutsSeverityOverBlockSeverity() {
             // Given - callouts has WARN, block has ERROR
-            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder()
-                .allowed(false)
-                .severity(Severity.WARN)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .callouts(calloutsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder().allowed(false)
+                    .severity(Severity.WARN).build();
+            ListingBlock config = ListingBlock.builder().callouts(calloutsConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("public class Test { // <1>\n    // code\n}");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use callouts severity (WARN) instead of block severity (ERROR)");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use callouts severity (WARN) instead of block severity (ERROR)");
         }
-        
+
         @Test
         @DisplayName("should use block severity when callouts severity is not defined")
         void shouldUseBlockSeverityWhenCalloutsSeverityNotDefined() {
             // Given - callouts has no severity, block has ERROR
-            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder()
-                .allowed(false)
-                // No severity set
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .callouts(calloutsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder().allowed(false)
+                    // No severity set
+                    .build();
+            ListingBlock config = ListingBlock.builder().callouts(calloutsConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("public class Test { // <1>\n    // code\n}");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.ERROR, msg.getSeverity(), 
-                "Should use block severity (ERROR) when callouts severity is not defined");
+            assertEquals(Severity.ERROR, msg.getSeverity(),
+                    "Should use block severity (ERROR) when callouts severity is not defined");
             assertEquals("listing.callouts.notAllowed", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should allow callouts when allowed is true")
         void shouldAllowCalloutsWhenAllowedIsTrue() {
             // Given
-            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder()
-                .allowed(true)
-                .severity(Severity.WARN)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .callouts(calloutsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder().allowed(true)
+                    .severity(Severity.WARN).build();
+            ListingBlock config = ListingBlock.builder().callouts(calloutsConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("public class Test { // <1>\n    // code\n}");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // Callouts allowed
         }
-        
+
         @Test
         @DisplayName("should validate maximum callout count")
         void shouldValidateMaximumCalloutCount() {
             // Given
-            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder()
-                .allowed(true)
-                .max(2)
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .callouts(calloutsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder().allowed(true).max(2)
+                    .severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().callouts(calloutsConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("code // <1>\nmore // <2>\nagain // <3>");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -566,29 +486,23 @@ class ListingBlockValidatorTest {
             assertEquals("At most 2 callouts", msg.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("lines validation")
     class LinesValidation {
-        
+
         @Test
         @DisplayName("should validate minimum lines")
         void shouldValidateMinimumLines() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(5)
-                .severity(Severity.INFO)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            LineConfig lineConfig = LineConfig.builder().min(5).severity(Severity.INFO).build();
+            ListingBlock config = ListingBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("line1\nline2\nline3");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -598,30 +512,24 @@ class ListingBlockValidatorTest {
             assertEquals("3", msg.getActualValue().orElse(null));
             assertEquals("At least 5 lines", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate maximum lines")
         void shouldValidateMaximumLines() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .max(50)
-                .severity(Severity.WARN)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            LineConfig lineConfig = LineConfig.builder().max(50).severity(Severity.WARN).build();
+            ListingBlock config = ListingBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
+
             // Create content with 51 lines
             StringBuilder content = new StringBuilder();
             for (int i = 1; i <= 51; i++) {
                 content.append("line ").append(i).append("\n");
             }
             when(mockBlock.getContent()).thenReturn(content.toString());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -632,88 +540,69 @@ class ListingBlockValidatorTest {
             assertEquals("At most 50 lines", msg.getExpectedValue().orElse(null));
         }
     }
-    
+
     @Nested
     @DisplayName("complex validation scenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple rules together")
         void shouldValidateMultipleRules() {
             // Given
             ListingBlock config = ListingBlock.builder()
-                .language(ListingBlock.LanguageConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("java", "python"))
-                    .severity(Severity.ERROR)
-                    .build())
-                .title(ListingBlock.TitleConfig.builder()
-                    .required(true)
-                    .severity(Severity.WARN)
-                    .build())
-                .lines(LineConfig.builder()
-                    .max(10)
-                    .severity(Severity.INFO)
-                    .build())
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .language(ListingBlock.LanguageConfig.builder().required(true)
+                            .allowed(Arrays.asList("java", "python")).severity(Severity.ERROR).build())
+                    .title(ListingBlock.TitleConfig.builder().required(true).severity(Severity.WARN).build())
+                    .lines(LineConfig.builder().max(10).severity(Severity.INFO).build()).severity(Severity.ERROR)
+                    .build();
+
             when(mockBlock.hasAttribute("language")).thenReturn(true);
             when(mockBlock.getAttribute("language")).thenReturn("javascript"); // Not allowed
             when(mockBlock.getTitle()).thenReturn(null); // Missing
-            when(mockBlock.getContent()).thenReturn("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11"); // Too long
-            
+            when(mockBlock.getContent())
+                    .thenReturn("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11"); // Too
+                                                                                                                  // long
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(3, messages.size());
             assertTrue(messages.stream().anyMatch(m -> "listing.language.allowed".equals(m.getRuleId())));
             assertTrue(messages.stream().anyMatch(m -> "listing.title.required".equals(m.getRuleId())));
             assertTrue(messages.stream().anyMatch(m -> "listing.lines.max".equals(m.getRuleId())));
         }
-        
+
         @Test
         @DisplayName("should handle empty content")
         void shouldHandleEmptyContent() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(1)
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            LineConfig lineConfig = LineConfig.builder().min(1).severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("0", messages.get(0).getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle null content")
         void shouldHandleNullContent() {
             // Given
-            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder()
-                .allowed(false)
-                .severity(Severity.ERROR)
-                .build();
-            ListingBlock config = ListingBlock.builder()
-                .callouts(calloutsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            ListingBlock.CalloutsConfig calloutsConfig = ListingBlock.CalloutsConfig.builder().allowed(false)
+                    .severity(Severity.ERROR).build();
+            ListingBlock config = ListingBlock.builder().callouts(calloutsConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // No content means no callouts
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/LiteralBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/LiteralBlockValidatorTest.java
@@ -25,57 +25,52 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 class LiteralBlockValidatorTest {
-    
+
     private LiteralBlockValidator validator;
-    
+
     @Mock
     private Block mockBlock;
-    
+
     @Mock
     private BlockValidationContext mockContext;
-    
+
     @Mock
     private SourceLocation mockLocation;
-    
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         validator = new LiteralBlockValidator();
-        
+
         // Default setup
         when(mockContext.createLocation(any())).thenReturn(mockLocation);
         when(mockContext.getFilename()).thenReturn("test.adoc");
         when(mockBlock.getContent()).thenReturn("Line 1\nLine 2");
         when(mockBlock.getSourceLocation()).thenReturn(null);
     }
-    
+
     @Test
     @DisplayName("should return LITERAL as supported type")
     void shouldReturnLiteralAsSupportedType() {
         assertEquals(BlockType.LITERAL, validator.getSupportedType());
     }
-    
+
     @Nested
     @DisplayName("Title Validation")
     class TitleValidationTests {
-        
+
         @Test
         @DisplayName("should validate required title when missing")
         void shouldValidateRequiredTitleWhenMissing() {
             // Given
             when(mockBlock.getTitle()).thenReturn(null);
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .title(TitleConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .title(TitleConfig.builder().required(true).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -83,25 +78,19 @@ class LiteralBlockValidatorTest {
             assertEquals("literal.title.required", message.getRuleId());
             assertEquals("Literal block requires a title", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate title min length")
         void shouldValidateTitleMinLength() {
             // Given
             when(mockBlock.getTitle()).thenReturn("Hi");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .title(TitleConfig.builder()
-                    .required(false)
-                    .minLength(5)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .title(TitleConfig.builder().required(false).minLength(5).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -110,98 +99,79 @@ class LiteralBlockValidatorTest {
             assertEquals("2 characters", message.getActualValue().orElse(null));
             assertEquals("At least 5 characters", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate title max length")
         void shouldValidateTitleMaxLength() {
             // Given
             when(mockBlock.getTitle()).thenReturn("This is a very long title that exceeds the maximum allowed length");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .title(TitleConfig.builder()
-                    .maxLength(50)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .title(TitleConfig.builder().maxLength(50).severity(Severity.INFO).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.INFO, message.getSeverity());
             assertEquals("literal.title.maxLength", message.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should pass when title is valid")
         void shouldPassWhenTitleIsValid() {
             // Given
             when(mockBlock.getTitle()).thenReturn("Valid Title");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .title(TitleConfig.builder()
-                    .required(false)
-                    .minLength(5)
-                    .maxLength(50)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO).title(
+                    TitleConfig.builder().required(false).minLength(5).maxLength(50).severity(Severity.INFO).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should use block severity when title severity is null")
         void shouldUseBlockSeverityWhenTitleSeverityIsNull() {
             // Given
             when(mockBlock.getTitle()).thenReturn(null);
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.WARN)
-                .title(TitleConfig.builder()
-                    .required(true)
-                    .severity(null) // No severity specified
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.WARN)
+                    .title(TitleConfig.builder().required(true).severity(null) // No severity specified
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Lines Validation")
     class LinesValidationTests {
-        
+
         @Test
         @DisplayName("should validate min lines")
         void shouldValidateMinLines() {
             // Given
             when(mockBlock.getContent()).thenReturn("Line 1");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .lines(LinesConfig.builder()
-                    .min(3)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .lines(LinesConfig.builder().min(3).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -210,7 +180,7 @@ class LiteralBlockValidatorTest {
             assertEquals("1 lines", message.getActualValue().orElse(null));
             assertEquals("At least 3 lines", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate max lines")
         void shouldValidateMaxLines() {
@@ -218,22 +188,18 @@ class LiteralBlockValidatorTest {
             // Create a string with 60 lines
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < 60; i++) {
-                if (i > 0) sb.append("\n");
+                if (i > 0)
+                    sb.append("\n");
                 sb.append("Line");
             }
             when(mockBlock.getContent()).thenReturn(sb.toString());
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .lines(LinesConfig.builder()
-                    .max(50)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .lines(LinesConfig.builder().max(50).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -242,75 +208,60 @@ class LiteralBlockValidatorTest {
             assertEquals("60 lines", message.getActualValue().orElse(null));
             assertEquals("At most 50 lines", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle content fallback when lines are null")
         void shouldHandleContentFallbackWhenLinesAreNull() {
             // Given
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2\nLine 3");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .lines(LinesConfig.builder()
-                    .min(1)
-                    .max(5)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .lines(LinesConfig.builder().min(1).max(5).severity(Severity.INFO).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // 3 lines is within 1-5 range
         }
     }
-    
+
     @Nested
     @DisplayName("Indentation Validation")
     class IndentationValidationTests {
-        
+
         @Test
         @DisplayName("should skip validation when not required")
         void shouldSkipValidationWhenNotRequired() {
             // Given
             when(mockBlock.getContent()).thenReturn("  Line 1\n    Line 2");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .indentation(IndentationConfig.builder()
-                    .required(false)
-                    .consistent(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO).indentation(
+                    IndentationConfig.builder().required(false).consistent(true).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @org.junit.jupiter.api.Disabled("Skipping for now - indentation validation not working as expected")
         @DisplayName("should validate min spaces")
         void shouldValidateMinSpaces() {
             // Given
             when(mockBlock.getContent()).thenReturn("Line 1\n  Line 2");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .minSpaces(2)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .indentation(
+                            IndentationConfig.builder().required(true).minSpaces(2).severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size(), "Expected 1 validation message, but got " + messages.size());
             if (!messages.isEmpty()) {
@@ -322,25 +273,21 @@ class LiteralBlockValidatorTest {
                 assertEquals("At least 2 spaces", message.getExpectedValue().orElse(null));
             }
         }
-        
+
         @Test
         @DisplayName("should validate max spaces")
         void shouldValidateMaxSpaces() {
             // Given
             when(mockBlock.getContent()).thenReturn("    Line 1\n          Line 2");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .maxSpaces(8)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .indentation(
+                            IndentationConfig.builder().required(true).maxSpaces(8).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -350,30 +297,22 @@ class LiteralBlockValidatorTest {
             assertEquals("10 spaces", message.getActualValue().orElse(null));
             assertEquals("At most 8 spaces", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate consistent indentation")
         void shouldValidateConsistentIndentation() {
             // Given
-            when(mockBlock.getContent()).thenReturn(
-                "  Line 1\n" +
-                "  Line 2\n" +
-                "    Line 3\n" +  // Inconsistent
-                "  Line 4"
-            );
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .consistent(true)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+            when(mockBlock.getContent()).thenReturn("  Line 1\n" + "  Line 2\n" + "    Line 3\n" + // Inconsistent
+                    "  Line 4");
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .indentation(
+                            IndentationConfig.builder().required(true).consistent(true).severity(Severity.INFO).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -383,229 +322,165 @@ class LiteralBlockValidatorTest {
             assertEquals("4 spaces", message.getActualValue().orElse(null));
             assertEquals("2 spaces (consistent with first non-empty line)", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should skip empty lines for indentation check")
         void shouldSkipEmptyLinesForIndentationCheck() {
             // Given
-            when(mockBlock.getContent()).thenReturn(
-                "  Line 1\n" +
-                "\n" +              // Empty line
-                "  Line 2\n" +
-                "   \n" +           // Whitespace only
-                "  Line 3"
-            );
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .consistent(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+            when(mockBlock.getContent()).thenReturn("  Line 1\n" + "\n" + // Empty line
+                    "  Line 2\n" + "   \n" + // Whitespace only
+                    "  Line 3");
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO).indentation(
+                    IndentationConfig.builder().required(true).consistent(true).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // All non-empty lines have consistent 2-space indentation
         }
-        
+
         @Test
         @DisplayName("should count tabs as 4 spaces")
         void shouldCountTabsAs4Spaces() {
             // Given
-            when(mockBlock.getContent()).thenReturn(
-                "\tLine 1\n" +      // 1 tab = 4 spaces
-                "    Line 2"         // 4 spaces
+            when(mockBlock.getContent()).thenReturn("\tLine 1\n" + // 1 tab = 4 spaces
+                    "    Line 2" // 4 spaces
             );
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .consistent(true)
-                    .minSpaces(4)
-                    .maxSpaces(4)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO).indentation(IndentationConfig.builder()
+                    .required(true).consistent(true).minSpaces(4).maxSpaces(4).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // Both lines have 4 spaces of indentation
         }
     }
-    
+
     @Nested
     @DisplayName("Integration Tests")
     class IntegrationTests {
-        
+
         @Test
         @DisplayName("should validate all rules together")
         void shouldValidateAllRulesTogether() {
             // Given
             when(mockBlock.getTitle()).thenReturn("Valid Config");
-            when(mockBlock.getContent()).thenReturn(
-                "  server:\n" +
-                "    host: localhost\n" +
-                "    port: 8080\n" +
-                "    timeout: 30s"
-            );
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .name("Literal Block")
-                .severity(Severity.INFO)
-                .title(TitleConfig.builder()
-                    .required(false)
-                    .minLength(5)
-                    .maxLength(50)
-                    .severity(Severity.INFO)
-                    .build())
-                .lines(LinesConfig.builder()
-                    .min(1)
-                    .max(50)
-                    .severity(Severity.WARN)
-                    .build())
-                .indentation(IndentationConfig.builder()
-                    .required(false)
-                    .consistent(true)
-                    .minSpaces(0)
-                    .maxSpaces(8)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+            when(mockBlock.getContent())
+                    .thenReturn("  server:\n" + "    host: localhost\n" + "    port: 8080\n" + "    timeout: 30s");
+
+            LiteralBlock config = LiteralBlock.builder().name("Literal Block").severity(Severity.INFO)
+                    .title(TitleConfig.builder().required(false).minLength(5).maxLength(50).severity(Severity.INFO)
+                            .build())
+                    .lines(LinesConfig.builder().min(1).max(50).severity(Severity.WARN).build())
+                    .indentation(IndentationConfig.builder().required(false).consistent(true).minSpaces(0).maxSpaces(8)
+                            .severity(Severity.INFO).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should collect multiple validation errors")
         void shouldCollectMultipleValidationErrors() {
             // Given
             when(mockBlock.getTitle()).thenReturn("Hi"); // Too short
             when(mockBlock.getContent()).thenReturn("Line"); // Too few lines
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.INFO)
-                .title(TitleConfig.builder()
-                    .minLength(5)
-                    .severity(Severity.ERROR)
-                    .build())
-                .lines(LinesConfig.builder()
-                    .min(3)
-                    .severity(Severity.WARN)
-                    .build())
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .minSpaces(2)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.INFO)
+                    .title(TitleConfig.builder().minLength(5).severity(Severity.ERROR).build())
+                    .lines(LinesConfig.builder().min(3).severity(Severity.WARN).build())
+                    .indentation(
+                            IndentationConfig.builder().required(true).minSpaces(2).severity(Severity.INFO).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(3, messages.size());
-            
+
             // Verify different severities
             assertTrue(messages.stream().anyMatch(m -> m.getSeverity() == Severity.ERROR));
             assertTrue(messages.stream().anyMatch(m -> m.getSeverity() == Severity.WARN));
             assertTrue(messages.stream().anyMatch(m -> m.getSeverity() == Severity.INFO));
         }
     }
-    
+
     @Nested
     @DisplayName("Severity Hierarchy Tests")
     class SeverityHierarchyTests {
-        
+
         @Test
         @DisplayName("should use nested severity when specified for all configs")
         void shouldUseNestedSeverityWhenSpecified() {
             // Given
             when(mockBlock.getTitle()).thenReturn("Hi");
             when(mockBlock.getContent()).thenReturn("Line");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.ERROR) // Block severity
-                .title(TitleConfig.builder()
-                    .minLength(5)
-                    .severity(Severity.INFO) // Override with INFO
-                    .build())
-                .lines(LinesConfig.builder()
-                    .min(2)
-                    .severity(Severity.WARN) // Override with WARN
-                    .build())
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .minSpaces(2)
-                    .severity(Severity.ERROR) // Keep ERROR
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.ERROR) // Block severity
+                    .title(TitleConfig.builder().minLength(5).severity(Severity.INFO) // Override with INFO
+                            .build())
+                    .lines(LinesConfig.builder().min(2).severity(Severity.WARN) // Override with WARN
+                            .build())
+                    .indentation(IndentationConfig.builder().required(true).minSpaces(2).severity(Severity.ERROR) // Keep
+                                                                                                                  // ERROR
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(3, messages.size());
-            
+
             // Title validation should use INFO
             ValidationMessage titleMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("literal.title.minLength"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("literal.title.minLength")).findFirst().orElseThrow();
             assertEquals(Severity.INFO, titleMessage.getSeverity());
-            
+
             // Lines validation should use WARN
-            ValidationMessage linesMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("literal.lines.min"))
-                .findFirst().orElseThrow();
+            ValidationMessage linesMessage = messages.stream().filter(m -> m.getRuleId().equals("literal.lines.min"))
+                    .findFirst().orElseThrow();
             assertEquals(Severity.WARN, linesMessage.getSeverity());
-            
+
             // Indentation validation should use ERROR
             ValidationMessage indentMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("literal.indentation.minSpaces"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("literal.indentation.minSpaces")).findFirst().orElseThrow();
             assertEquals(Severity.ERROR, indentMessage.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should fallback to block severity when nested severity is null")
         void shouldFallbackToBlockSeverityWhenNull() {
             // Given
             when(mockBlock.getTitle()).thenReturn(null);
             when(mockBlock.getContent()).thenReturn("Line");
-            
-            LiteralBlock config = LiteralBlock.builder()
-                .severity(Severity.WARN) // Block severity
-                .title(TitleConfig.builder()
-                    .required(true)
-                    .severity(null) // No severity specified
-                    .build())
-                .lines(LinesConfig.builder()
-                    .min(2)
-                    .severity(null) // No severity specified
-                    .build())
-                .indentation(IndentationConfig.builder()
-                    .required(true)
-                    .minSpaces(2)
-                    .severity(null) // No severity specified
-                    .build())
-                .build();
-            
+
+            LiteralBlock config = LiteralBlock.builder().severity(Severity.WARN) // Block severity
+                    .title(TitleConfig.builder().required(true).severity(null) // No severity specified
+                            .build())
+                    .lines(LinesConfig.builder().min(2).severity(null) // No severity specified
+                            .build())
+                    .indentation(IndentationConfig.builder().required(true).minSpaces(2).severity(null) // No severity
+                                                                                                        // specified
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(3, messages.size());
-            
+
             // All messages should use block severity (WARN)
             assertTrue(messages.stream().allMatch(m -> m.getSeverity() == Severity.WARN));
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/ParagraphBlockValidatorTest.java
@@ -26,36 +26,40 @@ import org.asciidoctor.ast.Cursor;
 
 /**
  * Unit tests for {@link ParagraphBlockValidator}.
- * 
- * <p>This test class validates the behavior of the paragraph block validator,
- * which processes text paragraph blocks in AsciiDoc documents. The tests focus
- * on line count validation rules including minimum and maximum constraints.</p>
- * 
- * <p>Test scenarios include:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the paragraph block validator, which processes text paragraph blocks in
+ * AsciiDoc documents. The tests focus on line count validation rules including minimum and maximum constraints.
+ * </p>
+ *
+ * <p>
+ * Test scenarios include:
+ * </p>
  * <ul>
- *   <li>Basic validator functionality</li>
- *   <li>Line count validation (min/max)</li>
- *   <li>Empty and null content handling</li>
- *   <li>Non-empty line counting logic</li>
- *   <li>Content extraction from nested blocks</li>
- *   <li>Severity hierarchy with fallback to block severity</li>
+ * <li>Basic validator functionality</li>
+ * <li>Line count validation (min/max)</li>
+ * <li>Empty and null content handling</li>
+ * <li>Non-empty line counting logic</li>
+ * <li>Content extraction from nested blocks</li>
+ * <li>Severity hierarchy with fallback to block severity</li>
  * </ul>
- * 
- * <p>The validator counts only non-empty lines, ignoring blank lines and
- * lines containing only whitespace.</p>
- * 
+ *
+ * <p>
+ * The validator counts only non-empty lines, ignoring blank lines and lines containing only whitespace.
+ * </p>
+ *
  * @see ParagraphBlockValidator
  * @see ParagraphBlock
  * @see LineConfig
  */
 @DisplayName("ParagraphBlockValidator")
 class ParagraphBlockValidatorTest {
-    
+
     private ParagraphBlockValidator validator;
     private BlockValidationContext context;
     private StructuralNode mockBlock;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new ParagraphBlockValidator();
@@ -63,54 +67,46 @@ class ParagraphBlockValidatorTest {
         context = new BlockValidationContext(mockSection, "test.adoc");
         mockBlock = mock(StructuralNode.class);
     }
-    
+
     @Test
     @DisplayName("should return PARAGRAPH as supported type")
     void shouldReturnParagraphAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.PARAGRAPH, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when no line config")
         void shouldReturnEmptyListWhenNoLineConfig() {
             // Given
-            ParagraphBlock config = ParagraphBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
+            ParagraphBlock config = ParagraphBlock.builder().severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn("Some content");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate minimum lines")
         void shouldValidateMinimumLines() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(3)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
+            LineConfig lineConfig = LineConfig.builder().min(3).severity(Severity.ERROR).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -120,62 +116,50 @@ class ParagraphBlockValidatorTest {
             assertEquals("2", msg.getActualValue().orElse(null));
             assertEquals("At least 3 lines", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should include placeholder and exact position for too few lines - based on test-errors.adoc line 11")
         void shouldIncludePlaceholderForTooFewLines() {
             // Given - Based on test-errors.adoc line 11: "This section has a paragraph without any errors."
             BlockValidationContext testContext = new BlockValidationContext(mockSection, "test-errors.adoc");
-            
-            LineConfig lineConfig = LineConfig.builder()
-                .min(2)
-                .severity(Severity.INFO)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+
+            LineConfig lineConfig = LineConfig.builder().min(2).severity(Severity.INFO).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
+
             // Mock source location
             Cursor mockCursor = mock(Cursor.class);
             when(mockCursor.getLineNumber()).thenReturn(11);
             when(mockBlock.getSourceLocation()).thenReturn(mockCursor);
             when(mockBlock.getContent()).thenReturn("This section has a paragraph without any errors.");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, testContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("paragraph.lines.min", msg.getRuleId());
             assertEquals(ErrorType.MISSING_VALUE, msg.getErrorType());
             assertEquals("Add more content here...", msg.getMissingValueHint());
-            
+
             // Without file content, validator falls back to column 1
             assertEquals(1, msg.getLocation().getStartColumn());
             assertEquals(1, msg.getLocation().getEndColumn());
             assertEquals(11, msg.getLocation().getStartLine());
             assertEquals(11, msg.getLocation().getEndLine());
         }
-        
+
         @Test
         @DisplayName("should validate maximum lines")
         void shouldValidateMaximumLines() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .max(2)
-                .severity(Severity.WARN)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
+            LineConfig lineConfig = LineConfig.builder().max(2).severity(Severity.WARN).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2\nLine 3");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -185,176 +169,135 @@ class ParagraphBlockValidatorTest {
             assertEquals("3", msg.getActualValue().orElse(null));
             assertEquals("At most 2 lines", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use block severity when lines severity is not defined")
         void shouldUseBlockSeverityWhenLinesSeverityNotDefined() {
             // Given - lines has no severity, block has INFO
-            LineConfig lineConfig = LineConfig.builder()
-                .max(2)
-                // No severity set
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.INFO)
-                .build();
-            
+            LineConfig lineConfig = LineConfig.builder().max(2)
+                    // No severity set
+                    .build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.INFO).build();
+
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2\nLine 3");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use block severity (INFO) when lines severity is not defined");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use block severity (INFO) when lines severity is not defined");
             assertEquals("paragraph.lines.max", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should pass when lines within range")
         void shouldPassWhenLinesWithinRange() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(2)
-                .max(5)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
+            LineConfig lineConfig = LineConfig.builder().min(2).max(5).severity(Severity.ERROR).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn("Line 1\nLine 2\nLine 3");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should count only non-empty lines")
         void shouldCountOnlyNonEmptyLines() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(2)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
+            LineConfig lineConfig = LineConfig.builder().min(2).severity(Severity.ERROR).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn("Line 1\n\n  \nLine 2");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // 2 non-empty lines, meets minimum
         }
-        
+
         @Test
         @DisplayName("should handle empty content")
         void shouldHandleEmptyContent() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(1)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
+            LineConfig lineConfig = LineConfig.builder().min(1).severity(Severity.ERROR).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn("");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("0", messages.get(0).getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle null content")
         void shouldHandleNullContent() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(1)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
+            LineConfig lineConfig = LineConfig.builder().min(1).severity(Severity.ERROR).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
             when(mockBlock.getContent()).thenReturn(null);
             when(mockBlock.getBlocks()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("0", messages.get(0).getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should get content from blocks when direct content is null")
         void shouldGetContentFromBlocksWhenDirectContentIsNull() {
             // Given
-            LineConfig lineConfig = LineConfig.builder()
-                .min(1)
-                .severity(Severity.ERROR)
-                .build();
-            ParagraphBlock config = ParagraphBlock.builder()
-                .lines(lineConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            LineConfig lineConfig = LineConfig.builder().min(1).severity(Severity.ERROR).build();
+            ParagraphBlock config = ParagraphBlock.builder().lines(lineConfig).severity(Severity.ERROR).build();
+
             StructuralNode childBlock = mock(StructuralNode.class);
             when(childBlock.getContent()).thenReturn("Child content");
             when(mockBlock.getContent()).thenReturn(null);
             when(mockBlock.getBlocks()).thenReturn(Arrays.asList(childBlock));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // Has content from child
         }
     }
-    
+
     @Nested
     @DisplayName("sentence validation")
     class SentenceValidation {
-        
+
         @Nested
         @DisplayName("sentence occurrence")
         class SentenceOccurrence {
-            
+
             @Test
             @DisplayName("should validate minimum sentence count")
             void shouldValidateMinimumSentenceCount() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(3)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.WARN)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(3).severity(Severity.ERROR).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.WARN)
+                        .build();
+
                 // Content with only 2 sentences
                 when(mockBlock.getContent()).thenReturn("This is the first sentence. This is the second sentence.");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 ValidationMessage msg = messages.get(0);
@@ -364,28 +307,22 @@ class ParagraphBlockValidatorTest {
                 assertEquals("2", msg.getActualValue().orElse(null));
                 assertEquals("At least 3 sentences", msg.getExpectedValue().orElse(null));
             }
-            
+
             @Test
             @DisplayName("should validate maximum sentence count")
             void shouldValidateMaximumSentenceCount() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .max(2)
-                        .severity(Severity.WARN)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().max(2).severity(Severity.WARN).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 // Content with 3 sentences
                 when(mockBlock.getContent()).thenReturn("First sentence. Second sentence. Third sentence.");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 ValidationMessage msg = messages.get(0);
@@ -395,85 +332,70 @@ class ParagraphBlockValidatorTest {
                 assertEquals("3", msg.getActualValue().orElse(null));
                 assertEquals("At most 2 sentences", msg.getExpectedValue().orElse(null));
             }
-            
+
             @Test
             @DisplayName("should use block severity when occurrence severity is not defined")
             void shouldUseBlockSeverityWhenOccurrenceSeverityNotDefined() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(2)
-                        // No severity set
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.INFO)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(2)
+                                // No severity set
+                                .build())
+                        .build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.INFO)
+                        .build();
+
                 when(mockBlock.getContent()).thenReturn("Only one sentence here.");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 ValidationMessage msg = messages.get(0);
-                assertEquals(Severity.INFO, msg.getSeverity(), 
-                    "Should use block severity (INFO) when occurrence severity is not defined");
+                assertEquals(Severity.INFO, msg.getSeverity(),
+                        "Should use block severity (INFO) when occurrence severity is not defined");
             }
-            
+
             @Test
             @DisplayName("should handle empty content with minimum sentences required")
             void shouldHandleEmptyContentWithMinimumSentencesRequired() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(1)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(1).severity(Severity.ERROR).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 when(mockBlock.getContent()).thenReturn("");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 assertEquals("0", messages.get(0).getActualValue().orElse(null));
             }
         }
-        
+
         @Nested
         @DisplayName("words per sentence")
         class WordsPerSentence {
-            
+
             @Test
             @DisplayName("should validate minimum words per sentence")
             void shouldValidateMinimumWordsPerSentence() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .words(ParagraphBlock.WordsConfig.builder()
-                        .min(5)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.WARN)
-                    .build();
-                
+                        .words(ParagraphBlock.WordsConfig.builder().min(5).severity(Severity.ERROR).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.WARN)
+                        .build();
+
                 // First sentence has only 3 words, second has 5
                 when(mockBlock.getContent()).thenReturn("Too short sentence. This sentence has five words.");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 ValidationMessage msg = messages.get(0);
@@ -483,28 +405,23 @@ class ParagraphBlockValidatorTest {
                 assertEquals("3 words", msg.getActualValue().orElse(null));
                 assertEquals("At least 5 words", msg.getExpectedValue().orElse(null));
             }
-            
+
             @Test
             @DisplayName("should validate maximum words per sentence")
             void shouldValidateMaximumWordsPerSentence() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .words(ParagraphBlock.WordsConfig.builder()
-                        .max(8)
-                        .severity(Severity.WARN)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .words(ParagraphBlock.WordsConfig.builder().max(8).severity(Severity.WARN).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 // Sentence with 10 words
-                when(mockBlock.getContent()).thenReturn("This sentence has way too many words for the configured maximum limit.");
-                
+                when(mockBlock.getContent())
+                        .thenReturn("This sentence has way too many words for the configured maximum limit.");
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 ValidationMessage msg = messages.get(0);
@@ -514,213 +431,168 @@ class ParagraphBlockValidatorTest {
                 assertEquals("12 words", msg.getActualValue().orElse(null));
                 assertEquals("At most 8 words", msg.getExpectedValue().orElse(null));
             }
-            
+
             @Test
             @DisplayName("should use block severity when words severity is not defined")
             void shouldUseBlockSeverityWhenWordsSeverityNotDefined() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .words(ParagraphBlock.WordsConfig.builder()
-                        .min(5)
-                        // No severity set
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.INFO)
-                    .build();
-                
+                        .words(ParagraphBlock.WordsConfig.builder().min(5)
+                                // No severity set
+                                .build())
+                        .build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.INFO)
+                        .build();
+
                 when(mockBlock.getContent()).thenReturn("Short.");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(1, messages.size());
                 ValidationMessage msg = messages.get(0);
-                assertEquals(Severity.INFO, msg.getSeverity(), 
-                    "Should use block severity (INFO) when words severity is not defined");
+                assertEquals(Severity.INFO, msg.getSeverity(),
+                        "Should use block severity (INFO) when words severity is not defined");
             }
-            
+
             @Test
             @DisplayName("should validate multiple sentences for word count")
             void shouldValidateMultipleSentencesForWordCount() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .words(ParagraphBlock.WordsConfig.builder()
-                        .min(4)
-                        .max(8)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .words(ParagraphBlock.WordsConfig.builder().min(4).max(8).severity(Severity.ERROR).build())
+                        .build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 // Mix of valid and invalid sentences
-                when(mockBlock.getContent()).thenReturn(
-                    "Too short. " + // 2 words - too few
-                    "This sentence is just right. " + // 5 words - OK
-                    "This sentence has way too many words to be considered valid." // 12 words - too many
+                when(mockBlock.getContent()).thenReturn("Too short. " + // 2 words - too few
+                        "This sentence is just right. " + // 5 words - OK
+                        "This sentence has way too many words to be considered valid." // 12 words - too many
                 );
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(2, messages.size());
-                assertTrue(messages.stream().anyMatch(m -> 
-                    m.getMessage().equals("Sentence 1 has too few words")));
-                assertTrue(messages.stream().anyMatch(m -> 
-                    m.getMessage().equals("Sentence 3 has too many words")));
+                assertTrue(messages.stream().anyMatch(m -> m.getMessage().equals("Sentence 1 has too few words")));
+                assertTrue(messages.stream().anyMatch(m -> m.getMessage().equals("Sentence 3 has too many words")));
             }
         }
-        
+
         @Nested
         @DisplayName("sentence detection")
         class SentenceDetection {
-            
+
             @Test
             @DisplayName("should detect sentences with different punctuation")
             void shouldDetectSentencesWithDifferentPunctuation() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(3)
-                        .max(3)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(3).max(3).severity(Severity.ERROR).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 // Content with period, question mark, and exclamation mark
                 when(mockBlock.getContent()).thenReturn("This is a statement. Is this a question? This is exciting!");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertTrue(messages.isEmpty()); // Exactly 3 sentences
             }
-            
+
             @Test
             @DisplayName("should handle multi-line sentences")
             void shouldHandleMultiLineSentences() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(2)
-                        .max(2)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(2).max(2).severity(Severity.ERROR).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 // Content with sentences spanning multiple lines
-                when(mockBlock.getContent()).thenReturn(
-                    "This is a long sentence that\nspans multiple lines\nbut is still one sentence. " +
-                    "This is\nanother sentence."
-                );
-                
+                when(mockBlock.getContent())
+                        .thenReturn("This is a long sentence that\nspans multiple lines\nbut is still one sentence. "
+                                + "This is\nanother sentence.");
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertTrue(messages.isEmpty()); // Exactly 2 sentences
             }
-            
+
             @Test
             @DisplayName("should treat content without sentence ending as one sentence")
             void shouldTreatContentWithoutSentenceEndingAsOneSentence() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(1)
-                        .max(1)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(1).max(1).severity(Severity.ERROR).build()).build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.ERROR)
+                        .build();
+
                 // Content without sentence-ending punctuation
                 when(mockBlock.getContent()).thenReturn("This is content without proper punctuation");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertTrue(messages.isEmpty()); // Treated as 1 sentence
             }
         }
-        
+
         @Nested
         @DisplayName("complex sentence validation")
         class ComplexSentenceValidation {
-            
+
             @Test
             @DisplayName("should validate both occurrence and words constraints")
             void shouldValidateBothOccurrenceAndWordsConstraints() {
                 // Given
                 ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
-                    .occurrence(OccurrenceConfig.builder()
-                        .min(2)
-                        .max(4)
-                        .severity(Severity.WARN)
-                        .build())
-                    .words(ParagraphBlock.WordsConfig.builder()
-                        .min(5)
-                        .max(10)
-                        .severity(Severity.ERROR)
-                        .build())
-                    .build();
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .sentence(sentenceConfig)
-                    .severity(Severity.INFO)
-                    .build();
-                
+                        .occurrence(OccurrenceConfig.builder().min(2).max(4).severity(Severity.WARN).build())
+                        .words(ParagraphBlock.WordsConfig.builder().min(5).max(10).severity(Severity.ERROR).build())
+                        .build();
+                ParagraphBlock config = ParagraphBlock.builder().sentence(sentenceConfig).severity(Severity.INFO)
+                        .build();
+
                 // One sentence with too few words, one with too many
-                when(mockBlock.getContent()).thenReturn(
-                    "Short. " + // 1 word - too few
-                    "This sentence has way too many words and should trigger a validation error for exceeding the limit." // 17 words - too many
+                when(mockBlock.getContent()).thenReturn("Short. " + // 1 word - too few
+                        "This sentence has way too many words and should trigger a validation error for exceeding the limit." // 17
+                                                                                                                              // words
+                                                                                                                              // -
+                                                                                                                              // too
+                                                                                                                              // many
                 );
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertEquals(2, messages.size());
                 // Check word violations (should use ERROR severity)
-                assertTrue(messages.stream().anyMatch(m -> 
-                    m.getRuleId().equals("paragraph.sentence.words.min") &&
-                    m.getSeverity() == Severity.ERROR));
-                assertTrue(messages.stream().anyMatch(m -> 
-                    m.getRuleId().equals("paragraph.sentence.words.max") &&
-                    m.getSeverity() == Severity.ERROR));
+                assertTrue(messages.stream().anyMatch(m -> m.getRuleId().equals("paragraph.sentence.words.min")
+                        && m.getSeverity() == Severity.ERROR));
+                assertTrue(messages.stream().anyMatch(m -> m.getRuleId().equals("paragraph.sentence.words.max")
+                        && m.getSeverity() == Severity.ERROR));
             }
-            
+
             @Test
             @DisplayName("should handle no sentence config gracefully")
             void shouldHandleNoSentenceConfigGracefully() {
                 // Given
-                ParagraphBlock config = ParagraphBlock.builder()
-                    .severity(Severity.ERROR)
-                    .build();
-                
+                ParagraphBlock config = ParagraphBlock.builder().severity(Severity.ERROR).build();
+
                 when(mockBlock.getContent()).thenReturn("Some content with sentences. Another sentence here.");
-                
+
                 // When
                 List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-                
+
                 // Then
                 assertTrue(messages.isEmpty()); // No sentence validation performed
             }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/PassBlockValidatorTest.java
@@ -27,65 +27,57 @@ import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 class PassBlockValidatorTest {
-    
+
     private PassBlockValidator validator;
-    
+
     @Mock
     private StructuralNode mockBlock;
-    
+
     @Mock
     private BlockValidationContext mockContext;
-    
+
     private SourceLocation mockLocation;
-    
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         validator = new PassBlockValidator();
-        
+
         // Mock context filename
         when(mockContext.getFilename()).thenReturn("test.adoc");
-        
+
         // Create a proper location object instead of mocking it
-        mockLocation = SourceLocation.builder()
-                .filename("test.adoc")
-                .startLine(10)
-                .build();
-        
+        mockLocation = SourceLocation.builder().filename("test.adoc").startLine(10).build();
+
         // Default setup
         when(mockContext.createLocation(any())).thenReturn(mockLocation);
         when(mockContext.createLocation(any(), anyInt(), anyInt())).thenReturn(mockLocation);
         when(mockBlock.getContent()).thenReturn("<div>Test content</div>");
         when(mockBlock.getSourceLocation()).thenReturn(null);
     }
-    
+
     @Test
     @DisplayName("should return PASS as supported type")
     void shouldReturnPassAsSupportedType() {
         assertEquals(BlockType.PASS, validator.getSupportedType());
     }
-    
+
     @Nested
     @DisplayName("Type Validation")
     class TypeValidationTests {
-        
+
         @Test
         @DisplayName("should validate required type when missing")
         void shouldValidateRequiredTypeWhenMissing() {
             // Given
             when(mockBlock.getAttribute("type")).thenReturn(null);
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .type(TypeConfig.builder().required(true).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -93,25 +85,19 @@ class PassBlockValidatorTest {
             assertEquals("pass.type.required", message.getRuleId());
             assertEquals("Pass block requires a type", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate allowed types")
         void shouldValidateAllowedTypes() {
             // Given
             when(mockBlock.getAttribute("type")).thenReturn("javascript");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("html", "xml", "svg"))
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR).type(TypeConfig.builder().required(true)
+                    .allowed(Arrays.asList("html", "xml", "svg")).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -120,98 +106,79 @@ class PassBlockValidatorTest {
             assertEquals("javascript", message.getActualValue().orElse(null));
             assertTrue(message.getExpectedValue().orElse("").contains("html, xml, svg"));
         }
-        
+
         @Test
         @DisplayName("should pass when type is valid")
         void shouldPassWhenTypeIsValid() {
             // Given
             when(mockBlock.getAttribute("type")).thenReturn("html");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("html", "xml", "svg"))
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR).type(TypeConfig.builder().required(true)
+                    .allowed(Arrays.asList("html", "xml", "svg")).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should use block severity when type severity is null")
         void shouldUseBlockSeverityWhenTypeSeverityIsNull() {
             // Given
             when(mockBlock.getAttribute("type")).thenReturn(null);
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.WARN)
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .severity(null) // No severity specified
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.WARN)
+                    .type(TypeConfig.builder().required(true).severity(null) // No severity specified
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals(Severity.WARN, messages.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Content Validation")
     class ContentValidationTests {
-        
+
         @Test
         @DisplayName("should validate required content when missing")
         void shouldValidateRequiredContentWhenMissing() {
             // Given
             when(mockBlock.getContent()).thenReturn("");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .content(ContentConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .content(ContentConfig.builder().required(true).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("pass.content.required", message.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should validate max length")
         void shouldValidateMaxLength() {
             // Given
             String longContent = "x".repeat(100);
             when(mockBlock.getContent()).thenReturn(longContent);
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .content(ContentConfig.builder()
-                    .maxLength(50)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .content(ContentConfig.builder().maxLength(50).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -220,72 +187,59 @@ class PassBlockValidatorTest {
             assertEquals("100 characters", message.getActualValue().orElse(null));
             assertEquals("Maximum 50 characters", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate content pattern")
         void shouldValidateContentPattern() {
             // Given
             when(mockBlock.getContent()).thenReturn("<script>alert('bad')</script>");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .content(ContentConfig.builder()
-                    .pattern("^<[^>]+>.*</[^>]+>$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .content(ContentConfig.builder().pattern("^<[^>]+>.*</[^>]+>$").severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // Pattern matches
         }
-        
+
         @Test
         @DisplayName("should fail when content does not match pattern")
         void shouldFailWhenContentDoesNotMatchPattern() {
             // Given
             when(mockBlock.getContent()).thenReturn("plain text");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .content(ContentConfig.builder()
-                    .pattern("^<[^>]+>.*</[^>]+>$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .content(ContentConfig.builder().pattern("^<[^>]+>.*</[^>]+>$").severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("pass.content.pattern", messages.get(0).getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("Reason Validation")
     class ReasonValidationTests {
-        
+
         @Test
         @DisplayName("should validate required reason when missing")
         void shouldValidateRequiredReasonWhenMissing() {
             // Given
             when(mockBlock.getAttribute("reason")).thenReturn(null);
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .reason(ReasonConfig.builder().required(true).severity(Severity.ERROR).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -293,25 +247,20 @@ class PassBlockValidatorTest {
             assertEquals("pass.reason.required", message.getRuleId());
             assertEquals("Pass block requires a reason", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate min length of reason")
         void shouldValidateMinLengthOfReason() {
             // Given
             when(mockBlock.getAttribute("reason")).thenReturn("Too short");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .minLength(20)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .reason(ReasonConfig.builder().required(true).minLength(20).severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -320,61 +269,50 @@ class PassBlockValidatorTest {
             assertEquals("9 characters", message.getActualValue().orElse(null));
             assertEquals("At least 20 characters", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate max length of reason")
         void shouldValidateMaxLengthOfReason() {
             // Given
             String longReason = "This is a very long reason that exceeds the maximum allowed length";
             when(mockBlock.getAttribute("reason")).thenReturn(longReason);
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .maxLength(50)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .reason(ReasonConfig.builder().required(true).maxLength(50).severity(Severity.INFO).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.INFO, message.getSeverity());
             assertEquals("pass.reason.maxLength", message.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should pass when reason is valid")
         void shouldPassWhenReasonIsValid() {
             // Given
             when(mockBlock.getAttribute("reason")).thenReturn("Custom widget for product gallery display");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .minLength(20)
-                    .maxLength(200)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR).reason(
+                    ReasonConfig.builder().required(true).minLength(20).maxLength(200).severity(Severity.ERROR).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Integration Tests")
     class IntegrationTests {
-        
+
         @Test
         @DisplayName("should validate all rules together")
         void shouldValidateAllRulesTogether() {
@@ -382,36 +320,23 @@ class PassBlockValidatorTest {
             when(mockBlock.getAttribute("type")).thenReturn("html");
             when(mockBlock.getAttribute("reason")).thenReturn("Custom widget for product gallery display");
             when(mockBlock.getContent()).thenReturn("<div class=\"product-slider\">Content</div>");
-            
-            PassBlock config = PassBlock.builder()
-                .name("Passthrough Block")
-                .severity(Severity.ERROR)
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("html", "xml", "svg"))
-                    .severity(Severity.ERROR)
-                    .build())
-                .content(ContentConfig.builder()
-                    .required(true)
-                    .maxLength(1000)
-                    .pattern("^<[^>]+>.*</[^>]+>$")
-                    .severity(Severity.ERROR)
-                    .build())
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .minLength(20)
-                    .maxLength(200)
-                    .severity(Severity.ERROR)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().name("Passthrough Block").severity(Severity.ERROR)
+                    .type(TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml", "svg"))
+                            .severity(Severity.ERROR).build())
+                    .content(ContentConfig.builder().required(true).maxLength(1000).pattern("^<[^>]+>.*</[^>]+>$")
+                            .severity(Severity.ERROR).build())
+                    .reason(ReasonConfig.builder().required(true).minLength(20).maxLength(200).severity(Severity.ERROR)
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should collect multiple validation errors")
         void shouldCollectMultipleValidationErrors() {
@@ -419,41 +344,30 @@ class PassBlockValidatorTest {
             when(mockBlock.getAttribute("type")).thenReturn(null);
             when(mockBlock.getAttribute("reason")).thenReturn("Short");
             when(mockBlock.getContent()).thenReturn("");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR)
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .severity(Severity.ERROR)
-                    .build())
-                .content(ContentConfig.builder()
-                    .required(true)
-                    .severity(Severity.WARN)
-                    .build())
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .minLength(20)
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR)
+                    .type(TypeConfig.builder().required(true).severity(Severity.ERROR).build())
+                    .content(ContentConfig.builder().required(true).severity(Severity.WARN).build())
+                    .reason(ReasonConfig.builder().required(true).minLength(20).severity(Severity.INFO).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(3, messages.size());
-            
+
             // Verify different severities
             assertTrue(messages.stream().anyMatch(m -> m.getSeverity() == Severity.ERROR));
             assertTrue(messages.stream().anyMatch(m -> m.getSeverity() == Severity.WARN));
             assertTrue(messages.stream().anyMatch(m -> m.getSeverity() == Severity.INFO));
         }
     }
-    
+
     @Nested
     @DisplayName("Severity Hierarchy Tests")
     class SeverityHierarchyTests {
-        
+
         @Test
         @DisplayName("should use nested severity when specified for all configs")
         void shouldUseNestedSeverityWhenSpecified() {
@@ -461,49 +375,39 @@ class PassBlockValidatorTest {
             when(mockBlock.getAttribute("type")).thenReturn("javascript");
             when(mockBlock.getAttribute("reason")).thenReturn("Short");
             when(mockBlock.getContent()).thenReturn("x".repeat(100));
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.ERROR) // Block severity
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("html", "xml", "svg"))
-                    .severity(Severity.INFO) // Override with INFO
-                    .build())
-                .content(ContentConfig.builder()
-                    .maxLength(50)
-                    .severity(Severity.WARN) // Override with WARN
-                    .build())
-                .reason(ReasonConfig.builder()
-                    .minLength(20)
-                    .severity(Severity.ERROR) // Keep ERROR
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.ERROR) // Block severity
+                    .type(TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml", "svg"))
+                            .severity(Severity.INFO) // Override with INFO
+                            .build())
+                    .content(ContentConfig.builder().maxLength(50).severity(Severity.WARN) // Override with WARN
+                            .build())
+                    .reason(ReasonConfig.builder().minLength(20).severity(Severity.ERROR) // Keep ERROR
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(3, messages.size());
-            
+
             // Type validation should use INFO
-            ValidationMessage typeMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("pass.type.allowed"))
-                .findFirst().orElseThrow();
+            ValidationMessage typeMessage = messages.stream().filter(m -> m.getRuleId().equals("pass.type.allowed"))
+                    .findFirst().orElseThrow();
             assertEquals(Severity.INFO, typeMessage.getSeverity());
-            
+
             // Content validation should use WARN
             ValidationMessage contentMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("pass.content.maxLength"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("pass.content.maxLength")).findFirst().orElseThrow();
             assertEquals(Severity.WARN, contentMessage.getSeverity());
-            
+
             // Reason validation should use ERROR
             ValidationMessage reasonMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("pass.reason.minLength"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("pass.reason.minLength")).findFirst().orElseThrow();
             assertEquals(Severity.ERROR, reasonMessage.getSeverity());
         }
-        
+
         @Test
         @DisplayName("should fallback to block severity when nested severity is null")
         void shouldFallbackToBlockSeverityWhenNull() {
@@ -511,33 +415,26 @@ class PassBlockValidatorTest {
             when(mockBlock.getAttribute("type")).thenReturn(null);
             when(mockBlock.getAttribute("reason")).thenReturn(null);
             when(mockBlock.getContent()).thenReturn("");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.WARN) // Block severity
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .severity(null) // No severity specified
-                    .build())
-                .content(ContentConfig.builder()
-                    .required(true)
-                    .severity(null) // No severity specified
-                    .build())
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .severity(null) // No severity specified
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.WARN) // Block severity
+                    .type(TypeConfig.builder().required(true).severity(null) // No severity specified
+                            .build())
+                    .content(ContentConfig.builder().required(true).severity(null) // No severity specified
+                            .build())
+                    .reason(ReasonConfig.builder().required(true).severity(null) // No severity specified
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(3, messages.size());
-            
+
             // All messages should use block severity (WARN)
             assertTrue(messages.stream().allMatch(m -> m.getSeverity() == Severity.WARN));
         }
-        
+
         @Test
         @DisplayName("should handle mixed severity configurations")
         void shouldHandleMixedSeverityConfigurations() {
@@ -545,30 +442,23 @@ class PassBlockValidatorTest {
             when(mockBlock.getAttribute("type")).thenReturn("invalid");
             when(mockBlock.getAttribute("reason")).thenReturn("Valid reason for using pass block");
             when(mockBlock.getContent()).thenReturn("<div>Valid content</div>");
-            
-            PassBlock config = PassBlock.builder()
-                .severity(Severity.INFO) // Block severity
-                .type(TypeConfig.builder()
-                    .required(true)
-                    .allowed(Arrays.asList("html", "xml"))
-                    .severity(Severity.ERROR) // Override type severity
-                    .build())
-                .content(ContentConfig.builder()
-                    .required(true)
-                    .severity(null) // Use block severity
-                    .build())
-                .reason(ReasonConfig.builder()
-                    .required(true)
-                    .severity(null) // Use block severity
-                    .build())
-                .build();
-            
+
+            PassBlock config = PassBlock.builder().severity(Severity.INFO) // Block severity
+                    .type(TypeConfig.builder().required(true).allowed(Arrays.asList("html", "xml"))
+                            .severity(Severity.ERROR) // Override type severity
+                            .build())
+                    .content(ContentConfig.builder().required(true).severity(null) // Use block severity
+                            .build())
+                    .reason(ReasonConfig.builder().required(true).severity(null) // Use block severity
+                            .build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, mockContext);
-            
+
             // Then
             assertEquals(1, messages.size()); // Only type validation fails
-            
+
             ValidationMessage message = messages.get(0);
             assertEquals("pass.type.allowed", message.getRuleId());
             assertEquals(Severity.ERROR, message.getSeverity()); // Uses nested severity

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/QuoteBlockValidatorTest.java
@@ -23,30 +23,30 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("QuoteBlockValidator Tests")
 class QuoteBlockValidatorTest {
-    
+
     private QuoteBlockValidator validator;
     private StructuralNode mockNode;
     private BlockValidationContext mockContext;
-    
+
     @BeforeEach
     void setUp() {
         validator = new QuoteBlockValidator();
         mockNode = mock(StructuralNode.class);
         mockContext = mock(BlockValidationContext.class);
-        
+
         // Mock the location creation
         SourceLocation mockLocation = mock(SourceLocation.class);
         when(mockContext.createLocation(any(StructuralNode.class))).thenReturn(mockLocation);
         when(mockContext.getFilename()).thenReturn("test.adoc");
         when(mockNode.getSourceLocation()).thenReturn(null);
     }
-    
+
     @Test
     @DisplayName("should return QUOTE block type")
     void shouldReturnCorrectBlockType() {
         assertEquals(BlockType.QUOTE, validator.getSupportedType());
     }
-    
+
     @Test
     @DisplayName("should return empty list for non-quote block config")
     void shouldReturnEmptyListForNonQuoteBlock() {
@@ -54,417 +54,329 @@ class QuoteBlockValidatorTest {
         List<ValidationMessage> results = validator.validate(mockNode, nonQuoteBlock, mockContext);
         assertTrue(results.isEmpty());
     }
-    
+
     @Nested
     @DisplayName("Author Validation Tests")
     class AttributionValidationTests {
-        
+
         @Test
         @DisplayName("should validate required author when missing")
         void shouldValidateRequiredAuthorWhenMissing() {
             when(mockNode.getAttribute("author")).thenReturn(null);
             when(mockNode.getAttribute("attribution")).thenReturn(null);
             when(mockNode.getAttribute("1")).thenReturn(null);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .severity(Severity.ERROR)
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().required(true).severity(Severity.ERROR).build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.ERROR, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("Quote attribution is required but not provided"));
         }
-        
+
         @Test
         @DisplayName("should validate author min length")
         void shouldValidateAuthorMinLength() {
             when(mockNode.getAttribute("author")).thenReturn("AB");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .minLength(3)
-                            .build())
-                    .build();
-            
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().minLength(3).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.WARN, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("too short"));
             assertTrue(results.get(0).getMessage().contains("minimum 3"));
             assertTrue(results.get(0).getMessage().contains("found 2"));
         }
-        
+
         @Test
         @DisplayName("should validate author max length")
         void shouldValidateAuthorMaxLength() {
             String longAuthor = "A".repeat(101);
             when(mockNode.getAttribute("author")).thenReturn(longAuthor);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.INFO)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .maxLength(100)
-                            .severity(Severity.ERROR)
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.INFO)
+                    .attribution(QuoteBlock.AttributionConfig.builder().maxLength(100).severity(Severity.ERROR).build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.ERROR, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("too long"));
             assertTrue(results.get(0).getMessage().contains("maximum 100"));
             assertTrue(results.get(0).getMessage().contains("found 101"));
         }
-        
+
         @Test
         @DisplayName("should validate author pattern")
         void shouldValidateAuthorPattern() {
             when(mockNode.getAttribute("author")).thenReturn("123 Invalid");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$").build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("Quote attribution does not match required pattern"));
             assertEquals("123 Invalid", results.get(0).getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should accept valid author")
         void shouldAcceptValidAuthor() {
             when(mockNode.getAttribute("author")).thenReturn("John Doe");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .minLength(3)
-                            .maxLength(100)
-                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN).attribution(QuoteBlock.AttributionConfig
+                    .builder().required(true).minLength(3).maxLength(100).pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$").build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertTrue(results.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should check multiple author sources")
         void shouldCheckMultipleAuthorSources() {
             when(mockNode.getAttribute("author")).thenReturn(null);
             when(mockNode.getAttribute("attribution")).thenReturn("Jane Smith");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .build())
-                    .build();
-            
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().required(true).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertTrue(results.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Source Validation Tests")
     class CitationValidationTests {
-        
+
         @Test
         @DisplayName("should validate required source when missing")
         void shouldValidateRequiredSourceWhenMissing() {
             when(mockNode.getAttribute("citetitle")).thenReturn(null);
             when(mockNode.getAttribute("source")).thenReturn(null);
             when(mockNode.getAttribute("2")).thenReturn(null);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .required(true)
-                            .severity(Severity.ERROR)
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .citation(QuoteBlock.CitationConfig.builder().required(true).severity(Severity.ERROR).build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.ERROR, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("Quote citation is required but not provided"));
         }
-        
+
         @Test
         @DisplayName("should validate source pattern")
         void shouldValidateSourcePattern() {
             when(mockNode.getAttribute("citetitle")).thenReturn("Book @ Title #123");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .pattern("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$")
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .citation(QuoteBlock.CitationConfig.builder().pattern("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$").build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("Quote citation does not match required pattern"));
         }
-        
+
         @Test
         @DisplayName("should check multiple source attributes")
         void shouldCheckMultipleSourceAttributes() {
             when(mockNode.getAttribute("citetitle")).thenReturn(null);
             when(mockNode.getAttribute("source")).thenReturn(null);
             when(mockNode.getAttribute("2")).thenReturn("The Great Book");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .required(true)
-                            .minLength(5)
-                            .build())
-                    .build();
-            
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .citation(QuoteBlock.CitationConfig.builder().required(true).minLength(5).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertTrue(results.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Content Validation Tests")
     class ContentValidationTests {
-        
+
         @Test
         @DisplayName("should validate required content when missing")
         void shouldValidateRequiredContentWhenMissing() {
             when(mockNode.getContent()).thenReturn(null);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .content(QuoteBlock.ContentConfig.builder()
-                            .required(true)
-                            .build())
-                    .build();
-            
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder().required(true).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("requires content"));
         }
-        
+
         @Test
         @DisplayName("should validate content min length")
         void shouldValidateContentMinLength() {
             when(mockNode.getContent()).thenReturn("Short");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .content(QuoteBlock.ContentConfig.builder()
-                            .minLength(20)
-                            .build())
-                    .build();
-            
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder().minLength(20).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("too short"));
             assertTrue(results.get(0).getMessage().contains("minimum 20"));
             assertTrue(results.get(0).getMessage().contains("found 5"));
         }
-        
+
         @Test
         @DisplayName("should validate content max length")
         void shouldValidateContentMaxLength() {
             String longContent = "A".repeat(1001);
             when(mockNode.getContent()).thenReturn(longContent);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .content(QuoteBlock.ContentConfig.builder()
-                            .maxLength(1000)
-                            .build())
-                    .build();
-            
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder().maxLength(1000).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("too long"));
             assertTrue(results.get(0).getMessage().contains("maximum 1000"));
             assertTrue(results.get(0).getMessage().contains("found 1001"));
         }
-        
+
         @Test
         @DisplayName("should validate content line count")
         void shouldValidateContentLineCount() {
             String multiLineContent = "Line 1\nLine 2\nLine 3";
             when(mockNode.getContent()).thenReturn(multiLineContent);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
                     .content(QuoteBlock.ContentConfig.builder()
-                            .lines(QuoteBlock.LinesConfig.builder()
-                                    .min(5)
-                                    .severity(Severity.ERROR)
-                                    .build())
-                            .build())
+                            .lines(QuoteBlock.LinesConfig.builder().min(5).severity(Severity.ERROR).build()).build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.ERROR, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("too few lines"));
             assertTrue(results.get(0).getMessage().contains("minimum 5"));
             assertTrue(results.get(0).getMessage().contains("found 3"));
         }
-        
+
         @Test
         @DisplayName("should validate max line count")
         void shouldValidateMaxLineCount() {
             String manyLines = String.join("\n", "Line".repeat(21).split("(?<=.{4})"));
             when(mockNode.getContent()).thenReturn(manyLines);
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .content(QuoteBlock.ContentConfig.builder()
-                            .lines(QuoteBlock.LinesConfig.builder()
-                                    .max(20)
-                                    .build())
-                            .build())
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN).content(
+                    QuoteBlock.ContentConfig.builder().lines(QuoteBlock.LinesConfig.builder().max(20).build()).build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("too many lines"));
         }
     }
-    
+
     @Nested
     @DisplayName("Severity Hierarchy Tests")
     class SeverityHierarchyTests {
-        
+
         @Test
         @DisplayName("should use nested severity over block severity")
         void shouldUseNestedSeverityOverBlockSeverity() {
             when(mockNode.getAttribute("author")).thenReturn("AB");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.INFO)  // Block level
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .minLength(3)
-                            .severity(Severity.ERROR)  // Nested level
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.INFO) // Block level
+                    .attribution(QuoteBlock.AttributionConfig.builder().minLength(3).severity(Severity.ERROR) // Nested
+                                                                                                              // level
                             .build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.ERROR, results.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should fall back to block severity when nested not specified")
         void shouldFallBackToBlockSeverity() {
             when(mockNode.getAttribute("source")).thenReturn("AB");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)  // Block level
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .minLength(3)
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN) // Block level
+                    .citation(QuoteBlock.CitationConfig.builder().minLength(3)
                             // No severity specified
                             .build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(1, results.size());
             assertEquals(Severity.WARN, results.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Integration Tests")
     class IntegrationTests {
-        
+
         @Test
         @DisplayName("should validate complete quote block")
         void shouldValidateCompleteQuoteBlock() {
             when(mockNode.getAttribute("author")).thenReturn("Albert Einstein");
             when(mockNode.getAttribute("citetitle")).thenReturn("Theory of Relativity");
-            when(mockNode.getContent()).thenReturn("Imagination is more important than knowledge. " +
-                    "Knowledge is limited. Imagination embraces the entire world, stimulating progress, giving birth to evolution.");
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.INFO)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .required(true)
-                            .minLength(3)
-                            .maxLength(100)
-                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
-                            .severity(Severity.ERROR)
-                            .build())
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .required(false)
-                            .minLength(5)
-                            .maxLength(200)
-                            .build())
-                    .content(QuoteBlock.ContentConfig.builder()
-                            .required(true)
-                            .minLength(20)
-                            .maxLength(1000)
-                            .lines(QuoteBlock.LinesConfig.builder()
-                                    .min(1)
-                                    .max(20)
-                                    .build())
-                            .build())
+            when(mockNode.getContent()).thenReturn("Imagination is more important than knowledge. "
+                    + "Knowledge is limited. Imagination embraces the entire world, stimulating progress, giving birth to evolution.");
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.INFO)
+                    .attribution(QuoteBlock.AttributionConfig.builder().required(true).minLength(3).maxLength(100)
+                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$").severity(Severity.ERROR).build())
+                    .citation(QuoteBlock.CitationConfig.builder().required(false).minLength(5).maxLength(200).build())
+                    .content(QuoteBlock.ContentConfig.builder().required(true).minLength(20).maxLength(1000)
+                            .lines(QuoteBlock.LinesConfig.builder().min(1).max(20).build()).build())
                     .build();
-            
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertTrue(results.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should collect multiple validation errors")
         void shouldCollectMultipleValidationErrors() {
-            when(mockNode.getAttribute("author")).thenReturn("a");  // Too short
-            when(mockNode.getAttribute("citetitle")).thenReturn("b");  // Too short
-            when(mockNode.getContent()).thenReturn("Short");  // Too short
-            
-            QuoteBlock block = QuoteBlock.builder()
-                    .severity(Severity.WARN)
-                    .attribution(QuoteBlock.AttributionConfig.builder()
-                            .minLength(3)
-                            .build())
-                    .citation(QuoteBlock.CitationConfig.builder()
-                            .minLength(5)
-                            .build())
-                    .content(QuoteBlock.ContentConfig.builder()
-                            .minLength(20)
-                            .build())
-                    .build();
-            
+            when(mockNode.getAttribute("author")).thenReturn("a"); // Too short
+            when(mockNode.getAttribute("citetitle")).thenReturn("b"); // Too short
+            when(mockNode.getContent()).thenReturn("Short"); // Too short
+
+            QuoteBlock block = QuoteBlock.builder().severity(Severity.WARN)
+                    .attribution(QuoteBlock.AttributionConfig.builder().minLength(3).build())
+                    .citation(QuoteBlock.CitationConfig.builder().minLength(5).build())
+                    .content(QuoteBlock.ContentConfig.builder().minLength(20).build()).build();
+
             List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
-            
+
             assertEquals(3, results.size());
             assertTrue(results.stream().allMatch(r -> r.getSeverity() == Severity.WARN));
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/SidebarBlockValidatorTest.java
@@ -23,418 +23,339 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("SidebarBlockValidator")
 class SidebarBlockValidatorTest {
-    
+
     private SidebarBlockValidator validator;
     private BlockValidationContext context;
-    
+
     @Mock
     private StructuralNode node;
-    
+
     @Mock
     private Section section;
-    
+
     @Mock
     private Cursor sourceLocation;
-    
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         validator = new SidebarBlockValidator();
         context = new BlockValidationContext(section, "test.adoc");
     }
-    
+
     @Test
     @DisplayName("should support SIDEBAR block type")
     void shouldSupportSidebarBlockType() {
         assertEquals(BlockType.SIDEBAR, validator.getSupportedType());
     }
-    
+
     @Nested
     @DisplayName("Title validation")
     class TitleValidation {
-        
+
         @Test
         @DisplayName("should pass when title is not configured")
         void shouldPassWhenTitleNotConfigured() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertTrue(results.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when required title is missing")
         void shouldFailWhenRequiredTitleMissing() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .title(SidebarBlock.TitleConfig.builder()
-                    .required(true)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .title(SidebarBlock.TitleConfig.builder().required(true).build()).build();
+
             when(node.getTitle()).thenReturn(null);
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertEquals(Severity.ERROR, results.get(0).getSeverity());
             assertEquals("Sidebar block requires a title", results.get(0).getMessage());
             assertEquals(10, results.get(0).getLocation().getStartLine());
         }
-        
+
         @Test
         @DisplayName("should use title severity when specified")
         void shouldUseTitleSeverityWhenSpecified() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .title(SidebarBlock.TitleConfig.builder()
-                    .required(true)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .title(SidebarBlock.TitleConfig.builder().required(true).severity(Severity.WARN).build()).build();
+
             when(node.getTitle()).thenReturn(null);
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertEquals(Severity.WARN, results.get(0).getSeverity());
         }
-        
+
         @Test
         @DisplayName("should validate title length")
         void shouldValidateTitleLength() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .title(SidebarBlock.TitleConfig.builder()
-                    .minLength(5)
-                    .maxLength(10)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .title(SidebarBlock.TitleConfig.builder().minLength(5).maxLength(10).build()).build();
+
             when(node.getTitle()).thenReturn("abc");
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("too short"));
             assertEquals("3 characters", results.get(0).getActualValue().get());
         }
-        
+
         @Test
         @DisplayName("should validate title pattern")
         void shouldValidateTitlePattern() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .title(SidebarBlock.TitleConfig.builder()
-                    .pattern("^[A-Z].*$")
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .title(SidebarBlock.TitleConfig.builder().pattern("^[A-Z].*$").build()).build();
+
             when(node.getTitle()).thenReturn("lowercase");
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("does not match required pattern"));
         }
-        
+
         @Test
         @DisplayName("should pass valid title")
         void shouldPassValidTitle() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .title(SidebarBlock.TitleConfig.builder()
-                    .required(true)
-                    .minLength(5)
-                    .maxLength(50)
-                    .pattern("^[A-Z].*$")
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .title(SidebarBlock.TitleConfig.builder().required(true).minLength(5).maxLength(50)
+                            .pattern("^[A-Z].*$").build())
+                    .build();
+
             when(node.getTitle()).thenReturn("Valid Title");
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertTrue(results.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Content validation")
     class ContentValidation {
-        
+
         @Test
         @DisplayName("should pass when content is not configured")
         void shouldPassWhenContentNotConfigured() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertTrue(results.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when required content is missing")
         void shouldFailWhenRequiredContentMissing() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .content(SidebarBlock.ContentConfig.builder()
-                    .required(true)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .content(SidebarBlock.ContentConfig.builder().required(true).build()).build();
+
             when(node.getContent()).thenReturn(null);
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertEquals("Sidebar block requires content", results.get(0).getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate content length")
         void shouldValidateContentLength() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .content(SidebarBlock.ContentConfig.builder()
-                    .minLength(50)
-                    .maxLength(100)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .content(SidebarBlock.ContentConfig.builder().minLength(50).maxLength(100).build()).build();
+
             when(node.getContent()).thenReturn("Short content");
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertTrue(results.get(0).getMessage().contains("too short"));
         }
-        
+
         @Test
         @DisplayName("should validate line count")
         void shouldValidateLineCount() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .content(SidebarBlock.ContentConfig.builder()
-                    .lines(SidebarBlock.LinesConfig.builder()
-                        .min(3)
-                        .max(5)
-                        .severity(Severity.WARN)
-                        .build())
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .content(SidebarBlock.ContentConfig.builder()
+                            .lines(SidebarBlock.LinesConfig.builder().min(3).max(5).severity(Severity.WARN).build())
+                            .build())
+                    .build();
+
             when(node.getContent()).thenReturn("Line 1");
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertEquals(Severity.WARN, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("too few lines"));
         }
-        
+
         @Test
         @DisplayName("should pass valid content")
         void shouldPassValidContent() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .content(SidebarBlock.ContentConfig.builder()
-                    .required(true)
-                    .minLength(10)
-                    .maxLength(100)
-                    .lines(SidebarBlock.LinesConfig.builder()
-                        .min(1)
-                        .max(5)
-                        .build())
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .content(SidebarBlock.ContentConfig.builder().required(true).minLength(10).maxLength(100)
+                            .lines(SidebarBlock.LinesConfig.builder().min(1).max(5).build()).build())
+                    .build();
+
             when(node.getContent()).thenReturn("This is valid sidebar content\nWith multiple lines");
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertTrue(results.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Position validation")
     class PositionValidation {
-        
+
         @Test
         @DisplayName("should pass when position is not configured")
         void shouldPassWhenPositionNotConfigured() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertTrue(results.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when required position is missing")
         void shouldFailWhenRequiredPositionMissing() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .position(SidebarBlock.PositionConfig.builder()
-                    .required(true)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .position(SidebarBlock.PositionConfig.builder().required(true).build()).build();
+
             when(node.getAttribute("position")).thenReturn(null);
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertEquals("Sidebar block requires a position attribute", results.get(0).getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate allowed positions")
         void shouldValidateAllowedPositions() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .position(SidebarBlock.PositionConfig.builder()
-                    .allowed(List.of("left", "right", "float"))
-                    .severity(Severity.INFO)
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .position(SidebarBlock.PositionConfig.builder().allowed(List.of("left", "right", "float"))
+                            .severity(Severity.INFO).build())
+                    .build();
+
             when(node.getAttribute("position")).thenReturn("center");
             when(node.getSourceLocation()).thenReturn(sourceLocation);
             when(sourceLocation.getLineNumber()).thenReturn(10);
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertEquals(1, results.size());
             assertEquals(Severity.INFO, results.get(0).getSeverity());
             assertTrue(results.get(0).getMessage().contains("Invalid sidebar position"));
             assertEquals("center", results.get(0).getActualValue().get());
         }
-        
+
         @Test
         @DisplayName("should pass valid position")
         void shouldPassValidPosition() {
             // Given
-            SidebarBlock config = SidebarBlock.builder()
-                .name("test")
-                .severity(Severity.ERROR)
-                .position(SidebarBlock.PositionConfig.builder()
-                    .required(true)
-                    .allowed(List.of("left", "right", "float"))
-                    .build())
-                .build();
-            
+            SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                    .position(SidebarBlock.PositionConfig.builder().required(true)
+                            .allowed(List.of("left", "right", "float")).build())
+                    .build();
+
             when(node.getAttribute("position")).thenReturn("left");
-            
+
             // When
             List<ValidationMessage> results = validator.validate(node, config, context);
-            
+
             // Then
             assertTrue(results.isEmpty());
         }
     }
-    
+
     @Test
     @DisplayName("should handle null node gracefully")
     void shouldHandleNullNodeGracefully() {
         // Given
-        SidebarBlock config = SidebarBlock.builder()
-            .name("test")
-            .severity(Severity.ERROR)
-            .title(SidebarBlock.TitleConfig.builder().required(true).build())
-            .content(SidebarBlock.ContentConfig.builder().required(true).build())
-            .position(SidebarBlock.PositionConfig.builder().required(true).build())
-            .build();
-        
+        SidebarBlock config = SidebarBlock.builder().name("test").severity(Severity.ERROR)
+                .title(SidebarBlock.TitleConfig.builder().required(true).build())
+                .content(SidebarBlock.ContentConfig.builder().required(true).build())
+                .position(SidebarBlock.PositionConfig.builder().required(true).build()).build();
+
         when(node.getTitle()).thenReturn(null);
         when(node.getContent()).thenReturn(null);
         when(node.getAttribute("position")).thenReturn(null);
         when(node.getSourceLocation()).thenReturn(null);
-        
+
         // When
         List<ValidationMessage> results = validator.validate(node, config, context);
-        
+
         // Then
         assertEquals(3, results.size());
         assertTrue(results.stream().allMatch(r -> r.getLocation().getStartLine() == 1));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/TableBlockValidatorTest.java
@@ -28,37 +28,41 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
  * Unit tests for {@link TableBlockValidator}.
- * 
- * <p>This test class validates the behavior of the table block validator,
- * which processes table structures in AsciiDoc documents. The tests cover
- * comprehensive validation rules for table dimensions, headers, captions,
- * and formatting options.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the table block validator, which processes table structures in AsciiDoc
+ * documents. The tests cover comprehensive validation rules for table dimensions, headers, captions, and formatting
+ * options.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality and type checking</li>
- *   <li>ColumnsValidation - Column count constraints and severity hierarchy</li>
- *   <li>RowsValidation - Row count constraints and severity hierarchy</li>
- *   <li>HeaderValidation - Header requirements and pattern matching</li>
- *   <li>CaptionValidation - Caption requirements, patterns, and length constraints</li>
- *   <li>FormatValidation - Table formatting options (style, borders)</li>
+ * <li>Validate - Basic validator functionality and type checking</li>
+ * <li>ColumnsValidation - Column count constraints and severity hierarchy</li>
+ * <li>RowsValidation - Row count constraints and severity hierarchy</li>
+ * <li>HeaderValidation - Header requirements and pattern matching</li>
+ * <li>CaptionValidation - Caption requirements, patterns, and length constraints</li>
+ * <li>FormatValidation - Table formatting options (style, borders)</li>
  * </ul>
- * 
- * <p>Each nested test class includes severity hierarchy tests to verify that
- * nested configuration severity overrides block-level severity when specified,
- * and falls back to block severity when not specified.</p>
- * 
+ *
+ * <p>
+ * Each nested test class includes severity hierarchy tests to verify that nested configuration severity overrides
+ * block-level severity when specified, and falls back to block severity when not specified.
+ * </p>
+ *
  * @see TableBlockValidator
  * @see TableBlock
  */
 @DisplayName("TableBlockValidator")
 class TableBlockValidatorTest {
-    
+
     private TableBlockValidator validator;
     private BlockValidationContext context;
     private Table mockTable;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new TableBlockValidator();
@@ -66,77 +70,68 @@ class TableBlockValidatorTest {
         context = new BlockValidationContext(mockSection, "test.adoc");
         mockTable = mock(Table.class);
     }
-    
+
     @Test
     @DisplayName("should return TABLE as supported type")
     void shouldReturnTableAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.TABLE, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when table is not Table instance")
         void shouldReturnEmptyListWhenNotTableInstance() {
             // Given
             StructuralNode notATable = mock(StructuralNode.class);
-            TableBlock config = TableBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock config = TableBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notATable, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            TableBlock config = TableBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock config = TableBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("columns validation")
     class ColumnsValidation {
-        
+
         @Test
         @DisplayName("should validate minimum columns")
         void shouldValidateMinimumColumns() {
             // Given
-            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder()
-                .min(3)
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .columns(columnsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder().min(3)
+                    .severity(Severity.ERROR).build();
+            TableBlock config = TableBlock.builder().columns(columnsConfig).severity(Severity.ERROR).build();
+
             Column col1 = mock(Column.class);
             Column col2 = mock(Column.class);
             when(mockTable.getColumns()).thenReturn(Arrays.asList(col1, col2));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -146,115 +141,96 @@ class TableBlockValidatorTest {
             assertEquals("2", msg.getActualValue().orElse(null));
             assertEquals("At least 3 columns", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate maximum columns")
         void shouldValidateMaximumColumns() {
             // Given
-            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder()
-                .max(2)
-                .severity(Severity.WARN)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .columns(columnsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder().max(2)
+                    .severity(Severity.WARN).build();
+            TableBlock config = TableBlock.builder().columns(columnsConfig).severity(Severity.ERROR).build();
+
             Column col1 = mock(Column.class);
             Column col2 = mock(Column.class);
             Column col3 = mock(Column.class);
             when(mockTable.getColumns()).thenReturn(Arrays.asList(col1, col2, col3));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals(Severity.WARN, msg.getSeverity());
             assertEquals("table.columns.max", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should use columns severity over block severity")
         void shouldUseColumnsSeverityOverBlockSeverity() {
             // Given - columns has WARN, block has ERROR
-            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder()
-                .min(3)
-                .severity(Severity.WARN)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .columns(columnsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder().min(3)
+                    .severity(Severity.WARN).build();
+            TableBlock config = TableBlock.builder().columns(columnsConfig).severity(Severity.ERROR).build();
+
             Column col1 = mock(Column.class);
             when(mockTable.getColumns()).thenReturn(Collections.singletonList(col1));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use columns severity (WARN) instead of block severity (ERROR)");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use columns severity (WARN) instead of block severity (ERROR)");
             assertEquals("table.columns.min", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should use block severity when columns severity is not defined")
         void shouldUseBlockSeverityWhenColumnsSeverityNotDefined() {
             // Given - columns has no severity, block has INFO
-            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder()
-                .min(3)
-                // No severity set
-                .build();
-            TableBlock config = TableBlock.builder()
-                .columns(columnsConfig)
-                .severity(Severity.INFO)
-                .build();
-            
+            TableBlock.DimensionConfig columnsConfig = TableBlock.DimensionConfig.builder().min(3)
+                    // No severity set
+                    .build();
+            TableBlock config = TableBlock.builder().columns(columnsConfig).severity(Severity.INFO).build();
+
             Column col1 = mock(Column.class);
             when(mockTable.getColumns()).thenReturn(Collections.singletonList(col1));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use block severity (INFO) when columns severity is not defined");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use block severity (INFO) when columns severity is not defined");
             assertEquals("table.columns.min", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("rows validation")
     class RowsValidation {
-        
+
         @Test
         @DisplayName("should validate minimum rows")
         void shouldValidateMinimumRows() {
             // Given
-            TableBlock.DimensionConfig rowsConfig = TableBlock.DimensionConfig.builder()
-                .min(5)
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .rows(rowsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.DimensionConfig rowsConfig = TableBlock.DimensionConfig.builder().min(5).severity(Severity.ERROR)
+                    .build();
+            TableBlock config = TableBlock.builder().rows(rowsConfig).severity(Severity.ERROR).build();
+
             Row row1 = mock(Row.class);
             Row row2 = mock(Row.class);
             Row row3 = mock(Row.class);
             when(mockTable.getBody()).thenReturn(Arrays.asList(row1, row2, row3));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -263,82 +239,68 @@ class TableBlockValidatorTest {
             assertEquals("3", msg.getActualValue().orElse(null));
             assertEquals("At least 5 rows", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use rows severity over block severity")
         void shouldUseRowsSeverityOverBlockSeverity() {
             // Given - rows has INFO, block has ERROR
-            TableBlock.DimensionConfig rowsConfig = TableBlock.DimensionConfig.builder()
-                .min(5)
-                .severity(Severity.INFO)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .rows(rowsConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.DimensionConfig rowsConfig = TableBlock.DimensionConfig.builder().min(5).severity(Severity.INFO)
+                    .build();
+            TableBlock config = TableBlock.builder().rows(rowsConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getBody()).thenReturn(Collections.emptyList());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use rows severity (INFO) instead of block severity (ERROR)");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use rows severity (INFO) instead of block severity (ERROR)");
             assertEquals("table.rows.min", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should use block severity when rows severity is not defined")
         void shouldUseBlockSeverityWhenRowsSeverityNotDefined() {
             // Given - rows has no severity, block has WARN
-            TableBlock.DimensionConfig rowsConfig = TableBlock.DimensionConfig.builder()
-                .min(5)
-                // No severity set
-                .build();
-            TableBlock config = TableBlock.builder()
-                .rows(rowsConfig)
-                .severity(Severity.WARN)
-                .build();
-            
+            TableBlock.DimensionConfig rowsConfig = TableBlock.DimensionConfig.builder().min(5)
+                    // No severity set
+                    .build();
+            TableBlock config = TableBlock.builder().rows(rowsConfig).severity(Severity.WARN).build();
+
             when(mockTable.getBody()).thenReturn(Collections.emptyList());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use block severity (WARN) when rows severity is not defined");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use block severity (WARN) when rows severity is not defined");
             assertEquals("table.rows.min", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("header validation")
     class HeaderValidation {
-        
+
         @Test
         @DisplayName("should validate required header")
         void shouldValidateRequiredHeader() {
             // Given
-            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .header(headerConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+            TableBlock config = TableBlock.builder().header(headerConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getHeader()).thenReturn(Collections.emptyList());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -346,21 +308,15 @@ class TableBlockValidatorTest {
             assertEquals("Table header is required but not provided", msg.getMessage());
             // The validator may or may not set actualValue/expectedValue - don't assert on them
         }
-        
+
         @Test
         @DisplayName("should validate header pattern")
         void shouldValidateHeaderPattern() {
             // Given
-            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder()
-                .required(true)
-                .pattern(Pattern.compile("^[A-Z].*"))
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .header(headerConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder().required(true)
+                    .pattern(Pattern.compile("^[A-Z].*")).severity(Severity.ERROR).build();
+            TableBlock config = TableBlock.builder().header(headerConfig).severity(Severity.ERROR).build();
+
             Row headerRow = mock(Row.class);
             Cell cell1 = mock(Cell.class);
             Cell cell2 = mock(Cell.class);
@@ -368,10 +324,10 @@ class TableBlockValidatorTest {
             when(cell2.getText()).thenReturn("age"); // lowercase - should fail
             when(headerRow.getCells()).thenReturn(Arrays.asList(cell1, cell2));
             when(mockTable.getHeader()).thenReturn(Arrays.asList(headerRow));
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -380,107 +336,88 @@ class TableBlockValidatorTest {
             assertEquals("age", msg.getActualValue().orElse(null));
             assertEquals("Pattern: ^[A-Z].*", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use header severity over block severity")
         void shouldUseHeaderSeverityOverBlockSeverity() {
             // Given - header has WARN, block has ERROR
-            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder()
-                .required(true)
-                .severity(Severity.WARN)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .header(headerConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder().required(true)
+                    .severity(Severity.WARN).build();
+            TableBlock config = TableBlock.builder().header(headerConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getHeader()).thenReturn(Collections.emptyList());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use header severity (WARN) instead of block severity (ERROR)");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use header severity (WARN) instead of block severity (ERROR)");
             assertEquals("table.header.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should use block severity when header severity is not defined")
         void shouldUseBlockSeverityWhenHeaderSeverityNotDefined() {
             // Given - header has no severity, block has ERROR
-            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder()
-                .required(true)
-                // No severity set
-                .build();
-            TableBlock config = TableBlock.builder()
-                .header(headerConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.HeaderConfig headerConfig = TableBlock.HeaderConfig.builder().required(true)
+                    // No severity set
+                    .build();
+            TableBlock config = TableBlock.builder().header(headerConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getHeader()).thenReturn(Collections.emptyList());
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.ERROR, msg.getSeverity(), 
-                "Should use block severity (ERROR) when header severity is not defined");
+            assertEquals(Severity.ERROR, msg.getSeverity(),
+                    "Should use block severity (ERROR) when header severity is not defined");
             assertEquals("table.header.required", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("caption validation")
     class CaptionValidation {
-        
+
         @Test
         @DisplayName("should validate required caption")
         void shouldValidateRequiredCaption() {
             // Given
-            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder()
-                .required(true)
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .caption(captionConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder().required(true)
+                    .severity(Severity.ERROR).build();
+            TableBlock config = TableBlock.builder().caption(captionConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("table.caption.required", msg.getRuleId());
             assertEquals("Table caption is required but not provided", msg.getMessage());
         }
-        
+
         @Test
         @DisplayName("should validate caption min length")
         void shouldValidateCaptionMinLength() {
             // Given
-            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder()
-                .minLength(10)
-                .severity(Severity.WARN)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .caption(captionConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder().minLength(10)
+                    .severity(Severity.WARN).build();
+            TableBlock config = TableBlock.builder().caption(captionConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getTitle()).thenReturn("Short");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -489,25 +426,20 @@ class TableBlockValidatorTest {
             assertEquals("5 characters", msg.getActualValue().orElse(null));
             assertEquals("At least 10 characters", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate caption pattern")
         void shouldValidateCaptionPattern() {
             // Given
             TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder()
-                .pattern(Pattern.compile("^Table \\d+:.*"))
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .caption(captionConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile("^Table \\d+:.*")).severity(Severity.ERROR).build();
+            TableBlock config = TableBlock.builder().caption(captionConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getTitle()).thenReturn("Invalid caption");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -515,82 +447,68 @@ class TableBlockValidatorTest {
             assertEquals("Table caption does not match required pattern", msg.getMessage());
             assertEquals("Invalid caption", msg.getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should use caption severity over block severity")
         void shouldUseCaptionSeverityOverBlockSeverity() {
             // Given - caption has INFO, block has ERROR
-            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder()
-                .required(true)
-                .severity(Severity.INFO)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .caption(captionConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder().required(true)
+                    .severity(Severity.INFO).build();
+            TableBlock config = TableBlock.builder().caption(captionConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use caption severity (INFO) instead of block severity (ERROR)");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use caption severity (INFO) instead of block severity (ERROR)");
             assertEquals("table.caption.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should use block severity when caption severity is not defined")
         void shouldUseBlockSeverityWhenCaptionSeverityNotDefined() {
             // Given - caption has no severity, block has WARN
-            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder()
-                .required(true)
-                // No severity set
-                .build();
-            TableBlock config = TableBlock.builder()
-                .caption(captionConfig)
-                .severity(Severity.WARN)
-                .build();
-            
+            TableBlock.CaptionConfig captionConfig = TableBlock.CaptionConfig.builder().required(true)
+                    // No severity set
+                    .build();
+            TableBlock config = TableBlock.builder().caption(captionConfig).severity(Severity.WARN).build();
+
             when(mockTable.getTitle()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use block severity (WARN) when caption severity is not defined");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use block severity (WARN) when caption severity is not defined");
             assertEquals("table.caption.required", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("format validation")
     class FormatValidation {
-        
+
         @Test
         @DisplayName("should validate table style")
         void shouldValidateTableStyle() {
             // Given
-            TableBlock.FormatConfig formatConfig = TableBlock.FormatConfig.builder()
-                .style("grid")
-                .severity(Severity.INFO)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .format(formatConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.FormatConfig formatConfig = TableBlock.FormatConfig.builder().style("grid")
+                    .severity(Severity.INFO).build();
+            TableBlock config = TableBlock.builder().format(formatConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getAttribute("options")).thenReturn("header,footer");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -599,25 +517,20 @@ class TableBlockValidatorTest {
             assertEquals("header,footer", msg.getActualValue().orElse(null));
             assertEquals("Style: grid", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate table borders")
         void shouldValidateTableBorders() {
             // Given
-            TableBlock.FormatConfig formatConfig = TableBlock.FormatConfig.builder()
-                .borders(true)
-                .severity(Severity.ERROR)
-                .build();
-            TableBlock config = TableBlock.builder()
-                .format(formatConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            TableBlock.FormatConfig formatConfig = TableBlock.FormatConfig.builder().borders(true)
+                    .severity(Severity.ERROR).build();
+            TableBlock config = TableBlock.builder().format(formatConfig).severity(Severity.ERROR).build();
+
             when(mockTable.getAttribute("frame")).thenReturn("none");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockTable, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/UlistBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/UlistBlockValidatorTest.java
@@ -24,31 +24,34 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
  * Unit tests for {@link UlistBlockValidator}.
- * 
- * <p>This test class validates the behavior of the unordered list block validator,
- * which processes ulist blocks in AsciiDoc documents. The tests cover all
- * validation rules including item count, nesting level, and marker style.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the unordered list block validator, which processes ulist blocks in
+ * AsciiDoc documents. The tests cover all validation rules including item count, nesting level, and marker style.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality</li>
- *   <li>ItemsValidation - Item count constraints</li>
- *   <li>NestingLevelValidation - Maximum nesting depth</li>
- *   <li>MarkerStyleValidation - List marker style validation</li>
- *   <li>ComplexScenarios - Combined validation scenarios</li>
+ * <li>Validate - Basic validator functionality</li>
+ * <li>ItemsValidation - Item count constraints</li>
+ * <li>NestingLevelValidation - Maximum nesting depth</li>
+ * <li>MarkerStyleValidation - List marker style validation</li>
+ * <li>ComplexScenarios - Combined validation scenarios</li>
  * </ul>
- * 
+ *
  * @see UlistBlockValidator
  * @see UlistBlock
  */
 @DisplayName("UlistBlockValidator")
 class UlistBlockValidatorTest {
-    
+
     private UlistBlockValidator validator;
     private BlockValidationContext context;
     private Block mockBlock;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new UlistBlockValidator();
@@ -58,77 +61,66 @@ class UlistBlockValidatorTest {
         when(mockBlock.getContext()).thenReturn("ulist");
         when(mockBlock.getSourceLocation()).thenReturn(null);
     }
-    
+
     @Test
     @DisplayName("should return ULIST as supported type")
     void shouldReturnUlistAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.ULIST, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when block is not Block instance")
         void shouldReturnEmptyListWhenNotBlockInstance() {
             // Given
             StructuralNode notABlock = mock(StructuralNode.class);
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notABlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("ItemsValidation")
     class ItemsValidation {
-        
+
         @Test
         @DisplayName("should validate minimum item count")
         void shouldValidateMinimumItemCount() {
             // Given
-            List<StructuralNode> items = Arrays.asList(
-                mock(ListItem.class)
-            );
+            List<StructuralNode> items = Arrays.asList(mock(ListItem.class));
             when(mockBlock.getBlocks()).thenReturn(items);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .items(UlistBlock.ItemsConfig.builder()
-                    .min(2)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .items(UlistBlock.ItemsConfig.builder().min(2).severity(Severity.WARN).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -138,29 +130,21 @@ class UlistBlockValidatorTest {
             assertEquals("1", message.getActualValue().orElse(null));
             assertEquals("At least 2 items", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate maximum item count")
         void shouldValidateMaximumItemCount() {
             // Given
-            List<StructuralNode> items = Arrays.asList(
-                mock(ListItem.class),
-                mock(ListItem.class),
-                mock(ListItem.class),
-                mock(ListItem.class)
-            );
+            List<StructuralNode> items = Arrays.asList(mock(ListItem.class), mock(ListItem.class), mock(ListItem.class),
+                    mock(ListItem.class));
             when(mockBlock.getBlocks()).thenReturn(items);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .items(UlistBlock.ItemsConfig.builder()
-                    .max(3)
-                    .build())
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .items(UlistBlock.ItemsConfig.builder().max(3).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -170,38 +154,30 @@ class UlistBlockValidatorTest {
             assertEquals("4", message.getActualValue().orElse(null));
             assertEquals("At most 3 items", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should pass when item count is within range")
         void shouldPassWhenItemCountIsWithinRange() {
             // Given
-            List<StructuralNode> items = Arrays.asList(
-                mock(ListItem.class),
-                mock(ListItem.class),
-                mock(ListItem.class)
-            );
+            List<StructuralNode> items = Arrays.asList(mock(ListItem.class), mock(ListItem.class),
+                    mock(ListItem.class));
             when(mockBlock.getBlocks()).thenReturn(items);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .items(UlistBlock.ItemsConfig.builder()
-                    .min(2)
-                    .max(5)
-                    .build())
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .items(UlistBlock.ItemsConfig.builder().min(2).max(5).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("NestingLevelValidation")
     class NestingLevelValidation {
-        
+
         @Test
         @DisplayName("should validate maximum nesting level")
         void shouldValidateMaximumNestingLevel() {
@@ -210,24 +186,20 @@ class UlistBlockValidatorTest {
             Block grandParent = mock(Block.class);
             when(grandParent.getContext()).thenReturn("ulist");
             when(grandParent.getParent()).thenReturn(null);
-            
+
             Block parent = mock(Block.class);
             when(parent.getContext()).thenReturn("ulist");
             when(parent.getParent()).thenReturn(grandParent);
-            
+
             when(mockBlock.getParent()).thenReturn(parent);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .nestingLevel(UlistBlock.NestingLevelConfig.builder()
-                    .max(1)
-                    .severity(Severity.WARN)
-                    .build())
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .nestingLevel(UlistBlock.NestingLevelConfig.builder().max(1).severity(Severity.WARN).build())
+                    .build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -237,7 +209,7 @@ class UlistBlockValidatorTest {
             assertEquals("2", message.getActualValue().orElse(null));
             assertEquals("Maximum nesting level: 1", message.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should pass when nesting level is within limit")
         void shouldPassWhenNestingLevelIsWithinLimit() {
@@ -245,176 +217,144 @@ class UlistBlockValidatorTest {
             Block parent = mock(Block.class);
             when(parent.getContext()).thenReturn("paragraph");
             when(parent.getParent()).thenReturn(null);
-            
+
             when(mockBlock.getParent()).thenReturn(parent);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .nestingLevel(UlistBlock.NestingLevelConfig.builder()
-                    .max(2)
-                    .build())
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .nestingLevel(UlistBlock.NestingLevelConfig.builder().max(2).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("MarkerStyleValidation")
     class MarkerStyleValidation {
-        
+
         @Test
         @DisplayName("should validate marker style")
         void shouldValidateMarkerStyle() {
             // Given
             when(mockBlock.getAttribute("marker")).thenReturn("-");
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .markerStyle("*")
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR).markerStyle("*").build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             // Marker style validation appears to be not implemented
             assertEquals(0, messages.size());
         }
-        
+
         @Test
         @DisplayName("should pass when marker style matches")
         void shouldPassWhenMarkerStyleMatches() {
             // Given
             when(mockBlock.getAttribute("marker")).thenReturn("*");
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .markerStyle("*")
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR).markerStyle("*").build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should use style attribute when marker is not present")
         void shouldUseStyleAttributeWhenMarkerIsNotPresent() {
             // Given
             when(mockBlock.getAttribute("marker")).thenReturn(null);
             when(mockBlock.getStyle()).thenReturn("-");
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.INFO)
-                .markerStyle("*")
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.INFO).markerStyle("*").build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             // Marker style validation appears to be not implemented
             assertEquals(0, messages.size());
         }
-        
+
         @Test
         @DisplayName("should default to asterisk when no marker info available")
         void shouldDefaultToAsteriskWhenNoMarkerInfoAvailable() {
             // Given
             when(mockBlock.getAttribute("marker")).thenReturn(null);
             when(mockBlock.getStyle()).thenReturn(null);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.WARN)
-                .markerStyle("-")
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.WARN).markerStyle("-").build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             // Marker style validation appears to be not implemented
             assertEquals(0, messages.size());
         }
     }
-    
+
     @Nested
     @DisplayName("ComplexScenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple rules together")
         void shouldValidateMultipleRulesTogether() {
             // Given
-            List<StructuralNode> items = Arrays.asList(
-                mock(ListItem.class)
-            );
+            List<StructuralNode> items = Arrays.asList(mock(ListItem.class));
             when(mockBlock.getBlocks()).thenReturn(items);
             when(mockBlock.getAttribute("marker")).thenReturn("-");
-            
+
             // Create nested parent
             Block parent = mock(Block.class);
             when(parent.getContext()).thenReturn("ulist");
             when(parent.getParent()).thenReturn(null);
             when(mockBlock.getParent()).thenReturn(parent);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .items(UlistBlock.ItemsConfig.builder()
-                    .min(2)
-                    .severity(Severity.WARN)
-                    .build())
-                .nestingLevel(UlistBlock.NestingLevelConfig.builder()
-                    .max(0)
-                    .severity(Severity.INFO)
-                    .build())
-                .markerStyle("*")
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .items(UlistBlock.ItemsConfig.builder().min(2).severity(Severity.WARN).build())
+                    .nestingLevel(UlistBlock.NestingLevelConfig.builder().max(0).severity(Severity.INFO).build())
+                    .markerStyle("*").build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(2, messages.size());
-            
+
             // Check items violation
-            ValidationMessage itemsMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("ulist.items.min"))
-                .findFirst().orElseThrow();
+            ValidationMessage itemsMessage = messages.stream().filter(m -> m.getRuleId().equals("ulist.items.min"))
+                    .findFirst().orElseThrow();
             assertEquals(Severity.WARN, itemsMessage.getSeverity());
-            
+
             // Check nesting violation
             ValidationMessage nestingMessage = messages.stream()
-                .filter(m -> m.getRuleId().equals("ulist.nestingLevel.max"))
-                .findFirst().orElseThrow();
+                    .filter(m -> m.getRuleId().equals("ulist.nestingLevel.max")).findFirst().orElseThrow();
             assertEquals(Severity.INFO, nestingMessage.getSeverity());
-            
+
             // Marker style validation seems to be not working or disabled
         }
-        
+
         @Test
         @DisplayName("should handle empty list blocks gracefully")
         void shouldHandleEmptyListBlocksGracefully() {
             // Given
             when(mockBlock.getBlocks()).thenReturn(null);
-            
-            UlistBlock config = UlistBlock.builder()
-                .severity(Severity.ERROR)
-                .items(UlistBlock.ItemsConfig.builder()
-                    .min(1)
-                    .build())
-                .build();
-            
+
+            UlistBlock config = UlistBlock.builder().severity(Severity.ERROR)
+                    .items(UlistBlock.ItemsConfig.builder().min(1).build()).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("0", messages.get(0).getActualValue().orElse(null));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/VerseBlockValidatorTest.java
@@ -23,44 +23,49 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 /**
  * Unit tests for {@link VerseBlockValidator}.
- * 
- * <p>This test class validates the behavior of the verse block validator,
- * which processes verse/quote blocks in AsciiDoc documents. The tests cover
- * validation rules for author information, source attribution, and verse
- * content.</p>
- * 
- * <p>Test structure follows a nested class pattern for better organization:</p>
+ *
+ * <p>
+ * This test class validates the behavior of the verse block validator, which processes verse/quote blocks in AsciiDoc
+ * documents. The tests cover validation rules for author information, source attribution, and verse content.
+ * </p>
+ *
+ * <p>
+ * Test structure follows a nested class pattern for better organization:
+ * </p>
  * <ul>
- *   <li>Validate - Basic validator functionality and type checking</li>
- *   <li>AuthorValidation - Author requirements and pattern matching</li>
- *   <li>AttributionValidation - Source attribution validation</li>
- *   <li>ContentValidation - Verse content length constraints</li>
- *   <li>SeverityHierarchy - Block-level severity usage (no nested severity support)</li>
- *   <li>ComplexScenarios - Combined validation scenarios and edge cases</li>
+ * <li>Validate - Basic validator functionality and type checking</li>
+ * <li>AuthorValidation - Author requirements and pattern matching</li>
+ * <li>AttributionValidation - Source attribution validation</li>
+ * <li>ContentValidation - Verse content length constraints</li>
+ * <li>SeverityHierarchy - Block-level severity usage (no nested severity support)</li>
+ * <li>ComplexScenarios - Combined validation scenarios and edge cases</li>
  * </ul>
- * 
- * <p>The validator supports various AsciiDoc attributes for verse blocks:</p>
+ *
+ * <p>
+ * The validator supports various AsciiDoc attributes for verse blocks:
+ * </p>
  * <ul>
- *   <li>author - The author of the verse/quote</li>
- *   <li>attribution/citetitle - The source or title of the work</li>
- *   <li>content - The actual verse or quote text</li>
+ * <li>author - The author of the verse/quote</li>
+ * <li>attribution/citetitle - The source or title of the work</li>
+ * <li>content - The actual verse or quote text</li>
  * </ul>
- * 
- * <p>Note: Like ImageBlock, VerseBlock configurations do not support
- * individual severity levels for nested rules. All validations use
- * the block-level severity.</p>
- * 
+ *
+ * <p>
+ * Note: Like ImageBlock, VerseBlock configurations do not support individual severity levels for nested rules. All
+ * validations use the block-level severity.
+ * </p>
+ *
  * @see VerseBlockValidator
  * @see VerseBlock
  */
 @DisplayName("VerseBlockValidator")
 class VerseBlockValidatorTest {
-    
+
     private VerseBlockValidator validator;
     private BlockValidationContext context;
     private Block mockBlock;
     private Section mockSection;
-    
+
     @BeforeEach
     void setUp() {
         validator = new VerseBlockValidator();
@@ -68,74 +73,65 @@ class VerseBlockValidatorTest {
         context = new BlockValidationContext(mockSection, "test.adoc");
         mockBlock = mock(Block.class);
     }
-    
+
     @Test
     @DisplayName("should return VERSE as supported type")
     void shouldReturnVerseAsSupportedType() {
         // Given/When
         BlockType type = validator.getSupportedType();
-        
+
         // Then
         assertEquals(BlockType.VERSE, type);
     }
-    
+
     @Nested
     @DisplayName("validate")
     class Validate {
-        
+
         @Test
         @DisplayName("should return empty list when block is not Block instance")
         void shouldReturnEmptyListWhenNotBlockInstance() {
             // Given
             StructuralNode notABlock = mock(StructuralNode.class);
-            VerseBlock config = VerseBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock config = VerseBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(notABlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should return empty list when no validations configured")
         void shouldReturnEmptyListWhenNoValidationsConfigured() {
             // Given
-            VerseBlock config = VerseBlock.builder()
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock config = VerseBlock.builder().severity(Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("author validation")
     class AuthorValidation {
-        
+
         @Test
         @DisplayName("should validate required author")
         void shouldValidateRequiredAuthor() {
             // Given
-            VerseBlock.AuthorConfig authorConfig = VerseBlock.AuthorConfig.builder()
-                .required(true)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .author(authorConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.AuthorConfig authorConfig = VerseBlock.AuthorConfig.builder().required(true).build();
+            VerseBlock config = VerseBlock.builder().author(authorConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("attribution")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -145,25 +141,21 @@ class VerseBlockValidatorTest {
             assertEquals("No author", msg.getActualValue().orElse(null));
             assertEquals("Author required", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate author pattern")
         void shouldValidateAuthorPattern() {
             // Given
             VerseBlock.AuthorConfig authorConfig = VerseBlock.AuthorConfig.builder()
-                .pattern(Pattern.compile("^[A-Z][a-z]+ [A-Z][a-z]+$"))
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .author(authorConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile("^[A-Z][a-z]+ [A-Z][a-z]+$")).build();
+            VerseBlock config = VerseBlock.builder().author(authorConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("author")).thenReturn(true);
             when(mockBlock.getAttribute("author")).thenReturn("john doe");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -173,52 +165,43 @@ class VerseBlockValidatorTest {
             assertEquals("john doe", msg.getActualValue().orElse(null));
             assertEquals("Pattern: ^[A-Z][a-z]+ [A-Z][a-z]+$", msg.getExpectedValue().orElse(null));
         }
-        
-        
+
         @Test
         @DisplayName("should pass when author matches pattern")
         void shouldPassWhenAuthorMatchesPattern() {
             // Given
             VerseBlock.AuthorConfig authorConfig = VerseBlock.AuthorConfig.builder()
-                .pattern(Pattern.compile("^[A-Z][a-z]+ [A-Z][a-z]+$"))
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .author(authorConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile("^[A-Z][a-z]+ [A-Z][a-z]+$")).build();
+            VerseBlock config = VerseBlock.builder().author(authorConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("attribution")).thenReturn(true);
             when(mockBlock.getAttribute("attribution")).thenReturn("John Doe");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("attribution validation")
     class AttributionValidation {
-        
+
         @Test
         @DisplayName("should validate required attribution")
         void shouldValidateRequiredAttribution() {
             // Given
-            VerseBlock.AttributionConfig attributionConfig = VerseBlock.AttributionConfig.builder()
-                .required(true)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .attribution(attributionConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.AttributionConfig attributionConfig = VerseBlock.AttributionConfig.builder().required(true)
+                    .build();
+            VerseBlock config = VerseBlock.builder().attribution(attributionConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("citetitle")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -227,25 +210,21 @@ class VerseBlockValidatorTest {
             assertEquals("No attribution", msg.getActualValue().orElse(null));
             assertEquals("Attribution required", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate attribution pattern")
         void shouldValidateAttributionPattern() {
             // Given
             VerseBlock.AttributionConfig attributionConfig = VerseBlock.AttributionConfig.builder()
-                .pattern(Pattern.compile(".*\\(\\d{4}\\)$"))
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .attribution(attributionConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .pattern(Pattern.compile(".*\\(\\d{4}\\)$")).build();
+            VerseBlock config = VerseBlock.builder().attribution(attributionConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("citetitle")).thenReturn(true);
             when(mockBlock.getAttribute("citetitle")).thenReturn("Book Title");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -254,30 +233,25 @@ class VerseBlockValidatorTest {
             assertEquals("Verse attribution does not match required pattern", msg.getMessage());
             assertEquals("Book Title", msg.getActualValue().orElse(null));
         }
-        
+
     }
-    
+
     @Nested
     @DisplayName("content validation")
     class ContentValidation {
-        
+
         @Test
         @DisplayName("should validate minimum content length")
         void shouldValidateMinimumContentLength() {
             // Given
-            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder()
-                .minLength(20)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .content(contentConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder().minLength(20).build();
+            VerseBlock config = VerseBlock.builder().content(contentConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("Short verse");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -287,26 +261,21 @@ class VerseBlockValidatorTest {
             assertEquals("11 characters", msg.getActualValue().orElse(null));
             assertEquals("At least 20 characters", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate maximum content length")
         void shouldValidateMaximumContentLength() {
             // Given
-            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder()
-                .maxLength(50)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .content(contentConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder().maxLength(50).build();
+            VerseBlock config = VerseBlock.builder().content(contentConfig).severity(Severity.ERROR).build();
+
             // Create long content
             String longContent = "This is a very long verse that exceeds the maximum length allowed";
             when(mockBlock.getContent()).thenReturn(longContent);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
@@ -315,203 +284,166 @@ class VerseBlockValidatorTest {
             assertEquals("65 characters", msg.getActualValue().orElse(null));
             assertEquals("At most 50 characters", msg.getExpectedValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should pass when content length is within bounds")
         void shouldPassWhenContentLengthIsWithinBounds() {
             // Given
-            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder()
-                .minLength(10)
-                .maxLength(100)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .content(contentConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder().minLength(10).maxLength(100)
+                    .build();
+            VerseBlock config = VerseBlock.builder().content(contentConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("This is a perfect verse");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("severity hierarchy")
     class SeverityHierarchy {
-        
+
         @Test
         @DisplayName("should always use block severity for author validation")
         void shouldAlwaysUseBlockSeverityForAuthor() {
             // Given - VerseBlock.AuthorConfig has no severity field
-            VerseBlock.AuthorConfig authorConfig = VerseBlock.AuthorConfig.builder()
-                .required(true)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .author(authorConfig)
-                .severity(Severity.WARN) // Block severity
-                .build();
-            
+            VerseBlock.AuthorConfig authorConfig = VerseBlock.AuthorConfig.builder().required(true).build();
+            VerseBlock config = VerseBlock.builder().author(authorConfig).severity(Severity.WARN) // Block severity
+                    .build();
+
             when(mockBlock.hasAttribute("attribution")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.WARN, msg.getSeverity(), 
-                "Should use block severity (WARN) since AuthorConfig has no severity field");
+            assertEquals(Severity.WARN, msg.getSeverity(),
+                    "Should use block severity (WARN) since AuthorConfig has no severity field");
             assertEquals("verse.author.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should always use block severity for attribution validation")
         void shouldAlwaysUseBlockSeverityForAttribution() {
             // Given - VerseBlock.AttributionConfig has no severity field
-            VerseBlock.AttributionConfig attributionConfig = VerseBlock.AttributionConfig.builder()
-                .required(true)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .attribution(attributionConfig)
-                .severity(Severity.INFO) // Block severity
-                .build();
-            
+            VerseBlock.AttributionConfig attributionConfig = VerseBlock.AttributionConfig.builder().required(true)
+                    .build();
+            VerseBlock config = VerseBlock.builder().attribution(attributionConfig).severity(Severity.INFO) // Block
+                                                                                                            // severity
+                    .build();
+
             when(mockBlock.hasAttribute("citetitle")).thenReturn(false);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.INFO, msg.getSeverity(), 
-                "Should use block severity (INFO) since AttributionConfig has no severity field");
+            assertEquals(Severity.INFO, msg.getSeverity(),
+                    "Should use block severity (INFO) since AttributionConfig has no severity field");
             assertEquals("verse.attribution.required", msg.getRuleId());
         }
-        
+
         @Test
         @DisplayName("should always use block severity for content validation")
         void shouldAlwaysUseBlockSeverityForContent() {
             // Given - VerseBlock.ContentConfig has no severity field
-            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder()
-                .minLength(10)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .content(contentConfig)
-                .severity(Severity.ERROR) // Block severity
-                .build();
-            
+            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder().minLength(10).build();
+            VerseBlock config = VerseBlock.builder().content(contentConfig).severity(Severity.ERROR) // Block severity
+                    .build();
+
             when(mockBlock.getContent()).thenReturn("Short");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
-            assertEquals(Severity.ERROR, msg.getSeverity(), 
-                "Should use block severity (ERROR) since ContentConfig has no severity field");
+            assertEquals(Severity.ERROR, msg.getSeverity(),
+                    "Should use block severity (ERROR) since ContentConfig has no severity field");
             assertEquals("verse.content.minLength", msg.getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("complex validation scenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate multiple rules together")
         void shouldValidateMultipleRules() {
             // Given
-            VerseBlock config = VerseBlock.builder()
-                .author(VerseBlock.AuthorConfig.builder()
-                    .required(true)
-                    .pattern(Pattern.compile("^[A-Z].*"))
-                    .build())
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock config = VerseBlock.builder().author(
+                    VerseBlock.AuthorConfig.builder().required(true).pattern(Pattern.compile("^[A-Z].*")).build())
+                    .severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("author")).thenReturn(true);
             when(mockBlock.getAttribute("author")).thenReturn("anonymous"); // Invalid pattern
             when(mockBlock.hasAttribute("citetitle")).thenReturn(false); // Missing
             when(mockBlock.getContent()).thenReturn("Short verse");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.stream().anyMatch(m -> "verse.author.pattern".equals(m.getRuleId())));
         }
-        
+
         @Test
         @DisplayName("should handle empty content")
         void shouldHandleEmptyContent() {
             // Given
-            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder()
-                .minLength(1)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .content(contentConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder().minLength(1).build();
+            VerseBlock config = VerseBlock.builder().content(contentConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn("");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("0 characters", messages.get(0).getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should handle null content")
         void shouldHandleNullContent() {
             // Given
-            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder()
-                .minLength(1)
-                .build();
-            VerseBlock config = VerseBlock.builder()
-                .content(contentConfig)
-                .severity(Severity.ERROR)
-                .build();
-            
+            VerseBlock.ContentConfig contentConfig = VerseBlock.ContentConfig.builder().minLength(1).build();
+            VerseBlock config = VerseBlock.builder().content(contentConfig).severity(Severity.ERROR).build();
+
             when(mockBlock.getContent()).thenReturn(null);
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertEquals("0 characters", messages.get(0).getActualValue().orElse(null));
         }
-        
+
         @Test
         @DisplayName("should validate all attributes when present")
         void shouldValidateAllAttributesWhenPresent() {
             // Given
             VerseBlock config = VerseBlock.builder()
-                .author(VerseBlock.AuthorConfig.builder()
-                    .required(true)
-                    .pattern(Pattern.compile("^[A-Z][a-z]+ [A-Z][a-z]+$"))
-                    .build())
-                .attribution(VerseBlock.AttributionConfig.builder()
-                    .required(true)
-                    .pattern(Pattern.compile(".*\\(\\d{4}\\)$"))
-                    .build())
-                .content(VerseBlock.ContentConfig.builder()
-                    .minLength(10)
-                    .maxLength(200)
-                    .build())
-                .severity(Severity.ERROR)
-                .build();
-            
+                    .author(VerseBlock.AuthorConfig.builder().required(true)
+                            .pattern(Pattern.compile("^[A-Z][a-z]+ [A-Z][a-z]+$")).build())
+                    .attribution(VerseBlock.AttributionConfig.builder().required(true)
+                            .pattern(Pattern.compile(".*\\(\\d{4}\\)$")).build())
+                    .content(VerseBlock.ContentConfig.builder().minLength(10).maxLength(200).build())
+                    .severity(Severity.ERROR).build();
+
             when(mockBlock.hasAttribute("author")).thenReturn(true);
             when(mockBlock.getAttribute("author")).thenReturn("William Shakespeare");
             when(mockBlock.getAttribute("author", null)).thenReturn("William Shakespeare");
@@ -521,10 +453,10 @@ class VerseBlockValidatorTest {
             when(mockBlock.hasAttribute("citetitle")).thenReturn(true);
             when(mockBlock.getAttribute("citetitle")).thenReturn("Hamlet (1603)");
             when(mockBlock.getContent()).thenReturn("To be, or not to be,\nthat is the question");
-            
+
             // When
             List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
-            
+
             // Then
             assertTrue(messages.isEmpty()); // All validations pass
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidatorTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/block/VideoBlockValidatorTest.java
@@ -25,18 +25,18 @@ import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 
 @DisplayName("VideoBlockValidator")
 class VideoBlockValidatorTest {
-    
+
     private VideoBlockValidator validator;
-    
+
     @Mock
     private StructuralNode node;
-    
+
     @Mock
     private org.asciidoctor.ast.Cursor sourceLocation;
-    
+
     @Mock
     private BlockValidationContext context;
-    
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
@@ -44,54 +44,46 @@ class VideoBlockValidatorTest {
         when(node.getSourceLocation()).thenReturn(sourceLocation);
         when(sourceLocation.getLineNumber()).thenReturn(10);
         when(sourceLocation.getFile()).thenReturn("test.adoc");
-        
+
         // Mock context methods
         when(context.getFilename()).thenReturn("test.adoc");
-        
+
         // Mock context.createLocation()
-        SourceLocation location = SourceLocation.builder()
-                .filename("test.adoc")
-                .startLine(10)
-                .build();
+        SourceLocation location = SourceLocation.builder().filename("test.adoc").startLine(10).build();
         when(context.createLocation(any(StructuralNode.class))).thenReturn(location);
     }
-    
+
     @Test
     @DisplayName("should return VIDEO block type")
     void shouldReturnVideoBlockType() {
         assertEquals(BlockType.VIDEO, validator.getSupportedType());
     }
-    
+
     @Test
     @DisplayName("should return empty list for non-VideoBlock config")
     void shouldReturnEmptyListForNonVideoBlockConfig() {
         // When
-        var messages = validator.validate(node, ParagraphBlock.builder().name("test").severity(Severity.WARN).build(), context);
-        
+        var messages = validator.validate(node, ParagraphBlock.builder().name("test").severity(Severity.WARN).build(),
+                context);
+
         // Then
         assertTrue(messages.isEmpty());
     }
-    
+
     @Nested
     @DisplayName("URL Validation")
     class UrlValidation {
-        
+
         @Test
         @DisplayName("should report error when required URL is missing")
         void shouldReportErrorWhenRequiredUrlMissing() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .url(VideoBlock.UrlConfig.builder()
-                            .required(true)
-                            .severity(Severity.ERROR)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .url(VideoBlock.UrlConfig.builder().required(true).severity(Severity.ERROR).build()).build();
+
             when(node.getAttribute("target")).thenReturn(null);
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals(Severity.ERROR, msg.getSeverity());
@@ -100,22 +92,17 @@ class VideoBlockValidatorTest {
             assertEquals("target", msg.getMissingValueHint());
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should report error when URL doesn't match pattern")
         void shouldReportErrorWhenUrlDoesntMatchPattern() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .url(VideoBlock.UrlConfig.builder()
-                            .pattern("^https?://.*\\.(mp4|webm)$")
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .url(VideoBlock.UrlConfig.builder().pattern("^https?://.*\\.(mp4|webm)$").build()).build();
+
             when(node.getAttribute("target")).thenReturn("https://dataliquid.com/video.avi");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals(Severity.WARN, msg.getSeverity());
@@ -125,48 +112,36 @@ class VideoBlockValidatorTest {
             assertEquals("^https?://.*\\.(mp4|webm)$", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should use nested severity when available")
         void shouldUseNestedSeverityWhenAvailable() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .url(VideoBlock.UrlConfig.builder()
-                            .required(true)
-                            .severity(Severity.INFO)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .url(VideoBlock.UrlConfig.builder().required(true).severity(Severity.INFO).build()).build();
+
             when(node.getAttribute("target")).thenReturn(null);
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             assertEquals(Severity.INFO, messages.get(0).getSeverity());
         }
     }
-    
+
     @Nested
     @DisplayName("Dimension Validation")
     class DimensionValidation {
-        
+
         @Test
         @DisplayName("should report error when width is below minimum")
         void shouldReportErrorWhenWidthBelowMinimum() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .width(VideoBlock.DimensionConfig.builder()
-                            .minValue(320)
-                            .maxValue(1920)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .width(VideoBlock.DimensionConfig.builder().minValue(320).maxValue(1920).build()).build();
+
             when(node.getAttribute("width")).thenReturn("200");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("Video width is below minimum value", msg.getMessage());
@@ -175,23 +150,18 @@ class VideoBlockValidatorTest {
             assertEquals(">= 320", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should report error when height exceeds maximum")
         void shouldReportErrorWhenHeightExceedsMaximum() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.ERROR)
-                    .height(VideoBlock.DimensionConfig.builder()
-                            .maxValue(1080)
-                            .severity(Severity.INFO)
-                            .build())
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.ERROR)
+                    .height(VideoBlock.DimensionConfig.builder().maxValue(1080).severity(Severity.INFO).build())
                     .build();
-            
+
             when(node.getAttribute("height")).thenReturn("2000");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals(Severity.INFO, msg.getSeverity());
@@ -201,22 +171,17 @@ class VideoBlockValidatorTest {
             assertEquals("<= 1080", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should report error for invalid dimension value")
         void shouldReportErrorForInvalidDimensionValue() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.ERROR)
-                    .width(VideoBlock.DimensionConfig.builder()
-                            .minValue(320)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.ERROR)
+                    .width(VideoBlock.DimensionConfig.builder().minValue(320).build()).build();
+
             when(node.getAttribute("width")).thenReturn("invalid");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("Video width is not a valid number", msg.getMessage());
@@ -226,26 +191,21 @@ class VideoBlockValidatorTest {
             assertTrue(msg.hasSuggestions());
         }
     }
-    
+
     @Nested
     @DisplayName("Poster Validation")
     class PosterValidation {
-        
+
         @Test
         @DisplayName("should report error when poster doesn't match pattern")
         void shouldReportErrorWhenPosterDoesntMatchPattern() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .poster(VideoBlock.PosterConfig.builder()
-                            .pattern(".*\\.(jpg|jpeg|png)$")
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .poster(VideoBlock.PosterConfig.builder().pattern(".*\\.(jpg|jpeg|png)$").build()).build();
+
             when(node.getAttribute("poster")).thenReturn("poster.gif");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("Video poster does not match required pattern", msg.getMessage());
@@ -255,29 +215,25 @@ class VideoBlockValidatorTest {
             assertTrue(msg.hasSuggestions());
         }
     }
-    
+
     @Nested
     @DisplayName("Controls Validation")
     class ControlsValidation {
-        
+
         @Test
         @DisplayName("should report error when controls are required but not enabled")
         void shouldReportErrorWhenControlsRequiredButNotEnabled() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
                     .options(VideoBlock.OptionsConfig.builder()
-                            .controls(VideoBlock.ControlsConfig.builder()
-                                    .required(true)
-                                    .severity(Severity.ERROR)
-                                    .build())
+                            .controls(
+                                    VideoBlock.ControlsConfig.builder().required(true).severity(Severity.ERROR).build())
                             .build())
                     .build();
-            
+
             when(node.getAttribute("options")).thenReturn("autoplay");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals(Severity.ERROR, msg.getSeverity());
@@ -288,48 +244,37 @@ class VideoBlockValidatorTest {
             assertEquals("controls", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should pass when controls are enabled")
         void shouldPassWhenControlsAreEnabled() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
                     .options(VideoBlock.OptionsConfig.builder()
-                            .controls(VideoBlock.ControlsConfig.builder()
-                                    .required(true)
-                                    .build())
-                            .build())
+                            .controls(VideoBlock.ControlsConfig.builder().required(true).build()).build())
                     .build();
-            
+
             when(node.getAttribute("options")).thenReturn("controls,loop");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Caption Validation")
     class CaptionValidation {
-        
+
         @Test
         @DisplayName("should report error when caption is too short")
         void shouldReportErrorWhenCaptionTooShort() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(VideoBlock.CaptionConfig.builder()
-                            .minLength(15)
-                            .severity(Severity.WARN)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .caption(VideoBlock.CaptionConfig.builder().minLength(15).severity(Severity.WARN).build()).build();
+
             when(node.getAttribute("caption")).thenReturn("Short");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals(Severity.WARN, msg.getSeverity());
@@ -339,23 +284,18 @@ class VideoBlockValidatorTest {
             assertEquals(">= 15 characters", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should report error when caption is too long")
         void shouldReportErrorWhenCaptionTooLong() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(VideoBlock.CaptionConfig.builder()
-                            .maxLength(50)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .caption(VideoBlock.CaptionConfig.builder().maxLength(50).build()).build();
+
             String longCaption = "This is a very long caption that definitely exceeds the maximum allowed length";
             when(node.getAttribute("caption")).thenReturn(longCaption);
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(1, messages.size());
             ValidationMessage msg = messages.get(0);
             assertEquals("Video caption is too long", msg.getMessage());
@@ -364,51 +304,34 @@ class VideoBlockValidatorTest {
             assertEquals("<= 50 characters", msg.getExpectedValue().orElse(null));
             assertTrue(msg.hasSuggestions());
         }
-        
+
         @Test
         @DisplayName("should use title when caption attribute is null")
         void shouldUseTitleWhenCaptionAttributeIsNull() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .caption(VideoBlock.CaptionConfig.builder()
-                            .required(true)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .caption(VideoBlock.CaptionConfig.builder().required(true).build()).build();
+
             when(node.getAttribute("caption")).thenReturn(null);
             when(node.getTitle()).thenReturn("Video Title");
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertTrue(messages.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("Complex Scenarios")
     class ComplexScenarios {
-        
+
         @Test
         @DisplayName("should validate all configured rules")
         void shouldValidateAllConfiguredRules() {
-            VideoBlock config = VideoBlock.builder()
-                    .name("test")
-                    .severity(Severity.WARN)
-                    .url(VideoBlock.UrlConfig.builder()
-                            .required(true)
-                            .pattern("^https://.*\\.(mp4|webm)$")
-                            .build())
-                    .width(VideoBlock.DimensionConfig.builder()
-                            .minValue(320)
-                            .maxValue(1920)
-                            .build())
-                    .caption(VideoBlock.CaptionConfig.builder()
-                            .required(true)
-                            .minLength(10)
-                            .build())
-                    .build();
-            
+            VideoBlock config = VideoBlock.builder().name("test").severity(Severity.WARN)
+                    .url(VideoBlock.UrlConfig.builder().required(true).pattern("^https://.*\\.(mp4|webm)$").build())
+                    .width(VideoBlock.DimensionConfig.builder().minValue(320).maxValue(1920).build())
+                    .caption(VideoBlock.CaptionConfig.builder().required(true).minLength(10).build()).build();
+
             // Invalid URL
             when(node.getAttribute("target")).thenReturn("http://example.com/video.avi");
             // Valid width
@@ -416,9 +339,9 @@ class VideoBlockValidatorTest {
             // Missing caption
             when(node.getAttribute("caption")).thenReturn(null);
             when(node.getTitle()).thenReturn(null);
-            
+
             List<ValidationMessage> messages = validator.validate(node, config, context);
-            
+
             assertEquals(2, messages.size());
             assertTrue(messages.stream().anyMatch(m -> m.getMessage().contains("URL")));
             assertTrue(messages.stream().anyMatch(m -> m.getMessage().contains("caption")));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/LengthRuleTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/LengthRuleTest.java
@@ -23,128 +23,120 @@ class LengthRuleTest {
 
     @BeforeEach
     void setUp() {
-        testLocation = SourceLocation.builder()
-            .filename("test.adoc")
-            .line(3)
-            .build();
+        testLocation = SourceLocation.builder().filename("test.adoc").line(3).build();
     }
 
     @Nested
     @DisplayName("Rule Building")
     class RuleBuilding {
-        
+
         @Test
         @DisplayName("should build rule with min and max constraints")
         void shouldBuildRuleWithMinAndMaxConstraints() {
             // Given
-            LengthRule.Builder builder = LengthRule.builder()
-                .addLengthConstraint("title", 5, 100, Severity.ERROR)
-                .addLengthConstraint("author", 3, 50, Severity.ERROR);
-            
+            LengthRule.Builder builder = LengthRule.builder().addLengthConstraint("title", 5, 100, Severity.ERROR)
+                    .addLengthConstraint("author", 3, 50, Severity.ERROR);
+
             // When
             LengthRule rule = builder.build();
-            
+
             // Then
             assertEquals("metadata.length", rule.getRuleId());
             assertTrue(rule.isApplicable("title"));
             assertTrue(rule.isApplicable("author"));
             assertFalse(rule.isApplicable("unknown"));
         }
-        
+
         @Test
         @DisplayName("should build rule with only min constraint")
         void shouldBuildRuleWithOnlyMinConstraint() {
             // Given
-            LengthRule.Builder builder = LengthRule.builder()
-                .addLengthConstraint("description", 10, null, Severity.WARN);
-            
+            LengthRule.Builder builder = LengthRule.builder().addLengthConstraint("description", 10, null,
+                    Severity.WARN);
+
             // When
             LengthRule rule = builder.build();
-            
+
             // Then
             assertTrue(rule.isApplicable("description"));
         }
-        
+
         @Test
         @DisplayName("should build rule with only max constraint")
         void shouldBuildRuleWithOnlyMaxConstraint() {
             // Given
-            LengthRule.Builder builder = LengthRule.builder()
-                .addLengthConstraint("keywords", null, 200, Severity.INFO);
-            
+            LengthRule.Builder builder = LengthRule.builder().addLengthConstraint("keywords", null, 200, Severity.INFO);
+
             // When
             LengthRule rule = builder.build();
-            
+
             // Then
             assertTrue(rule.isApplicable("keywords"));
         }
-        
+
         @Test
         @DisplayName("should reject when neither min nor max specified")
         void shouldRejectWhenNeitherMinNorMaxSpecified() {
             // Given
             LengthRule.Builder builder = LengthRule.builder();
-            
+
             // When/Then
-            assertThrows(IllegalArgumentException.class, () ->
-                builder.addLengthConstraint("invalid", null, null, Severity.ERROR)
-            );
+            assertThrows(IllegalArgumentException.class,
+                    () -> builder.addLengthConstraint("invalid", null, null, Severity.ERROR));
         }
-        
+
         @Test
         @DisplayName("should reject when min greater than max")
         void shouldRejectWhenMinGreaterThanMax() {
             // Given
             LengthRule.Builder builder = LengthRule.builder();
-            
+
             // When/Then
-            assertThrows(IllegalArgumentException.class, () ->
-                builder.addLengthConstraint("invalid", 100, 50, Severity.ERROR)
-            );
+            assertThrows(IllegalArgumentException.class,
+                    () -> builder.addLengthConstraint("invalid", 100, 50, Severity.ERROR));
         }
     }
 
     @Nested
     @DisplayName("Min Length Validation")
     class MinLengthValidation {
-        
+
         private LengthRule rule;
-        
+
         @BeforeEach
         void setUp() {
-            rule = LengthRule.builder()
-                .addLengthConstraint("title", 5, null, Severity.ERROR)
-                .build();
+            rule = LengthRule.builder().addLengthConstraint("title", 5, null, Severity.ERROR).build();
         }
-        
+
         @Test
         @DisplayName("should pass when value meets minimum length")
         void shouldPassWhenValueMeetsMinimumLength() {
             // Given
             String validTitle = "Valid Title";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("title", validTitle, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when value is too short")
         void shouldFailWhenValueIsTooShort() {
             // Given
             String shortTitle = "Hi";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("title", shortTitle, testLocation);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("metadata.length.min", message.getRuleId());
-            assertEquals("Attribute 'title' is too short: actual 'Hi' (2 characters), expected minimum 5 characters", message.getMessage());
+            assertEquals("Attribute 'title' is too short: actual 'Hi' (2 characters), expected minimum 5 characters",
+                    message.getMessage());
             // actualValue and expectedValue are already tested in the message
             // actualValue and expectedValue are already tested in the message
         }
@@ -153,44 +145,43 @@ class LengthRuleTest {
     @Nested
     @DisplayName("Max Length Validation")
     class MaxLengthValidation {
-        
+
         private LengthRule rule;
-        
+
         @BeforeEach
         void setUp() {
-            rule = LengthRule.builder()
-                .addLengthConstraint("author", null, 50, Severity.ERROR)
-                .build();
+            rule = LengthRule.builder().addLengthConstraint("author", null, 50, Severity.ERROR).build();
         }
-        
+
         @Test
         @DisplayName("should pass when value within maximum length")
         void shouldPassWhenValueWithinMaximumLength() {
             // Given
             String validAuthor = "John Doe";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("author", validAuthor, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when value is too long")
         void shouldFailWhenValueIsTooLong() {
             // Given
             String longName = "This is a very long author name that exceeds the maximum allowed length";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("author", longName, testLocation);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("metadata.length.max", message.getRuleId());
-            assertEquals("Attribute 'author' is too long: actual '" + longName + "' (" + longName.length() + " characters), expected maximum 50 characters", message.getMessage());
+            assertEquals("Attribute 'author' is too long: actual '" + longName + "' (" + longName.length()
+                    + " characters), expected maximum 50 characters", message.getMessage());
             // expectedValue is already tested in the message
         }
     }
@@ -198,44 +189,42 @@ class LengthRuleTest {
     @Nested
     @DisplayName("Combined Min Max Validation")
     class CombinedMinMaxValidation {
-        
+
         private LengthRule rule;
-        
+
         @BeforeEach
         void setUp() {
-            rule = LengthRule.builder()
-                .addLengthConstraint("title", 5, 100, Severity.ERROR)
-                .build();
+            rule = LengthRule.builder().addLengthConstraint("title", 5, 100, Severity.ERROR).build();
         }
-        
+
         @Test
         @DisplayName("should pass when value is within range")
         void shouldPassWhenValueIsWithinRange() {
             // Given
             String validTitle = "Perfect Title";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("title", validTitle, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail with both min and max messages when applicable")
         void shouldFailWithBothMinAndMaxMessagesWhenApplicable() {
             // Given
             String shortTitle = "Hi";
             String veryLongTitle = "A".repeat(150);
-            
+
             // When
             List<ValidationMessage> tooShort = rule.validate("title", shortTitle, testLocation);
             List<ValidationMessage> tooLong = rule.validate("title", veryLongTitle, testLocation);
-            
+
             // Then
             assertEquals(1, tooShort.size());
             assertEquals("metadata.length.min", tooShort.get(0).getRuleId());
-            
+
             assertEquals(1, tooLong.size());
             assertEquals("metadata.length.max", tooLong.get(0).getRuleId());
         }
@@ -244,33 +233,29 @@ class LengthRuleTest {
     @Nested
     @DisplayName("Edge Cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should skip validation for null values")
         void shouldSkipValidationForNullValues() {
             // Given
-            LengthRule rule = LengthRule.builder()
-                .addLengthConstraint("title", 5, 100, Severity.ERROR)
-                .build();
-            
+            LengthRule rule = LengthRule.builder().addLengthConstraint("title", 5, 100, Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("title", null, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate empty string as zero length")
         void shouldValidateEmptyStringAsZeroLength() {
             // Given
-            LengthRule rule = LengthRule.builder()
-                .addLengthConstraint("title", 1, 100, Severity.ERROR)
-                .build();
-            
+            LengthRule rule = LengthRule.builder().addLengthConstraint("title", 1, 100, Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("title", "", testLocation);
-            
+
             // Then
             assertEquals(1, messages.size());
             assertTrue(messages.get(0).getMessage().contains("(0 characters)"));

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/OrderRuleTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/OrderRuleTest.java
@@ -20,19 +20,17 @@ class OrderRuleTest {
     @Nested
     @DisplayName("Rule Building")
     class RuleBuilding {
-        
+
         @Test
         @DisplayName("should build rule with order constraints")
         void shouldBuildRuleWithOrderConstraints() {
             // Given
-            OrderRule.Builder builder = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .addOrderConstraint("revdate", 3, Severity.WARN);
-            
+            OrderRule.Builder builder = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).addOrderConstraint("revdate", 3, Severity.WARN);
+
             // When
             OrderRule rule = builder.build();
-            
+
             // Then
             assertEquals("metadata.order", rule.getRuleId());
             assertTrue(rule.isApplicable("title"));
@@ -40,18 +38,17 @@ class OrderRuleTest {
             assertTrue(rule.isApplicable("revdate"));
             assertFalse(rule.isApplicable("unknown"));
         }
-        
+
         @Test
         @DisplayName("should allow null order for flexible positioning")
         void shouldAllowNullOrderForFlexiblePositioning() {
             // Given
-            OrderRule.Builder builder = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("optional", null, Severity.INFO);
-            
+            OrderRule.Builder builder = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("optional", null, Severity.INFO);
+
             // When
             OrderRule rule = builder.build();
-            
+
             // Then
             assertTrue(rule.isApplicable("optional"));
         }
@@ -60,68 +57,61 @@ class OrderRuleTest {
     @Nested
     @DisplayName("Order Validation")
     class OrderValidation {
-        
+
         @Test
         @DisplayName("should pass when attributes are in correct order")
         void shouldPassWhenAttributesAreInCorrectOrder() {
             // Given
-            OrderRule rule = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .addOrderConstraint("revdate", 3, Severity.ERROR)
-                .build();
-            
+            OrderRule rule = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).addOrderConstraint("revdate", 3, Severity.ERROR)
+                    .build();
+
             // When
             rule.validate("title", "My Document", createLocation("test.adoc", 1));
             rule.validate("author", "John Doe", createLocation("test.adoc", 2));
             rule.validate("revdate", "2024-01-15", createLocation("test.adoc", 3));
-            
+
             // Then
             List<ValidationMessage> messages = rule.validateOrder();
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when attributes are out of order")
         void shouldFailWhenAttributesAreOutOfOrder() {
             // Given
-            OrderRule rule = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .addOrderConstraint("revdate", 3, Severity.ERROR)
-                .build();
-            
+            OrderRule rule = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).addOrderConstraint("revdate", 3, Severity.ERROR)
+                    .build();
+
             // When
             rule.validate("author", "John Doe", createLocation("test.adoc", 2));
             rule.validate("title", "My Document", createLocation("test.adoc", 3));
             rule.validate("revdate", "2024-01-15", createLocation("test.adoc", 4));
-            
+
             List<ValidationMessage> messages = rule.validateOrder();
-            
+
             // Then
             assertFalse(messages.isEmpty());
-            
-            assertTrue(messages.stream()
-                .anyMatch(m -> m.getMessage().equals("Attribute 'title' should appear before 'author': actual position line 3, expected before line 2")));
+
+            assertTrue(messages.stream().anyMatch(m -> m.getMessage().equals(
+                    "Attribute 'title' should appear before 'author': actual position line 3, expected before line 2")));
         }
-        
+
         @Test
         @DisplayName("should detect multiple order violations")
         void shouldDetectMultipleOrderViolations() {
             // Given
-            OrderRule rule = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .addOrderConstraint("version", 3, Severity.ERROR)
-                .addOrderConstraint("revdate", 4, Severity.ERROR)
-                .build();
-            
+            OrderRule rule = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).addOrderConstraint("version", 3, Severity.ERROR)
+                    .addOrderConstraint("revdate", 4, Severity.ERROR).build();
+
             // When
             rule.validate("version", "1.0", createLocation("test.adoc", 1));
             rule.validate("revdate", "2024-01-15", createLocation("test.adoc", 2));
             rule.validate("title", "My Document", createLocation("test.adoc", 3));
             rule.validate("author", "John Doe", createLocation("test.adoc", 4));
-            
+
             // Then
             List<ValidationMessage> messages = rule.validateOrder();
             assertTrue(messages.size() >= 2);
@@ -131,40 +121,36 @@ class OrderRuleTest {
     @Nested
     @DisplayName("Partial Order Validation")
     class PartialOrderValidation {
-        
+
         @Test
         @DisplayName("should handle missing attributes in order check")
         void shouldHandleMissingAttributesInOrderCheck() {
             // Given
-            OrderRule rule = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .addOrderConstraint("version", 3, Severity.ERROR)
-                .build();
-            
+            OrderRule rule = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).addOrderConstraint("version", 3, Severity.ERROR)
+                    .build();
+
             // When
             rule.validate("title", "My Document", createLocation("test.adoc", 1));
             rule.validate("version", "1.0", createLocation("test.adoc", 2));
-            
+
             // Then
             List<ValidationMessage> messages = rule.validateOrder();
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should ignore attributes without order constraint")
         void shouldIgnoreAttributesWithoutOrderConstraint() {
             // Given
-            OrderRule rule = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .build();
-            
+            OrderRule rule = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).build();
+
             // When
             rule.validate("title", "My Document", createLocation("test.adoc", 1));
             rule.validate("keywords", "test, doc", createLocation("test.adoc", 2));
             rule.validate("author", "John Doe", createLocation("test.adoc", 3));
-            
+
             // Then
             List<ValidationMessage> messages = rule.validateOrder();
             assertTrue(messages.isEmpty());
@@ -174,25 +160,23 @@ class OrderRuleTest {
     @Nested
     @DisplayName("Message Details")
     class MessageDetails {
-        
+
         @Test
         @DisplayName("should include line numbers in error messages")
         void shouldIncludeLineNumbersInErrorMessages() {
             // Given
-            OrderRule rule = OrderRule.builder()
-                .addOrderConstraint("title", 1, Severity.ERROR)
-                .addOrderConstraint("author", 2, Severity.ERROR)
-                .build();
-            
+            OrderRule rule = OrderRule.builder().addOrderConstraint("title", 1, Severity.ERROR)
+                    .addOrderConstraint("author", 2, Severity.ERROR).build();
+
             // When
             rule.validate("author", "John Doe", createLocation("test.adoc", 2));
             rule.validate("title", "My Document", createLocation("test.adoc", 5));
-            
+
             List<ValidationMessage> messages = rule.validateOrder();
-            
+
             // Then
             assertEquals(1, messages.size());
-            
+
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             // actualValue is already tested in the message
@@ -201,11 +185,8 @@ class OrderRuleTest {
             assertTrue(message.getMessage().contains("expected before line 2"));
         }
     }
-    
+
     private SourceLocation createLocation(String filename, int line) {
-        return SourceLocation.builder()
-            .filename(filename)
-            .line(line)
-            .build();
+        return SourceLocation.builder().filename(filename).line(line).build();
     }
 }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/PatternRuleTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/PatternRuleTest.java
@@ -23,28 +23,24 @@ class PatternRuleTest {
 
     @BeforeEach
     void setUp() {
-        testLocation = SourceLocation.builder()
-            .filename("test.adoc")
-            .line(2)
-            .build();
+        testLocation = SourceLocation.builder().filename("test.adoc").line(2).build();
     }
 
     @Nested
     @DisplayName("Rule Building")
     class RuleBuilding {
-        
+
         @Test
         @DisplayName("should build rule with valid patterns")
         void shouldBuildRuleWithValidPatterns() {
             // Given
-            PatternRule.Builder builder = PatternRule.builder()
-                .addPattern("title", "^[A-Z].*", Severity.ERROR)
-                .addPattern("version", "^\\d+\\.\\d+(\\.\\d+)?$", Severity.ERROR)
-                .addPattern("email", "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", Severity.WARN);
-            
+            PatternRule.Builder builder = PatternRule.builder().addPattern("title", "^[A-Z].*", Severity.ERROR)
+                    .addPattern("version", "^\\d+\\.\\d+(\\.\\d+)?$", Severity.ERROR)
+                    .addPattern("email", "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", Severity.WARN);
+
             // When
             PatternRule rule = builder.build();
-            
+
             // Then
             assertEquals("metadata.pattern", rule.getRuleId());
             assertTrue(rule.isApplicable("title"));
@@ -52,61 +48,59 @@ class PatternRuleTest {
             assertTrue(rule.isApplicable("email"));
             assertFalse(rule.isApplicable("unknown"));
         }
-        
+
         @Test
         @DisplayName("should reject invalid regex pattern")
         void shouldRejectInvalidRegexPattern() {
             // Given
             PatternRule.Builder builder = PatternRule.builder();
-            
+
             // When/Then
-            assertThrows(IllegalArgumentException.class, () ->
-                builder.addPattern("invalid", "[", Severity.ERROR)
-            );
+            assertThrows(IllegalArgumentException.class, () -> builder.addPattern("invalid", "[", Severity.ERROR));
         }
     }
 
     @Nested
     @DisplayName("Title Pattern Validation")
     class TitlePatternValidation {
-        
+
         private PatternRule rule;
-        
+
         @BeforeEach
         void setUp() {
-            rule = PatternRule.builder()
-                .addPattern("title", "^[A-Z].*", Severity.ERROR)
-                .build();
+            rule = PatternRule.builder().addPattern("title", "^[A-Z].*", Severity.ERROR).build();
         }
-        
+
         @Test
         @DisplayName("should pass when title starts with uppercase")
         void shouldPassWhenTitleStartsWithUppercase() {
             // Given
             String titleValue = "My Document Title";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("title", titleValue, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when title starts with lowercase")
         void shouldFailWhenTitleStartsWithLowercase() {
             // Given
             String titleValue = "my document title";
-            
+
             // When
             List<ValidationMessage> messages = rule.validate("title", titleValue, testLocation);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
             assertEquals(Severity.ERROR, message.getSeverity());
             assertEquals("metadata.pattern", message.getRuleId());
-            assertEquals("Attribute 'title' does not match required pattern: actual 'my document title', expected pattern '^[A-Z].*'", message.getMessage());
+            assertEquals(
+                    "Attribute 'title' does not match required pattern: actual 'my document title', expected pattern '^[A-Z].*'",
+                    message.getMessage());
             // actualValue and expectedValue are already included in the message
         }
     }
@@ -114,34 +108,32 @@ class PatternRuleTest {
     @Nested
     @DisplayName("Version Pattern Validation")
     class VersionPatternValidation {
-        
+
         private PatternRule rule;
-        
+
         @BeforeEach
         void setUp() {
-            rule = PatternRule.builder()
-                .addPattern("version", "^\\d+\\.\\d+(\\.\\d+)?$", Severity.ERROR)
-                .build();
+            rule = PatternRule.builder().addPattern("version", "^\\d+\\.\\d+(\\.\\d+)?$", Severity.ERROR).build();
         }
-        
+
         @Test
         @DisplayName("should accept semantic version format")
         void shouldAcceptSemanticVersionFormat() {
             // Given
             String[] validVersions = {"1.0", "1.0.0", "2.15.3"};
-            
+
             // When/Then
             for (String version : validVersions) {
                 assertTrue(rule.validate("version", version, testLocation).isEmpty());
             }
         }
-        
+
         @Test
         @DisplayName("should reject invalid version format")
         void shouldRejectInvalidVersionFormat() {
             // Given
             String[] invalidVersions = {"1", "1.0.0.0", "v1.0.0", "1.0-SNAPSHOT"};
-            
+
             // When/Then
             for (String version : invalidVersions) {
                 assertFalse(rule.validate("version", version, testLocation).isEmpty());
@@ -152,34 +144,33 @@ class PatternRuleTest {
     @Nested
     @DisplayName("Email Pattern Validation")
     class EmailPatternValidation {
-        
+
         private PatternRule rule;
-        
+
         @BeforeEach
         void setUp() {
             rule = PatternRule.builder()
-                .addPattern("email", "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", Severity.WARN)
-                .build();
+                    .addPattern("email", "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", Severity.WARN).build();
         }
-        
+
         @Test
         @DisplayName("should accept valid email formats")
         void shouldAcceptValidEmailFormats() {
             // Given
             String[] validEmails = {"user@example.com", "john.doe@company.co.uk", "test+tag@domain.org"};
-            
+
             // When/Then
             for (String email : validEmails) {
                 assertTrue(rule.validate("email", email, testLocation).isEmpty());
             }
         }
-        
+
         @Test
         @DisplayName("should reject invalid email formats")
         void shouldRejectInvalidEmailFormats() {
             // Given
             String[] invalidEmails = {"invalid", "@example.com", "user@", "user@domain"};
-            
+
             // When/Then
             for (String email : invalidEmails) {
                 assertFalse(rule.validate("email", email, testLocation).isEmpty());
@@ -190,33 +181,29 @@ class PatternRuleTest {
     @Nested
     @DisplayName("Edge Cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should skip validation for null values")
         void shouldSkipValidationForNullValues() {
             // Given
-            PatternRule rule = PatternRule.builder()
-                .addPattern("title", "^[A-Z].*", Severity.ERROR)
-                .build();
-            
+            PatternRule rule = PatternRule.builder().addPattern("title", "^[A-Z].*", Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("title", null, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should skip validation for empty values")
         void shouldSkipValidationForEmptyValues() {
             // Given
-            PatternRule rule = PatternRule.builder()
-                .addPattern("title", "^[A-Z].*", Severity.ERROR)
-                .build();
-            
+            PatternRule rule = PatternRule.builder().addPattern("title", "^[A-Z].*", Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("title", "", testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/RequiredRuleTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/validator/rules/RequiredRuleTest.java
@@ -24,28 +24,23 @@ class RequiredRuleTest {
 
     @BeforeEach
     void setUp() {
-        testLocation = SourceLocation.builder()
-            .filename("test.adoc")
-            .line(1)
-            .build();
+        testLocation = SourceLocation.builder().filename("test.adoc").line(1).build();
     }
 
     @Nested
     @DisplayName("Rule Building")
     class RuleBuilding {
-        
+
         @Test
         @DisplayName("should build rule with required attributes")
         void shouldBuildRuleWithRequiredAttributes() {
             // Given
-            RequiredRule.Builder builder = RequiredRule.builder()
-                .addAttribute("title", true, Severity.ERROR)
-                .addAttribute("author", true, Severity.ERROR)
-                .addAttribute("email", false, Severity.WARN);
-            
+            RequiredRule.Builder builder = RequiredRule.builder().addAttribute("title", true, Severity.ERROR)
+                    .addAttribute("author", true, Severity.ERROR).addAttribute("email", false, Severity.WARN);
+
             // When
             RequiredRule rule = builder.build();
-            
+
             // Then
             assertEquals("metadata.required", rule.getRuleId());
             assertTrue(rule.isApplicable("title"));
@@ -58,33 +53,29 @@ class RequiredRuleTest {
     @Nested
     @DisplayName("Validation")
     class Validation {
-        
+
         @Test
         @DisplayName("should pass when required attribute has value")
         void shouldPassWhenRequiredAttributeHasValue() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("title", true, Severity.ERROR)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("title", true, Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("title", "My Document", testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should fail when required attribute is null")
         void shouldFailWhenRequiredAttributeIsNull() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("author", true, Severity.ERROR)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("author", true, Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("author", null, testLocation);
-            
+
             // Then
             assertEquals(1, messages.size());
             ValidationMessage message = messages.get(0);
@@ -92,48 +83,42 @@ class RequiredRuleTest {
             assertEquals("metadata.required", message.getRuleId());
             assertEquals("Missing required attribute 'author'", message.getMessage());
         }
-        
+
         @Test
         @DisplayName("should pass when required attribute is empty")
         void shouldPassWhenRequiredAttributeIsEmpty() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("version", true, Severity.ERROR)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("version", true, Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("version", "", testLocation);
-            
+
             // Then
             assertEquals(0, messages.size()); // Empty values are valid for metadata attributes
         }
-        
+
         @Test
         @DisplayName("should pass when required attribute is whitespace only")
         void shouldPassWhenRequiredAttributeIsWhitespaceOnly() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("revdate", true, Severity.ERROR)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("revdate", true, Severity.ERROR).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("revdate", "   ", testLocation);
-            
+
             // Then
             assertEquals(0, messages.size()); // Whitespace-only values are valid for metadata attributes
         }
-        
+
         @Test
         @DisplayName("should pass when optional attribute is missing")
         void shouldPassWhenOptionalAttributeIsMissing() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("email", false, Severity.WARN)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("email", false, Severity.WARN).build();
+
             // When
             List<ValidationMessage> messages = rule.validate("email", null, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }
@@ -142,47 +127,42 @@ class RequiredRuleTest {
     @Nested
     @DisplayName("Missing Attributes Validation")
     class MissingAttributesValidation {
-        
+
         @Test
         @DisplayName("should detect all missing required attributes")
         void shouldDetectAllMissingRequiredAttributes() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("title", true, Severity.ERROR)
-                .addAttribute("author", true, Severity.ERROR)
-                .addAttribute("version", true, Severity.ERROR)
-                .addAttribute("email", false, Severity.WARN)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("title", true, Severity.ERROR)
+                    .addAttribute("author", true, Severity.ERROR).addAttribute("version", true, Severity.ERROR)
+                    .addAttribute("email", false, Severity.WARN).build();
+
             Set<String> presentAttributes = new HashSet<>();
             presentAttributes.add("title");
-            
+
             // When
             List<ValidationMessage> messages = rule.validateMissingAttributes(presentAttributes, testLocation);
-            
+
             // Then
             assertEquals(2, messages.size());
             assertTrue(messages.stream().anyMatch(m -> m.getMessage().equals("Missing required attribute 'author'")));
             assertTrue(messages.stream().anyMatch(m -> m.getMessage().equals("Missing required attribute 'version'")));
             assertFalse(messages.stream().anyMatch(m -> m.getMessage().contains("Missing required attribute 'email'")));
         }
-        
+
         @Test
         @DisplayName("should return empty list when all required attributes present")
         void shouldReturnEmptyListWhenAllRequiredAttributesPresent() {
             // Given
-            RequiredRule rule = RequiredRule.builder()
-                .addAttribute("title", true, Severity.ERROR)
-                .addAttribute("author", true, Severity.ERROR)
-                .build();
-            
+            RequiredRule rule = RequiredRule.builder().addAttribute("title", true, Severity.ERROR)
+                    .addAttribute("author", true, Severity.ERROR).build();
+
             Set<String> presentAttributes = new HashSet<>();
             presentAttributes.add("title");
             presentAttributes.add("author");
-            
+
             // When
             List<ValidationMessage> messages = rule.validateMissingAttributes(presentAttributes, testLocation);
-            
+
             // Then
             assertTrue(messages.isEmpty());
         }

--- a/src/test/java/com/dataliquid/linter/LinterTest.java
+++ b/src/test/java/com/dataliquid/linter/LinterTest.java
@@ -28,272 +28,251 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 @DisplayName("Linter")
 class LinterTest {
-    
+
     private Linter linter;
-    
+
     @BeforeEach
     void setUp() {
         linter = new Linter();
     }
-    
+
     @AfterEach
     void tearDown() {
         linter.close();
     }
-    
+
     @Nested
     @DisplayName("validateFile")
     class ValidateFileTest {
-        
+
         @Test
         @DisplayName("should throw NullPointerException when file is null")
         void shouldThrowNullPointerExceptionWhenFileIsNull() {
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateFile(null, config),
-                "file must not be null"
-            );
+
+            assertThrows(NullPointerException.class, () -> linter.validateFile(null, config), "file must not be null");
         }
-        
+
         @Test
         @DisplayName("should throw NullPointerException when config is null")
         void shouldThrowNullPointerExceptionWhenConfigIsNull(@TempDir Path tempDir) throws IOException {
             Path file = tempDir.resolve("test.adoc");
             Files.writeString(file, "= Test");
-            
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateFile(file, null),
-                "config must not be null"
-            );
+
+            assertThrows(NullPointerException.class, () -> linter.validateFile(file, null), "config must not be null");
         }
-        
+
         @Test
         @DisplayName("should throw IOException when file does not exist")
         void shouldThrowIOExceptionWhenFileDoesNotExist(@TempDir Path tempDir) {
             Path nonExistentFile = tempDir.resolve("non-existent.adoc");
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            IOException exception = assertThrows(IOException.class, () -> 
-                linter.validateFile(nonExistentFile, config)
-            );
-            
+
+            IOException exception = assertThrows(IOException.class, () -> linter.validateFile(nonExistentFile, config));
+
             assertTrue(exception.getMessage().contains("File does not exist"));
         }
-        
+
         @Test
         @DisplayName("should throw IOException when path is directory")
         void shouldThrowIOExceptionWhenPathIsDirectory(@TempDir Path tempDir) {
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            IOException exception = assertThrows(IOException.class, () -> 
-                linter.validateFile(tempDir, config)
-            );
-            
+
+            IOException exception = assertThrows(IOException.class, () -> linter.validateFile(tempDir, config));
+
             assertTrue(exception.getMessage().contains("Not a regular file"));
         }
-        
+
         @Test
         @DisplayName("should validate valid AsciiDoc file")
         void shouldValidateValidAsciiDocFile(@TempDir Path tempDir) throws IOException {
             Path file = tempDir.resolve("valid.adoc");
             Files.writeString(file, """
-                = Valid Document
-                John Doe <john@example.com>
-                v1.0, 2024-01-15
-                
-                == Introduction
-                
-                This is a valid document.
-                """);
-            
+                    = Valid Document
+                    John Doe <john@example.com>
+                    v1.0, 2024-01-15
+
+                    == Introduction
+
+                    This is a valid document.
+                    """);
+
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             ValidationResult result = linter.validateFile(file, config);
-            
+
             assertNotNull(result);
             assertFalse(result.hasErrors());
             assertFalse(result.hasWarnings());
         }
-        
+
         @Test
         @DisplayName("should validate file with configuration")
         void shouldValidateFileWithConfiguration(@TempDir Path tempDir) throws IOException {
             Path file = tempDir.resolve("document.adoc");
             Files.writeString(file, """
-                = Document Title
-                Author Name
-                
-                == Section
-                
-                Content here.
-                """);
-            
+                    = Document Title
+                    Author Name
+
+                    == Section
+
+                    Content here.
+                    """);
+
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             ValidationResult result = linter.validateFile(file, config);
-            
+
             assertNotNull(result);
             // With empty config, no validation errors should occur
             assertEquals(0, result.getErrorCount());
         }
     }
-    
+
     @Nested
     @DisplayName("validateFiles")
     class ValidateFilesTest {
-        
+
         @Test
         @DisplayName("should throw NullPointerException when files is null")
         void shouldThrowNullPointerExceptionWhenFilesIsNull() {
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateFiles(null, config),
-                "files must not be null"
-            );
+
+            assertThrows(NullPointerException.class, () -> linter.validateFiles(null, config),
+                    "files must not be null");
         }
-        
+
         @Test
         @DisplayName("should throw NullPointerException when config is null")
         void shouldThrowNullPointerExceptionWhenConfigIsNull() {
             List<Path> files = List.of();
-            
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateFiles(files, null),
-                "config must not be null"
-            );
+
+            assertThrows(NullPointerException.class, () -> linter.validateFiles(files, null),
+                    "config must not be null");
         }
-        
+
         @Test
         @DisplayName("should return empty map for empty file list")
         void shouldReturnEmptyMapForEmptyFileList() {
             List<Path> files = List.of();
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             Map<Path, ValidationResult> results = linter.validateFiles(files, config);
-            
+
             assertNotNull(results);
             assertTrue(results.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should validate multiple files")
         void shouldValidateMultipleFiles(@TempDir Path tempDir) throws IOException {
             Path file1 = tempDir.resolve("file1.adoc");
             Files.writeString(file1, "= Document 1\n\nContent 1");
-            
+
             Path file2 = tempDir.resolve("file2.adoc");
             Files.writeString(file2, "= Document 2\n\nContent 2");
-            
+
             List<Path> files = List.of(file1, file2);
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             Map<Path, ValidationResult> results = linter.validateFiles(files, config);
-            
+
             assertNotNull(results);
             assertEquals(2, results.size());
             assertTrue(results.containsKey(file1));
             assertTrue(results.containsKey(file2));
         }
-        
+
         @Test
         @DisplayName("should create error result for non-existent file")
         void shouldCreateErrorResultForNonExistentFile(@TempDir Path tempDir) throws IOException {
             Path existingFile = tempDir.resolve("existing.adoc");
             Files.writeString(existingFile, "= Existing\n\nContent");
-            
+
             Path nonExistentFile = tempDir.resolve("non-existent.adoc");
-            
+
             List<Path> files = List.of(existingFile, nonExistentFile);
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             Map<Path, ValidationResult> results = linter.validateFiles(files, config);
-            
+
             assertNotNull(results);
             assertEquals(2, results.size());
-            
+
             ValidationResult errorResult = results.get(nonExistentFile);
             assertNotNull(errorResult);
             assertTrue(errorResult.hasErrors());
             assertEquals(1, errorResult.getErrorCount());
-            
+
             List<ValidationMessage> messages = errorResult.getMessages();
             assertEquals(1, messages.size());
             assertEquals("io-error", messages.get(0).getRuleId());
         }
     }
-    
+
     @Nested
     @DisplayName("validateDirectory")
     class ValidateDirectoryTest {
-        
+
         @Test
         @DisplayName("should throw NullPointerException when directory is null")
         void shouldThrowNullPointerExceptionWhenDirectoryIsNull() {
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateDirectory(null, "*.adoc", false, config),
-                "directory must not be null"
-            );
+
+            assertThrows(NullPointerException.class, () -> linter.validateDirectory(null, "*.adoc", false, config),
+                    "directory must not be null");
         }
-        
+
         @Test
         @DisplayName("should throw NullPointerException when pattern is null")
         void shouldThrowNullPointerExceptionWhenPatternIsNull(@TempDir Path tempDir) {
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateDirectory(tempDir, null, false, config),
-                "pattern must not be null"
-            );
+
+            assertThrows(NullPointerException.class, () -> linter.validateDirectory(tempDir, null, false, config),
+                    "pattern must not be null");
         }
-        
+
         @Test
         @DisplayName("should throw NullPointerException when config is null")
         void shouldThrowNullPointerExceptionWhenConfigIsNull(@TempDir Path tempDir) {
-            assertThrows(NullPointerException.class, () -> 
-                linter.validateDirectory(tempDir, "*.adoc", false, null),
-                "config must not be null"
-            );
+            assertThrows(NullPointerException.class, () -> linter.validateDirectory(tempDir, "*.adoc", false, null),
+                    "config must not be null");
         }
-        
+
         @Test
         @DisplayName("should throw IOException when path is not directory")
         void shouldThrowIOExceptionWhenPathIsNotDirectory(@TempDir Path tempDir) throws IOException {
             Path file = tempDir.resolve("file.txt");
             Files.writeString(file, "content");
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
-            IOException exception = assertThrows(IOException.class, () -> 
-                linter.validateDirectory(file, "*.adoc", false, config)
-            );
-            
+
+            IOException exception = assertThrows(IOException.class,
+                    () -> linter.validateDirectory(file, "*.adoc", false, config));
+
             assertTrue(exception.getMessage().contains("Not a directory"));
         }
-        
+
         @Test
         @DisplayName("should find and validate matching files non-recursively")
         void shouldFindAndValidateMatchingFilesNonRecursively(@TempDir Path tempDir) throws IOException {
             Path file1 = tempDir.resolve("test1.adoc");
             Files.writeString(file1, "= Test 1");
-            
+
             Path file2 = tempDir.resolve("test2.adoc");
             Files.writeString(file2, "= Test 2");
-            
+
             Path file3 = tempDir.resolve("other.txt");
             Files.writeString(file3, "Other content");
-            
+
             Path subDir = tempDir.resolve("subdir");
             Files.createDirectory(subDir);
             Path file4 = subDir.resolve("test3.adoc");
             Files.writeString(file4, "= Test 3");
-            
+
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             Map<Path, ValidationResult> results = linter.validateDirectory(tempDir, "*.adoc", false, config);
-            
+
             assertNotNull(results);
             assertEquals(2, results.size());
             assertTrue(results.containsKey(file1));
@@ -301,62 +280,62 @@ class LinterTest {
             assertFalse(results.containsKey(file3));
             assertFalse(results.containsKey(file4));
         }
-        
+
         @Test
         @DisplayName("should find and validate matching files recursively")
         void shouldFindAndValidateMatchingFilesRecursively(@TempDir Path tempDir) throws IOException {
             Path file1 = tempDir.resolve("test1.adoc");
             Files.writeString(file1, "= Test 1");
-            
+
             Path subDir = tempDir.resolve("subdir");
             Files.createDirectory(subDir);
             Path file2 = subDir.resolve("test2.adoc");
             Files.writeString(file2, "= Test 2");
-            
+
             Path deepDir = subDir.resolve("deep");
             Files.createDirectory(deepDir);
             Path file3 = deepDir.resolve("test3.adoc");
             Files.writeString(file3, "= Test 3");
-            
+
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             Map<Path, ValidationResult> results = linter.validateDirectory(tempDir, "*.adoc", true, config);
-            
+
             assertNotNull(results);
             assertEquals(3, results.size());
             assertTrue(results.containsKey(file1));
             assertTrue(results.containsKey(file2));
             assertTrue(results.containsKey(file3));
         }
-        
+
         @Test
         @DisplayName("should return empty map when no files match pattern")
         void shouldReturnEmptyMapWhenNoFilesMatchPattern(@TempDir Path tempDir) throws IOException {
             Path file1 = tempDir.resolve("test.txt");
             Files.writeString(file1, "Text file");
-            
+
             Path file2 = tempDir.resolve("other.md");
             Files.writeString(file2, "Markdown file");
-            
+
             LinterConfiguration config = LinterConfiguration.builder().build();
-            
+
             Map<Path, ValidationResult> results = linter.validateDirectory(tempDir, "*.adoc", false, config);
-            
+
             assertNotNull(results);
             assertTrue(results.isEmpty());
         }
     }
-    
+
     @Nested
     @DisplayName("close")
     class CloseTest {
-        
+
         @Test
         @DisplayName("should close without error")
         void shouldCloseWithoutError() {
             assertDoesNotThrow(() -> linter.close());
         }
-        
+
         @Test
         @DisplayName("should handle multiple close calls")
         void shouldHandleMultipleCloseCalls() {
@@ -366,89 +345,89 @@ class LinterTest {
             });
         }
     }
-    
+
     @Nested
     @DisplayName("Integration")
     class IntegrationTest {
-        
+
         @Test
         @DisplayName("should validate document with metadata and sections")
         void shouldValidateDocumentWithMetadataAndSections(@TempDir Path tempDir) throws IOException {
             Path adocFile = tempDir.resolve("document.adoc");
             Files.writeString(adocFile, """
-                = Test Document
-                John Doe <john@example.com>
-                v1.0, 2024-01-15
-                
-                == Introduction
-                
-                This is the introduction section.
-                
-                == Main Content
-                
-                This is the main content.
-                
-                [source,java]
-                ----
-                public class Example {
-                    // Code here
-                }
-                ----
-                """);
-            
+                    = Test Document
+                    John Doe <john@example.com>
+                    v1.0, 2024-01-15
+
+                    == Introduction
+
+                    This is the introduction section.
+
+                    == Main Content
+
+                    This is the main content.
+
+                    [source,java]
+                    ----
+                    public class Example {
+                        // Code here
+                    }
+                    ----
+                    """);
+
             String configYaml = """
-                document:
-                  metadata:
-                    attributes:
-                      - name: author
-                        required: true
-                        pattern: "^[A-Z][a-zA-Z\\\\s]+$"
-                        severity: error
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                    - name: introduction
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^Introduction$"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
-                            severity: warn
-                    - name: mainContent
-                      level: 1
-                      occurrence:
-                        min: 1
-                      title:
-                        pattern: "^Main.*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
-                            severity: info
-                        - listing:
-                            severity: warn
-                            language:
-                              required: true
-                              severity: error
-                """;
-            
+                    document:
+                      metadata:
+                        attributes:
+                          - name: author
+                            required: true
+                            pattern: "^[A-Z][a-zA-Z\\\\s]+$"
+                            severity: error
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z].*"
+                            severity: error
+                        - name: introduction
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^Introduction$"
+                            severity: error
+                          allowedBlocks:
+                            - paragraph:
+                                severity: warn
+                        - name: mainContent
+                          level: 1
+                          occurrence:
+                            min: 1
+                          title:
+                            pattern: "^Main.*"
+                            severity: error
+                          allowedBlocks:
+                            - paragraph:
+                                severity: info
+                            - listing:
+                                severity: warn
+                                language:
+                                  required: true
+                                  severity: error
+                    """;
+
             Path configFile = tempDir.resolve("config.yaml");
             Files.writeString(configFile, configYaml);
-            
+
             ConfigurationLoader loader = new ConfigurationLoader();
             LinterConfiguration config = loader.loadConfiguration(configFile);
-            
+
             ValidationResult result = linter.validateFile(adocFile, config);
-            
+
             assertNotNull(result);
             // Just verify the validation completes without throwing exceptions
             // The actual validation logic is tested in individual validator tests

--- a/src/test/java/com/dataliquid/linter/LinterValidationIntegrationTest.java
+++ b/src/test/java/com/dataliquid/linter/LinterValidationIntegrationTest.java
@@ -22,776 +22,781 @@ import com.dataliquid.asciidoc.linter.validator.ValidationResult;
 
 @DisplayName("Linter Validation Integration Test")
 class LinterValidationIntegrationTest {
-    
+
     private Linter linter;
     private ConfigurationLoader configLoader;
-    
+
     @BeforeEach
     void setUp() {
         linter = new Linter();
         configLoader = new ConfigurationLoader(); // Schema validation enabled
     }
-    
+
     @AfterEach
     void tearDown() {
         linter.close();
     }
-    
+
     @Nested
     @DisplayName("Metadata Attribute Validation")
     class MetadataAttributeValidationTest {
-        
+
         @Nested
         @DisplayName("Required Attribute Tests")
         class RequiredAttributeTests {
-            
-            
+
             @Test
             @DisplayName("should detect missing required author")
             void shouldDetectMissingRequiredAuthor() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document Without Author
-                    
-                    Content here.
-                    """;
-                
+                        = Document Without Author
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertEquals(1, result.getErrorCount());
                 assertEquals("Missing required attribute 'author'", result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should detect multiple missing required attributes")
             void shouldDetectMultipleMissingRequiredAttributes() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            severity: error
-                          - name: revdate
-                            required: true
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                severity: error
+                              - name: revdate
+                                required: true
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Only Title Present
-                    
-                    Content here.
-                    """;
-                
+                        = Only Title Present
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertEquals(2, result.getErrorCount());
                 List<ValidationMessage> messages = result.getMessages();
-                assertTrue(messages.stream().anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'author'")));
-                assertTrue(messages.stream().anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'revdate'")));
+                assertTrue(messages.stream()
+                        .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'author'")));
+                assertTrue(messages.stream()
+                        .anyMatch(msg -> msg.getMessage().equals("Missing required attribute 'revdate'")));
             }
-            
+
             @Test
             @DisplayName("should accept all required attributes present")
             void shouldAcceptAllRequiredAttributesPresent() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Complete Document
-                    John Doe <john@example.com>
-                    
-                    Content here.
-                    """;
-                
+                        = Complete Document
+                        John Doe <john@example.com>
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
         }
-        
+
         @Nested
         @DisplayName("Pattern Validation Tests")
         class PatternValidationTests {
-            
+
             @Test
             @DisplayName("should validate email pattern")
             void shouldValidateEmailPattern() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: email
-                            required: true
-                            pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: email
+                                required: true
+                                pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :email: invalid-email
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :email: invalid-email
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
-                assertEquals("Attribute 'email' does not match required pattern: actual 'invalid-email', expected pattern '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'", 
-                    result.getMessages().get(0).getMessage());
+                assertEquals(
+                        "Attribute 'email' does not match required pattern: actual 'invalid-email', expected pattern '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$'",
+                        result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should validate date pattern")
             void shouldValidateDatePattern() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: revdate
-                            required: true
-                            pattern: "^\\\\d{4}-\\\\d{2}-\\\\d{2}$"
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: revdate
+                                required: true
+                                pattern: "^\\\\d{4}-\\\\d{2}-\\\\d{2}$"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :revdate: 15.01.2024
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :revdate: 15.01.2024
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
-                assertEquals("Attribute 'revdate' does not match required pattern: actual '15.01.2024', expected pattern '^\\d{4}-\\d{2}-\\d{2}$'", 
-                    result.getMessages().get(0).getMessage());
+                assertEquals(
+                        "Attribute 'revdate' does not match required pattern: actual '15.01.2024', expected pattern '^\\d{4}-\\d{2}-\\d{2}$'",
+                        result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should accept valid patterns")
             void shouldAcceptValidPatterns() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: version
-                            required: true
-                            pattern: "^\\\\d+\\\\.\\\\d+(\\\\.\\\\d+)?$"
-                            severity: error
-                          - name: author
-                            required: true
-                            pattern: "^[A-Z][a-zA-Z\\\\s]+$"
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: version
+                                required: true
+                                pattern: "^\\\\d+\\\\.\\\\d+(\\\\.\\\\d+)?$"
+                                severity: error
+                              - name: author
+                                required: true
+                                pattern: "^[A-Z][a-zA-Z\\\\s]+$"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    John Doe
-                    :version: 1.0.0
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        John Doe
+                        :version: 1.0.0
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
         }
-        
+
         @Nested
         @DisplayName("Length Validation Tests")
         class LengthValidationTests {
-            
+
             @Test
             @DisplayName("should validate minimum length")
             void shouldValidateMinimumLength() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            minLength: 5
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                minLength: 5
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :author: Bob
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :author: Bob
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
-                assertEquals("Attribute 'author' is too short: actual 'Bob' (3 characters), expected minimum 5 characters", 
-                    result.getMessages().get(0).getMessage());
+                assertEquals(
+                        "Attribute 'author' is too short: actual 'Bob' (3 characters), expected minimum 5 characters",
+                        result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should validate maximum length")
             void shouldValidateMaximumLength() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: keywords
-                            required: true
-                            maxLength: 20
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: keywords
+                                required: true
+                                maxLength: 20
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :keywords: This is a very long keywords list that exceeds the maximum allowed
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :keywords: This is a very long keywords list that exceeds the maximum allowed
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
-                assertEquals("Attribute 'keywords' is too long: actual 'This is a very long keywords list that exceeds the maximum allowed' (66 characters), expected maximum 20 characters", 
-                    result.getMessages().get(0).getMessage());
+                assertEquals(
+                        "Attribute 'keywords' is too long: actual 'This is a very long keywords list that exceeds the maximum allowed' (66 characters), expected maximum 20 characters",
+                        result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should accept length within bounds")
             void shouldAcceptLengthWithinBounds() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: description
-                            required: true
-                            minLength: 5
-                            maxLength: 50
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: description
+                                required: true
+                                minLength: 5
+                                maxLength: 50
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :description: Valid description length
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :description: Valid description length
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
         }
-        
+
         @Nested
         @DisplayName("Severity Level Tests")
         class SeverityLevelTests {
-            
+
             @Test
             @DisplayName("should report error severity for missing required")
             void shouldReportErrorSeverity() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertEquals(1, result.getErrorCount());
                 assertEquals(0, result.getWarningCount());
             }
-            
+
             @Test
             @DisplayName("should report warning severity")
             void shouldReportWarningSeverity() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: email
-                            pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
-                            required: true
-                            severity: warn
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: email
+                                pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
+                                required: true
+                                severity: warn
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :email: invalid-email
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :email: invalid-email
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
                 assertTrue(result.hasWarnings());
                 assertEquals(1, result.getWarningCount());
             }
-            
+
             @Test
             @DisplayName("should report info severity")
             void shouldReportInfoSeverity() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: keywords
-                            minLength: 10
-                            required: true
-                            severity: info
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: keywords
+                                minLength: 10
+                                required: true
+                                severity: info
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :keywords: short
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :keywords: short
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
                 assertFalse(result.hasWarnings());
                 assertEquals(1, result.getInfoCount());
             }
         }
-        
+
         @Nested
         @DisplayName("Edge Cases and Special Tests")
         class EdgeCasesTests {
-            
+
             @Test
             @DisplayName("should validate empty attribute with minLength")
             void shouldValidateEmptyAttributeWithMinLength() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            minLength: 1
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                minLength: 1
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :author:
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :author:
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
-                assertEquals("Attribute 'author' is too short: actual '' (0 characters), expected minimum 1 characters", 
-                    result.getMessages().get(0).getMessage());
+                assertEquals("Attribute 'author' is too short: actual '' (0 characters), expected minimum 1 characters",
+                        result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should validate multiple constraints on single attribute")
             void shouldValidateMultipleConstraints() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: description
-                            required: true
-                            pattern: "^[A-Z].*"
-                            minLength: 10
-                            maxLength: 50
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: description
+                                required: true
+                                pattern: "^[A-Z].*"
+                                minLength: 10
+                                maxLength: 50
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :description: short
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :description: short
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertEquals(2, result.getErrorCount()); // Pattern and minLength violations
                 List<ValidationMessage> messages = result.getMessages();
                 assertTrue(messages.stream().anyMatch(msg -> msg.getMessage().equals(
-                    "Attribute 'description' does not match required pattern: actual 'short', expected pattern '^[A-Z].*'")));
+                        "Attribute 'description' does not match required pattern: actual 'short', expected pattern '^[A-Z].*'")));
                 assertTrue(messages.stream().anyMatch(msg -> msg.getMessage().equals(
-                    "Attribute 'description' is too short: actual 'short' (5 characters), expected minimum 10 characters")));
+                        "Attribute 'description' is too short: actual 'short' (5 characters), expected minimum 10 characters")));
             }
-            
+
             @Test
             @DisplayName("should allow empty toc attribute")
             void shouldAllowEmptyTocAttribute() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: toc
-                            required: true
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: toc
+                                required: true
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :toc:
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :toc:
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should validate toc attribute with allowed values")
             void shouldValidateTocAttributeWithAllowedValues() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: toc
-                            required: true
-                            pattern: "^(left|right|preamble|macro)?$"
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: toc
+                                required: true
+                                pattern: "^(left|right|preamble|macro)?$"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :toc: left
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :toc: left
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should allow empty toc attribute with pattern")
             void shouldAllowEmptyTocAttributeWithPattern() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: toc
-                            required: true
-                            pattern: "^(left|right|preamble|macro)?$"
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: toc
+                                required: true
+                                pattern: "^(left|right|preamble|macro)?$"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :toc:
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :toc:
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should distinguish between missing and empty attributes")
             void shouldDistinguishBetweenMissingAndEmptyAttributes() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: toc
-                            required: true
-                            severity: error
-                          - name: author
-                            required: true
-                            minLength: 1
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: toc
+                                required: true
+                                severity: error
+                              - name: author
+                                required: true
+                                minLength: 1
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :toc:
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :toc:
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertEquals(1, result.getErrorCount());
                 // toc is present (empty is OK), but author is missing
                 assertEquals("Missing required attribute 'author'", result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should ignore undefined attributes")
             void shouldIgnoreUndefinedAttributes() {
                 // Given - configuration defines only title and author
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                severity: error
+                        """;
+
                 // Document has additional attributes that are not defined in rules
                 String adocContent = """
-                    = Document Title
-                    John Doe
-                    :keywords: java, testing, asciidoc
-                    :custom-field: some value
-                    :version: 1.0.0
-                    :toc:
-                    
-                    Content here.
-                    """;
-                
+                        = Document Title
+                        John Doe
+                        :keywords: java, testing, asciidoc
+                        :custom-field: some value
+                        :version: 1.0.0
+                        :toc:
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then - no errors because undefined attributes are ignored
                 assertFalse(result.hasErrors());
                 assertFalse(result.hasWarnings());
             }
-            
+
             @Test
             @DisplayName("should handle special characters in attribute values")
             void shouldHandleSpecialCharactersInAttributeValues() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            pattern: "^[A-Za-zÄÖÜäöüß\\\\s]+$"
-                            severity: error
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                pattern: "^[A-Za-zÄÖÜäöüß\\\\s]+$"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = Document
-                    :author: Björn Müller
-                    
-                    Content here.
-                    """;
-                
+                        = Document
+                        :author: Björn Müller
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
         }
-        
+
         @Nested
         @DisplayName("Complex Integration Scenarios")
         class ComplexIntegrationTests {
-            
+
             @Test
             @DisplayName("should validate complex metadata configuration")
             void shouldValidateComplexMetadataConfiguration() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: author
-                            required: true
-                            pattern: "^[A-Z][a-zA-Z\\\\s\\\\.]+$"
-                            minLength: 5
-                            maxLength: 50
-                            severity: error
-                          - name: revdate
-                            required: true
-                            pattern: "^\\\\d{4}-\\\\d{2}-\\\\d{2}$"
-                            severity: error
-                          - name: version
-                            required: true
-                            pattern: "^\\\\d+\\\\.\\\\d+(\\\\.\\\\d+)?$"
-                            severity: error
-                          - name: email
-                            required: false
-                            pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
-                            severity: warn
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: author
+                                required: true
+                                pattern: "^[A-Z][a-zA-Z\\\\s\\\\.]+$"
+                                minLength: 5
+                                maxLength: 50
+                                severity: error
+                              - name: revdate
+                                required: true
+                                pattern: "^\\\\d{4}-\\\\d{2}-\\\\d{2}$"
+                                severity: error
+                              - name: version
+                                required: true
+                                pattern: "^\\\\d+\\\\.\\\\d+(\\\\.\\\\d+)?$"
+                                severity: error
+                              - name: email
+                                required: false
+                                pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}$"
+                                severity: warn
+                        """;
+
                 String adocContent = """
-                    = Complete Technical Documentation
-                    John Doe Sr.
-                    :revdate: 2024-01-15
-                    :version: 2.1.0
-                    :email: john.doe@example.com
-                    
-                    Content here.
-                    """;
-                
+                        = Complete Technical Documentation
+                        John Doe Sr.
+                        :revdate: 2024-01-15
+                        :version: 2.1.0
+                        :email: john.doe@example.com
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
                 assertFalse(result.hasWarnings());
             }
-            
+
             @Test
             @DisplayName("should validate document with non-required attributes")
             void shouldValidateDocumentWithNonRequiredAttributes() {
                 // Given
                 String rules = """
-                    document:
-                      metadata:
-                        attributes:
-                          - name: description
-                            required: false
-                            maxLength: 5
-                            severity: warn
-                          - name: keywords
-                            required: false
-                            pattern: "^[a-zA-Z,\\\\s]+$"
-                            severity: info
-                    """;
-                
+                        document:
+                          metadata:
+                            attributes:
+                              - name: description
+                                required: false
+                                maxLength: 5
+                                severity: warn
+                              - name: keywords
+                                required: false
+                                pattern: "^[a-zA-Z,\\\\s]+$"
+                                severity: info
+                        """;
+
                 String adocContent = """
-                    = Document Title
-                    :description: This is a very long description
-                    :keywords: java, testing, 123numbers
-                    
-                    Content here.
-                    """;
-                
+                        = Document Title
+                        :description: This is a very long description
+                        :keywords: java, testing, 123numbers
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
                 assertTrue(result.hasWarnings());
@@ -800,88 +805,88 @@ class LinterValidationIntegrationTest {
             }
         }
     }
-    
+
     @Nested
     @DisplayName("Content Validation")
     class ContentValidation {
-        
+
         @Nested
         @DisplayName("Document Title Validation")
         class DocumentTitleValidation {
-            
+
             @Test
             @DisplayName("should not validate title pattern - must start with uppercase")
             void shouldNotValidateTitlePattern() {
                 // Given
                 String rules = """
-                    document:
-                      sections:
-                        - level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                    """;
-                
+                        document:
+                          sections:
+                            - level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^[A-Z].*"
+                                severity: error
+                        """;
+
                 String adocContent = """
-                    = lowercase title
-                    
-                    Content here.
-                    """;
-                
+                        = lowercase title
+
+                        Content here.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
-                assertEquals("Document title does not match required pattern", 
-                    result.getMessages().get(0).getMessage());
+                assertEquals("Document title does not match required pattern",
+                        result.getMessages().get(0).getMessage());
             }
-            
+
             @Test
             @DisplayName("should validate simple section with paragraph blocks")
             void shouldValidateSimpleSectionWithParagraphBlocks() {
                 // Given - Simple test with just one section
                 String rules = """
-                    document:
-                      sections:
-                        - name: intro
-                          level: 1
-                          occurrence:
-                            min: 1
-                            max: 1
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                                  severity: error
-                    """;
-                
+                        document:
+                          sections:
+                            - name: intro
+                              level: 1
+                              occurrence:
+                                min: 1
+                                max: 1
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      max: 2
+                                      severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    == Introduction
-                    
-                    This is the first paragraph.
-                    
-                    This is the second paragraph.
-                    """;
-                
+                        = My Document
+
+                        == Introduction
+
+                        This is the first paragraph.
+
+                        This is the second paragraph.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should validate complex document structure as requested")
             void shouldValidateComplexDocumentStructureAsRequested() {
@@ -889,61 +894,17 @@ class LinterValidationIntegrationTest {
                 // level 0 with paragraphs min 1 max 2
                 // subsection level 1 "Introduction" with paragraphs min 1 max 2
                 // subsection level 1 "Tutorial" with paragraphs min 1 (no max)
-                //   subsection level 2 with paragraphs min 1 max 2
+                // subsection level 2 with paragraphs min 1 max 2
                 String rules = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                                  severity: error
-                        - name: einleitung
-                          level: 1
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^Einleitung$"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                                  severity: error
-                        - name: tutorial
-                          level: 1
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^Tutorial$"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                                occurrence:
-                                  min: 1
-                                  severity: error
-                          subsections:
-                            - level: 2
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
                               occurrence:
-                                min: 0
-                                max: 10
+                                min: 1
+                                max: 1
                               title:
-                                pattern: "^Step \\\\d+$"
+                                pattern: "^[A-Z].*"
                                 severity: error
                               allowedBlocks:
                                 - paragraph:
@@ -952,398 +913,334 @@ class LinterValidationIntegrationTest {
                                       min: 1
                                       max: 2
                                       severity: error
-                    """;
-                
+                            - name: einleitung
+                              level: 1
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^Einleitung$"
+                                severity: error
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      max: 2
+                                      severity: error
+                            - name: tutorial
+                              level: 1
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^Tutorial$"
+                                severity: error
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      severity: error
+                              subsections:
+                                - level: 2
+                                  occurrence:
+                                    min: 0
+                                    max: 10
+                                  title:
+                                    pattern: "^Step \\\\d+$"
+                                    severity: error
+                                  allowedBlocks:
+                                    - paragraph:
+                                        severity: error
+                                        occurrence:
+                                          min: 1
+                                          max: 2
+                                          severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    This is a paragraph at document level.
-                    
-                    This is another paragraph at document level.
-                    
-                    == Einleitung
-                    
-                    First paragraph in Einleitung section.
-                    
-                    Second paragraph in Einleitung section.
-                    
-                    == Tutorial
-                    
-                    First paragraph in Tutorial.
-                    
-                    Second paragraph in Tutorial.
-                    
-                    Third paragraph in Tutorial (no max limit).
-                    
-                    === Step 1
-                    
-                    Step 1 paragraph.
-                    
-                    === Step 2
-                    
-                    Step 2 first paragraph.
-                    
-                    Step 2 second paragraph.
-                    """;
-                
+                        = My Document
+
+                        This is a paragraph at document level.
+
+                        This is another paragraph at document level.
+
+                        == Einleitung
+
+                        First paragraph in Einleitung section.
+
+                        Second paragraph in Einleitung section.
+
+                        == Tutorial
+
+                        First paragraph in Tutorial.
+
+                        Second paragraph in Tutorial.
+
+                        Third paragraph in Tutorial (no max limit).
+
+                        === Step 1
+
+                        Step 1 paragraph.
+
+                        === Step 2
+
+                        Step 2 first paragraph.
+
+                        Step 2 second paragraph.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should detect too many paragraphs in Einleitung section")
             void shouldDetectTooManyParagraphsInEinleitung() {
                 // Given
                 String rules = """
-                    document:
-                      sections:
-                        - name: einleitung
-                          level: 1
-                          occurrence:
-                            min: 1
-                            max: 1
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                                  severity: error
-                    """;
-                
+                        document:
+                          sections:
+                            - name: einleitung
+                              level: 1
+                              occurrence:
+                                min: 1
+                                max: 1
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      max: 2
+                                      severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    == Einleitung
-                    
-                    First paragraph.
-                    
-                    Second paragraph.
-                    
-                    Third paragraph - this exceeds the max of 2.
-                    """;
-                
+                        = My Document
+
+                        == Einleitung
+
+                        First paragraph.
+
+                        Second paragraph.
+
+                        Third paragraph - this exceeds the max of 2.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertTrue(result.getMessages().stream()
-                    .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
+                        .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
             }
-            
+
             @Test
             @DisplayName("should validate document level blocks correctly")
             void shouldValidateDocumentLevelBlocksCorrectly() {
                 // Given - Simple test with just document level paragraphs
                 String rules = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^[A-Z].*"
                                 severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                                  severity: error
-                    """;
-                
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      max: 2
+                                      severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    First paragraph at document level.
-                    
-                    Second paragraph at document level.
-                    """;
-                
+                        = My Document
+
+                        First paragraph at document level.
+
+                        Second paragraph at document level.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should validate exactly two paragraphs at document level")
             void shouldValidateExactlyTwoParagraphsAtDocumentLevel() {
                 // Given - Only document level with 2 paragraphs
                 String rules = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^[A-Z].*"
                                 severity: error
-                                occurrence:
-                                  min: 2
-                                  max: 2
-                                  severity: error
-                    """;
-                
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 2
+                                      max: 2
+                                      severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    First paragraph at document level.
-                    
-                    Second paragraph at document level.
-                    """;
-                
+                        = My Document
+
+                        First paragraph at document level.
+
+                        Second paragraph at document level.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should validate document level blocks with sections present")
             void shouldValidateDocumentLevelBlocksWithSectionsPresent() {
                 // Given - Document with 2 paragraphs at root + section with paragraph
                 String rules = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                                occurrence:
-                                  min: 2
-                                  max: 2
-                                  severity: error
-                        - name: section1
-                          level: 1
-                          occurrence:
-                            min: 0
-                          allowedBlocks:
-                            - paragraph:
-                                severity: error
-                    """;
-                
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 2
+                                      max: 2
+                                      severity: error
+                            - name: section1
+                              level: 1
+                              occurrence:
+                                min: 0
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    First paragraph at document level.
-                    
-                    Second paragraph at document level.
-                    
-                    == Section One
-                    
-                    Paragraph in section one.
-                    """;
-                
+                        = My Document
+
+                        First paragraph at document level.
+
+                        Second paragraph at document level.
+
+                        == Section One
+
+                        Paragraph in section one.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertFalse(result.hasErrors());
             }
-            
+
             @Test
             @DisplayName("should detect too many paragraphs at document level (level 0)")
             void shouldDetectTooManyParagraphsAtDocumentLevel() {
                 // Given
                 String rules = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^[A-Z].*"
                                 severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                                  severity: error
-                    """;
-                
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      max: 2
+                                      severity: error
+                        """;
+
                 String adocContent = """
-                    = My Document
-                    
-                    First paragraph at document level.
-                    
-                    Second paragraph at document level.
-                    
-                    Third paragraph - this exceeds the max of 2.
-                    """;
-                
+                        = My Document
+
+                        First paragraph at document level.
+
+                        Second paragraph at document level.
+
+                        Third paragraph - this exceeds the max of 2.
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
                 assertTrue(result.hasErrors());
                 assertTrue(result.getMessages().stream()
-                    .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
+                        .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
             }
-            
+
             @Test
             @DisplayName("should validate Level 0 subsections configuration - debugging")
             void shouldValidateLevel0SubsectionsConfigurationDebug() {
                 // Given - Level 0 WITHOUT subsections first to verify it works
                 String rulesWithoutSubsections = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
-                                severity: info
-                                occurrence:
-                                  min: 1
-                                  max: 1
-                        - name: mainSections
-                          level: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: info
-                          allowedBlocks:
-                            - paragraph:
-                                severity: info
-                    """;
-                
-                String adocContent = """
-                    = Document Title
-                    
-                    This is the document preamble paragraph.
-                    
-                    == Main Section
-                    
-                    This is a paragraph in the main section.
-                    
-                    Another paragraph in the main section.
-                    """;
-                
-                // First verify without subsections works
-                LinterConfiguration configWithout = configLoader.loadConfiguration(rulesWithoutSubsections);
-                
-                
-                ValidationResult resultWithout = linter.validateContent(adocContent, configWithout);
-                assertFalse(resultWithout.hasErrors(), 
-                    "Without subsections should work, but got: " + resultWithout.getMessages().stream()
-                        .map(msg -> msg.getMessage())
-                        .collect(Collectors.joining(", ")));
-            }
-            
-            @Test
-            @DisplayName("should validate named blocks matching unnamed document blocks")
-            void shouldValidateNamedBlocksMatchingUnnamedDocumentBlocks() {
-                // Given - Config with named blocks
-                String rules = """
-                    document:
-                      sections:
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          allowedBlocks:
-                            - paragraph:
-                                name: Introduction paragraph
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^[A-Z].*"
                                 severity: error
-                                occurrence:
-                                  min: 1
-                                  max: 2
-                            - listing:
-                                name: Example code
-                                severity: info
-                    """;
-                
-                String adocContent = """
-                    = My Document
-                    
-                    This is an introduction paragraph without a name attribute.
-                    
-                    Second paragraph.
-                    
-                    [source,java]
-                    ----
-                    public class Example {
-                        // Code without name attribute
-                    }
-                    ----
-                    """;
-                
-                LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
-                // When
-                ValidationResult result = linter.validateContent(adocContent, config);
-                
-                // Then
-                assertFalse(result.hasErrors(), 
-                    "Named blocks in config should match unnamed blocks in document");
-                assertFalse(result.hasWarnings());
-            }
-            
-            @Test
-            @DisplayName("should validate Level 0 subsections configuration")
-            void shouldValidateLevel0SubsectionsConfiguration() {
-                // Given - Level 0 with subsections structure exactly as in basic-rules.yaml
-                String rules = """
-                    document:
-                      sections:
-                        # Document title (level 0) with subsections structure
-                        - name: documentTitle
-                          level: 0
-                          occurrence:
-                            min: 1
-                            max: 1
-                          title:
-                            pattern: "^[A-Z].*"
-                            severity: error
-                          allowedBlocks:
-                            - paragraph:
-                                name: Document preamble
-                                severity: info
-                                occurrence:
-                                  min: 1
-                                  max: 1
-                          subsections:
-                            # Level 1 sections defined as subsections of level 0
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: info
+                                    occurrence:
+                                      min: 1
+                                      max: 1
                             - name: mainSections
                               level: 1
                               title:
@@ -1351,358 +1248,376 @@ class LinterValidationIntegrationTest {
                                 severity: info
                               allowedBlocks:
                                 - paragraph:
-                                    name: Section paragraphs
                                     severity: info
-                    """;
-                
+                        """;
+
                 String adocContent = """
-                    = Document Title
-                    
-                    This is the document preamble paragraph.
-                    
-                    == Main Section
-                    
-                    This is a paragraph in the main section.
-                    
-                    Another paragraph in the main section.
-                    """;
-                
+                        = Document Title
+
+                        This is the document preamble paragraph.
+
+                        == Main Section
+
+                        This is a paragraph in the main section.
+
+                        Another paragraph in the main section.
+                        """;
+
+                // First verify without subsections works
+                LinterConfiguration configWithout = configLoader.loadConfiguration(rulesWithoutSubsections);
+
+                ValidationResult resultWithout = linter.validateContent(adocContent, configWithout);
+                assertFalse(resultWithout.hasErrors(), "Without subsections should work, but got: " + resultWithout
+                        .getMessages().stream().map(msg -> msg.getMessage()).collect(Collectors.joining(", ")));
+            }
+
+            @Test
+            @DisplayName("should validate named blocks matching unnamed document blocks")
+            void shouldValidateNamedBlocksMatchingUnnamedDocumentBlocks() {
+                // Given - Config with named blocks
+                String rules = """
+                        document:
+                          sections:
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              allowedBlocks:
+                                - paragraph:
+                                    name: Introduction paragraph
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      max: 2
+                                - listing:
+                                    name: Example code
+                                    severity: info
+                        """;
+
+                String adocContent = """
+                        = My Document
+
+                        This is an introduction paragraph without a name attribute.
+
+                        Second paragraph.
+
+                        [source,java]
+                        ----
+                        public class Example {
+                            // Code without name attribute
+                        }
+                        ----
+                        """;
+
                 LinterConfiguration config = configLoader.loadConfiguration(rules);
-                
+
                 // When
                 ValidationResult result = linter.validateContent(adocContent, config);
-                
+
                 // Then
-                assertFalse(result.hasErrors(), 
-                    "Expected no errors, but got: " + result.getMessages().stream()
-                        .map(msg -> msg.getMessage())
-                        .collect(Collectors.joining(", ")));
+                assertFalse(result.hasErrors(), "Named blocks in config should match unnamed blocks in document");
                 assertFalse(result.hasWarnings());
             }
-            
+
+            @Test
+            @DisplayName("should validate Level 0 subsections configuration")
+            void shouldValidateLevel0SubsectionsConfiguration() {
+                // Given - Level 0 with subsections structure exactly as in basic-rules.yaml
+                String rules = """
+                        document:
+                          sections:
+                            # Document title (level 0) with subsections structure
+                            - name: documentTitle
+                              level: 0
+                              occurrence:
+                                min: 1
+                                max: 1
+                              title:
+                                pattern: "^[A-Z].*"
+                                severity: error
+                              allowedBlocks:
+                                - paragraph:
+                                    name: Document preamble
+                                    severity: info
+                                    occurrence:
+                                      min: 1
+                                      max: 1
+                              subsections:
+                                # Level 1 sections defined as subsections of level 0
+                                - name: mainSections
+                                  level: 1
+                                  title:
+                                    pattern: "^[A-Z].*"
+                                    severity: info
+                                  allowedBlocks:
+                                    - paragraph:
+                                        name: Section paragraphs
+                                        severity: info
+                        """;
+
+                String adocContent = """
+                        = Document Title
+
+                        This is the document preamble paragraph.
+
+                        == Main Section
+
+                        This is a paragraph in the main section.
+
+                        Another paragraph in the main section.
+                        """;
+
+                LinterConfiguration config = configLoader.loadConfiguration(rules);
+
+                // When
+                ValidationResult result = linter.validateContent(adocContent, config);
+
+                // Then
+                assertFalse(result.hasErrors(), "Expected no errors, but got: "
+                        + result.getMessages().stream().map(msg -> msg.getMessage()).collect(Collectors.joining(", ")));
+                assertFalse(result.hasWarnings());
+            }
+
         }
     }
-    
+
     @Nested
     @DisplayName("Block Occurrence Validation")
     class BlockOccurrenceValidation {
-        
+
         @Test
         @DisplayName("should validate minimum occurrence of blocks")
         void shouldValidateMinimumOccurrenceOfBlocks() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 2
-                              severity: error
-                        - listing:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 2
+                                  severity: error
+                            - listing:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Implementation
-                
-                This is only one paragraph.
-                """;
-            
+                    = Document
+
+                    == Implementation
+
+                    This is only one paragraph.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(2, result.getErrorCount()); // Missing 1 paragraph and 1 listing
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Too few occurrences of block: paragraph")));
+                    .anyMatch(msg -> msg.getMessage().contains("Too few occurrences of block: paragraph")));
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Too few occurrences of block: listing")));
+                    .anyMatch(msg -> msg.getMessage().contains("Too few occurrences of block: listing")));
         }
-        
+
         @Test
         @DisplayName("should validate maximum occurrence of blocks")
         void shouldValidateMaximumOccurrenceOfBlocks() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              max: 2
-                              severity: error
-                        - image:
-                            severity: error
-                            occurrence:
-                              max: 1
-                              severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  max: 2
+                                  severity: error
+                            - image:
+                                severity: error
+                                occurrence:
+                                  max: 1
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Overview
-                
-                First paragraph.
-                
-                Second paragraph.
-                
-                Third paragraph - exceeds max.
-                
-                image::diagram1.png[]
-                
-                image::diagram2.png[]
-                """;
-            
+                    = Document
+
+                    == Overview
+
+                    First paragraph.
+
+                    Second paragraph.
+
+                    Third paragraph - exceeds max.
+
+                    image::diagram1.png[]
+
+                    image::diagram2.png[]
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(2, result.getErrorCount()); // Too many paragraphs and images
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
+                    .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: image")));
+                    .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: image")));
         }
-        
+
         @Test
         @DisplayName("should validate exact occurrence of blocks")
         void shouldValidateExactOccurrenceOfBlocks() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 3
-                              max: 3
-                              severity: error
-                        - table:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              max: 1
-                              severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 3
+                                  max: 3
+                                  severity: error
+                            - table:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  max: 1
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Configuration
-                
-                First paragraph about configuration.
-                
-                Second paragraph with details.
-                
-                Third paragraph with examples.
-                
-                |===
-                | Option | Description
-                | debug | Enable debug mode
-                | verbose | Enable verbose output
-                |===
-                """;
-            
+                    = Document
+
+                    == Configuration
+
+                    First paragraph about configuration.
+
+                    Second paragraph with details.
+
+                    Third paragraph with examples.
+
+                    |===
+                    | Option | Description
+                    | debug | Enable debug mode
+                    | verbose | Enable verbose output
+                    |===
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should validate occurrence with mixed severity levels")
         void shouldValidateOccurrenceWithMixedSeverityLevels() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      title:
-                        pattern: ".*"
-                        severity: info
-                      allowedBlocks:
-                        - paragraph:
-                            severity: warn
-                            occurrence:
-                              min: 1
-                              severity: error
-                        - listing:
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          title:
+                            pattern: ".*"
                             severity: info
-                            occurrence:
-                              max: 2
-                              severity: warn
-                """;
-            
+                          allowedBlocks:
+                            - paragraph:
+                                severity: warn
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                            - listing:
+                                severity: info
+                                occurrence:
+                                  max: 2
+                                  severity: warn
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                [source,java]
-                ----
-                // First listing
-                ----
-                
-                [source,java]
-                ----
-                // Second listing
-                ----
-                
-                [source,java]
-                ----
-                // Third listing - exceeds max
-                ----
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    [source,java]
+                    ----
+                    // First listing
+                    ----
+
+                    [source,java]
+                    ----
+                    // Second listing
+                    ----
+
+                    [source,java]
+                    ----
+                    // Third listing - exceeds max
+                    ----
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors()); // min paragraph violation is error
             assertTrue(result.hasWarnings()); // max listing violation is warning
             assertEquals(1, result.getErrorCount());
             assertEquals(1, result.getWarningCount());
-            assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getSeverity().toString().equals("ERROR") && 
-                               msg.getMessage().contains("Too few occurrences of block: paragraph")));
-            assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getSeverity().toString().equals("WARN") && 
-                               msg.getMessage().contains("Too many occurrences of block: listing")));
+            assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getSeverity().toString().equals("ERROR")
+                    && msg.getMessage().contains("Too few occurrences of block: paragraph")));
+            assertTrue(result.getMessages().stream().anyMatch(msg -> msg.getSeverity().toString().equals("WARN")
+                    && msg.getMessage().contains("Too many occurrences of block: listing")));
         }
-        
+
         @Test
         @DisplayName("should validate occurrence across multiple sections")
         void shouldValidateOccurrenceAcrossMultipleSections() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: introSection
-                      level: 1
-                      title:
-                        pattern: "^Introduction$"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 2
-                              max: 3
-                              severity: error
-                    - name: detailsSection
-                      level: 1
-                      title:
-                        pattern: "^Details$"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              severity: error
-                        - listing:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              max: 2
-                              severity: error
-                """;
-            
-            String adocContent = """
-                = Document
-                
-                == Introduction
-                
-                First intro paragraph.
-                
-                Second intro paragraph.
-                
-                == Details
-                
-                Details paragraph.
-                
-                [source,java]
-                ----
-                public class Example {
-                    // Code example
-                }
-                ----
-                """;
-            
-            LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
-            // When
-            ValidationResult result = linter.validateContent(adocContent, config);
-            
-            // Then
-            assertFalse(result.hasErrors());
-        }
-        
-        @Test
-        @DisplayName("should show placeholder at correct position in nested sections")
-        void shouldShowPlaceholderAtCorrectPositionInNestedSections() {
-            // Given - Document with level 0, 1, and 2 sections where listing is missing in level 2
-            String rules = """
-                document:
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              severity: error
-                    - name: mainSection
-                      level: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              severity: error
-                      subsections:
-                        - name: subSection
-                          level: 2
+                    document:
+                      sections:
+                        - name: introSection
+                          level: 1
                           title:
-                            pattern: "^[A-Z].*"
+                            pattern: "^Introduction$"
+                            severity: error
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 2
+                                  max: 3
+                                  severity: error
+                        - name: detailsSection
+                          level: 1
+                          title:
+                            pattern: "^Details$"
                             severity: error
                           allowedBlocks:
                             - paragraph:
@@ -1714,565 +1629,639 @@ class LinterValidationIntegrationTest {
                                 severity: error
                                 occurrence:
                                   min: 1
+                                  max: 2
                                   severity: error
-                """;
-            
+                    """;
+
             String adocContent = """
-                = My Document
-                
-                This is a paragraph at document level.
-                
-                == Main Section
-                
-                This is a paragraph in the main section.
-                
-                === Sub Section
-                
-                This is a paragraph in the sub section.
-                """;
-            
+                    = Document
+
+                    == Introduction
+
+                    First intro paragraph.
+
+                    Second intro paragraph.
+
+                    == Details
+
+                    Details paragraph.
+
+                    [source,java]
+                    ----
+                    public class Example {
+                        // Code example
+                    }
+                    ----
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
+            // Then
+            assertFalse(result.hasErrors());
+        }
+
+        @Test
+        @DisplayName("should show placeholder at correct position in nested sections")
+        void shouldShowPlaceholderAtCorrectPositionInNestedSections() {
+            // Given - Document with level 0, 1, and 2 sections where listing is missing in level 2
+            String rules = """
+                    document:
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z].*"
+                            severity: error
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                        - name: mainSection
+                          level: 1
+                          title:
+                            pattern: "^[A-Z].*"
+                            severity: error
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                          subsections:
+                            - name: subSection
+                              level: 2
+                              title:
+                                pattern: "^[A-Z].*"
+                                severity: error
+                              allowedBlocks:
+                                - paragraph:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      severity: error
+                                - listing:
+                                    severity: error
+                                    occurrence:
+                                      min: 1
+                                      severity: error
+                    """;
+
+            String adocContent = """
+                    = My Document
+
+                    This is a paragraph at document level.
+
+                    == Main Section
+
+                    This is a paragraph in the main section.
+
+                    === Sub Section
+
+                    This is a paragraph in the sub section.
+                    """;
+
+            LinterConfiguration config = configLoader.loadConfiguration(rules);
+
+            // When
+            ValidationResult result = linter.validateContent(adocContent, config);
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(1, result.getErrorCount());
-            
+
             // Check that the error is for the missing listing in level 2
             ValidationMessage msg = result.getMessages().get(0);
             assertEquals("Too few occurrences of block: listing", msg.getMessage());
-            
+
             // The location should point to where the missing block should be inserted
             // The placeholder should appear after the paragraph in the subsection
             // After our fix, the line is correctly calculated as 13 (after the last line of content)
             assertEquals(13, msg.getLocation().getStartLine()); // Points to where block should be added
-            
+
             // Let's also run a console report to see where the placeholder appears
             // This would help debug the actual positioning
         }
-        
+
         @Test
         @DisplayName("should handle blocks without occurrence configuration")
         void shouldHandleBlocksWithoutOccurrenceConfiguration() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      title:
-                        pattern: ".*"
-                        severity: info
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                            # No occurrence configuration
-                        - listing:
-                            severity: error
-                            occurrence:
-                              min: 1
-                              severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          title:
+                            pattern: ".*"
+                            severity: info
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                # No occurrence configuration
+                            - listing:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                Multiple paragraphs are allowed.
-                
-                Another paragraph.
-                
-                And another one.
-                
-                [source,java]
-                ----
-                // Required listing
-                ----
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    Multiple paragraphs are allowed.
+
+                    Another paragraph.
+
+                    And another one.
+
+                    [source,java]
+                    ----
+                    // Required listing
+                    ----
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertFalse(result.hasErrors());
         }
     }
-    
+
     @Nested
     @DisplayName("Block Order Validation")
     class BlockOrderValidation {
-        
+
         @Test
         @DisplayName("should validate block order using order attribute")
         void shouldValidateBlockOrderUsingOrderAttribute() {
             // Given - Configuration with order attributes for blocks
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      title:
-                        pattern: ".*"
-                        severity: info
-                      allowedBlocks:
-                        - paragraph:
-                            name: intro
-                            severity: error
-                            order: 1
-                        - listing:
-                            name: code
-                            severity: error
-                            order: 2
-                        - paragraph:
-                            name: explanation
-                            severity: error
-                            order: 3
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          title:
+                            pattern: ".*"
+                            severity: info
+                          allowedBlocks:
+                            - paragraph:
+                                name: intro
+                                severity: error
+                                order: 1
+                            - listing:
+                                name: code
+                                severity: error
+                                order: 2
+                            - paragraph:
+                                name: explanation
+                                severity: error
+                                order: 3
+                    """;
+
             // Wrong order: code (order=2) before intro (order=1)
             String adocContent = """
-                = Document
-                
-                == Section One
-                
-                [source,java]
-                ----
-                public class Test {
-                }
-                ----
-                
-                This is the introduction paragraph.
-                
-                This is the explanation paragraph.
-                """;
-            
+                    = Document
+
+                    == Section One
+
+                    [source,java]
+                    ----
+                    public class Test {
+                    }
+                    ----
+
+                    This is the introduction paragraph.
+
+                    This is the explanation paragraph.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors());
-            assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("order") || 
-                                msg.getMessage().contains("Order")),
-                "Expected order validation error, but got: " + 
-                result.getMessages().stream()
-                    .map(ValidationMessage::getMessage)
-                    .collect(Collectors.joining(", ")));
+            assertTrue(
+                    result.getMessages().stream()
+                            .anyMatch(msg -> msg.getMessage().contains("order") || msg.getMessage().contains("Order")),
+                    "Expected order validation error, but got: " + result.getMessages().stream()
+                            .map(ValidationMessage::getMessage).collect(Collectors.joining(", ")));
         }
-        
+
         @Test
         @DisplayName("should accept correct block order")
         void shouldAcceptCorrectBlockOrder() {
             // Given - Configuration with order attributes
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      title:
-                        pattern: ".*"
-                        severity: info
-                      allowedBlocks:
-                        - paragraph:
-                            name: intro
-                            severity: error
-                            order: 1
-                        - listing:
-                            name: code
-                            severity: error
-                            order: 2
-                        - paragraph:
-                            name: explanation
-                            severity: error
-                            order: 3
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          title:
+                            pattern: ".*"
+                            severity: info
+                          allowedBlocks:
+                            - paragraph:
+                                name: intro
+                                severity: error
+                                order: 1
+                            - listing:
+                                name: code
+                                severity: error
+                                order: 2
+                            - paragraph:
+                                name: explanation
+                                severity: error
+                                order: 3
+                    """;
+
             // Richtige Reihenfolge
             String adocContent = """
-                = Document
-                
-                == Section One
-                
-                This is the introduction paragraph.
-                
-                [source,java]
-                ----
-                public class Test {
-                }
-                ----
-                
-                This is the explanation paragraph.
-                """;
-            
+                    = Document
+
+                    == Section One
+
+                    This is the introduction paragraph.
+
+                    [source,java]
+                    ----
+                    public class Test {
+                    }
+                    ----
+
+                    This is the explanation paragraph.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
-            assertFalse(result.hasErrors(), 
-                "Expected no errors for correct order, but got: " + 
-                result.getMessages().stream()
-                    .map(msg -> msg.getMessage())
-                    .collect(Collectors.joining(", ")));
+            assertFalse(result.hasErrors(), "Expected no errors for correct order, but got: "
+                    + result.getMessages().stream().map(msg -> msg.getMessage()).collect(Collectors.joining(", ")));
         }
-        
+
         @Test
         @DisplayName("should handle blocks without order attribute")
         void shouldHandleBlocksWithoutOrderAttribute() {
             // Given - Mix of blocks with and without order
             String rules = """
-                document:
-                  sections:
-                    - name: mainSection
-                      level: 1
-                      title:
-                        pattern: ".*"
-                        severity: info
-                      allowedBlocks:
-                        - paragraph:
-                            name: intro
-                            severity: error
-                            order: 1
-                        - listing:
-                            name: code
-                            severity: error
-                            # no order specified
-                        - paragraph:
-                            name: conclusion
-                            severity: error
-                            order: 10
-                """;
-            
+                    document:
+                      sections:
+                        - name: mainSection
+                          level: 1
+                          title:
+                            pattern: ".*"
+                            severity: info
+                          allowedBlocks:
+                            - paragraph:
+                                name: intro
+                                severity: error
+                                order: 1
+                            - listing:
+                                name: code
+                                severity: error
+                                # no order specified
+                            - paragraph:
+                                name: conclusion
+                                severity: error
+                                order: 10
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section One
-                
-                This is the introduction paragraph.
-                
-                [source,java]
-                ----
-                // Code can appear anywhere when no order specified
-                ----
-                
-                This is the conclusion paragraph.
-                """;
-            
+                    = Document
+
+                    == Section One
+
+                    This is the introduction paragraph.
+
+                    [source,java]
+                    ----
+                    // Code can appear anywhere when no order specified
+                    ----
+
+                    This is the conclusion paragraph.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
-            assertFalse(result.hasErrors(),
-                "Blocks without order should be allowed anywhere, but got: " +
-                result.getMessages().stream()
-                    .map(msg -> msg.getMessage())
-                    .collect(Collectors.joining(", ")));
+            assertFalse(result.hasErrors(), "Blocks without order should be allowed anywhere, but got: "
+                    + result.getMessages().stream().map(msg -> msg.getMessage()).collect(Collectors.joining(", ")));
         }
     }
-    
+
     @Nested
     @DisplayName("Front Matter Support")
     class FrontMatterSupport {
-        
+
         @Test
         @DisplayName("should skip front matter when validating document")
         void shouldSkipFrontMatterWhenValidatingDocument() {
             // Given - Document with YAML front matter
             String rules = """
-                document:
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
+                    document:
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z].*"
                             severity: error
-                            occurrence:
-                              min: 1
-                              max: 2
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  max: 2
+                                  severity: error
+                    """;
+
             String adocContent = """
-                ---
-                title: My Document
-                author: John Doe
-                tags: [asciidoc, testing]
-                date: 2024-01-15
-                ---
-                = My Document
-                
-                This is the first paragraph after front matter.
-                
-                This is the second paragraph.
-                """;
-            
+                    ---
+                    title: My Document
+                    author: John Doe
+                    tags: [asciidoc, testing]
+                    date: 2024-01-15
+                    ---
+                    = My Document
+
+                    This is the first paragraph after front matter.
+
+                    This is the second paragraph.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then - Should validate successfully, ignoring the front matter
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should validate document with front matter and sections")
         void shouldValidateDocumentWithFrontMatterAndSections() {
             // Given - Complex document with front matter
             String rules = """
-                document:
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
+                    document:
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z].*"
                             severity: error
-                            occurrence:
-                              min: 1
-                              severity: error
-                    - name: intro
-                      level: 1
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^Introduction$"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  severity: error
+                        - name: intro
+                          level: 1
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^Introduction$"
                             severity: error
-                            occurrence:
-                              min: 1
-                              max: 3
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  max: 3
+                                  severity: error
+                    """;
+
             String adocContent = """
-                ---
-                layout: post
-                title: Technical Documentation
-                author: Jane Smith
-                categories:
-                  - documentation
-                  - technical
-                metadata:
-                  version: 1.0.0
-                  status: draft
-                ---
-                = Technical Documentation
-                
-                This is the document introduction paragraph.
-                
-                == Introduction
-                
-                First paragraph of the introduction section.
-                
-                Second paragraph with more details.
-                
-                Third paragraph concluding the introduction.
-                """;
-            
+                    ---
+                    layout: post
+                    title: Technical Documentation
+                    author: Jane Smith
+                    categories:
+                      - documentation
+                      - technical
+                    metadata:
+                      version: 1.0.0
+                      status: draft
+                    ---
+                    = Technical Documentation
+
+                    This is the document introduction paragraph.
+
+                    == Introduction
+
+                    First paragraph of the introduction section.
+
+                    Second paragraph with more details.
+
+                    Third paragraph concluding the introduction.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should handle empty front matter")
         void shouldHandleEmptyFrontMatter() {
             // Given - Document with empty front matter
             String rules = """
-                document:
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      allowedBlocks:
-                        - paragraph:
-                            severity: error
-                """;
-            
+                    document:
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                    """;
+
             String adocContent = """
-                ---
-                ---
-                = Document with Empty Front Matter
-                
-                This paragraph should be validated normally.
-                """;
-            
+                    ---
+                    ---
+                    = Document with Empty Front Matter
+
+                    This paragraph should be validated normally.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should validate document without front matter normally")
         void shouldValidateDocumentWithoutFrontMatterNormally() {
             // Given - Document without front matter (ensure backward compatibility)
             String rules = """
-                document:
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
+                    document:
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z].*"
                             severity: error
-                            occurrence:
-                              min: 2
-                              max: 2
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 2
+                                  max: 2
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Regular Document
-                
-                First paragraph.
-                
-                Second paragraph.
-                """;
-            
+                    = Regular Document
+
+                    First paragraph.
+
+                    Second paragraph.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should detect errors after front matter")
         void shouldDetectErrorsAfterFrontMatter() {
             // Given - Document with front matter but violating rules
             String rules = """
-                document:
-                  sections:
-                    - name: documentTitle
-                      level: 0
-                      occurrence:
-                        min: 1
-                        max: 1
-                      title:
-                        pattern: "^[A-Z].*"
-                        severity: error
-                      allowedBlocks:
-                        - paragraph:
+                    document:
+                      sections:
+                        - name: documentTitle
+                          level: 0
+                          occurrence:
+                            min: 1
+                            max: 1
+                          title:
+                            pattern: "^[A-Z].*"
                             severity: error
-                            occurrence:
-                              min: 1
-                              max: 2
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - paragraph:
+                                severity: error
+                                occurrence:
+                                  min: 1
+                                  max: 2
+                                  severity: error
+                    """;
+
             String adocContent = """
-                ---
-                title: Document
-                author: Test Author
-                ---
-                = lowercase title
-                
-                First paragraph.
-                
-                Second paragraph.
-                
-                Third paragraph - this exceeds the max.
-                """;
-            
+                    ---
+                    title: Document
+                    author: Test Author
+                    ---
+                    = lowercase title
+
+                    First paragraph.
+
+                    Second paragraph.
+
+                    Third paragraph - this exceeds the max.
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(2, result.getErrorCount()); // Title pattern error + too many paragraphs
-            
+
             // Check for title pattern error
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Document title does not match required pattern")));
-            
+                    .anyMatch(msg -> msg.getMessage().contains("Document title does not match required pattern")));
+
             // Check for paragraph occurrence error
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
+                    .anyMatch(msg -> msg.getMessage().contains("Too many occurrences of block: paragraph")));
         }
     }
-    
+
     @Nested
     @DisplayName("Definition List Validation")
     class DefinitionListValidation {
-        
+
         @Test
         @DisplayName("should validate definition list term count")
         void shouldValidateDefinitionListTermCount() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - name: glossary
-                      level: 1
-                      title:
-                        pattern: "^Glossary$"
-                        severity: error
-                      allowedBlocks:
-                        - dlist:
+                    document:
+                      sections:
+                        - name: glossary
+                          level: 1
+                          title:
+                            pattern: "^Glossary$"
                             severity: error
-                            terms:
-                              min: 3
-                              severity: warn
-                """;
-            
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                terms:
+                                  min: 3
+                                  severity: warn
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Glossary
-                
-                API:: Application Programming Interface
-                HTTP:: Hypertext Transfer Protocol
-                """;
-            
+                    = Document
+
+                    == Glossary
+
+                    API:: Application Programming Interface
+                    HTTP:: Hypertext Transfer Protocol
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasWarnings());
             assertEquals(1, result.getMessages().size());
@@ -2280,41 +2269,41 @@ class LinterValidationIntegrationTest {
             assertEquals(Severity.WARN, msg.getSeverity());
             assertTrue(msg.getMessage().contains("too few terms"));
         }
-        
+
         @Test
         @DisplayName("should validate definition list term pattern")
         void shouldValidateDefinitionListTermPattern() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - level: 1
-                      title:
-                        pattern: ".*"
-                        severity: error
-                      allowedBlocks:
-                        - dlist:
+                    document:
+                      sections:
+                        - level: 1
+                          title:
+                            pattern: ".*"
                             severity: error
-                            terms:
-                              pattern: "^[A-Z].*"
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                terms:
+                                  pattern: "^[A-Z].*"
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                API:: Good - starts with uppercase
-                http:: Bad - starts with lowercase
-                REST:: Good - all uppercase
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    API:: Good - starts with uppercase
+                    http:: Bad - starts with lowercase
+                    REST:: Good - all uppercase
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(1, result.getMessages().size());
@@ -2322,172 +2311,172 @@ class LinterValidationIntegrationTest {
             assertEquals("http", msg.getActualValue().orElse(""));
             assertTrue(msg.getMessage().contains("does not match required pattern"));
         }
-        
+
         @Test
         @DisplayName("should validate definition list description requirements")
         void shouldValidateDefinitionListDescriptionRequirements() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - level: 1
-                      title:
-                        pattern: ".*"
-                        severity: error
-                      allowedBlocks:
-                        - dlist:
+                    document:
+                      sections:
+                        - level: 1
+                          title:
+                            pattern: ".*"
                             severity: error
-                            descriptions:
-                              required: true
-                              pattern: ".*\\\\.$"
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                descriptions:
+                                  required: true
+                                  pattern: ".*\\\\.$"
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                Term1:: Description with period.
-                Term2:: Description without period
-                Term3::
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    Term1:: Description with period.
+                    Term2:: Description without period
+                    Term3::
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertTrue(result.hasErrors());
             assertEquals(2, result.getMessages().size());
-            
+
             // Check for pattern violation
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("does not match required pattern") 
-                    && msg.getActualValue().orElse("").equals("Description without period")));
-            
+                    .anyMatch(msg -> msg.getMessage().contains("does not match required pattern")
+                            && msg.getActualValue().orElse("").equals("Description without period")));
+
             // Check for missing description
             assertTrue(result.getMessages().stream()
-                .anyMatch(msg -> msg.getMessage().contains("missing required description")));
+                    .anyMatch(msg -> msg.getMessage().contains("missing required description")));
         }
-        
+
         @Test
         @DisplayName("should skip nesting level validation - not supported by AsciiDoctor AST")
         void shouldSkipNestingLevelValidation() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - level: 1
-                      title:
-                        pattern: ".*"
-                        severity: error
-                      allowedBlocks:
-                        - dlist:
+                    document:
+                      sections:
+                        - level: 1
+                          title:
+                            pattern: ".*"
                             severity: error
-                            nestingLevel:
-                              max: 1
-                              severity: warn
-                """;
-            
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                nestingLevel:
+                                  max: 1
+                                  severity: warn
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                Level1::
-                  Nested::
-                    DoubleNested:::
-                      This exceeds max nesting level
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    Level1::
+                      Nested::
+                        DoubleNested:::
+                          This exceeds max nesting level
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then - nesting validation is not implemented
             assertFalse(result.hasWarnings());
             assertFalse(result.hasErrors());
         }
-        
+
         @Test
         @DisplayName("should skip delimiter style validation - not supported by AsciiDoctor AST")
         void shouldSkipDelimiterStyleValidation() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - level: 1
-                      title:
-                        pattern: ".*"
-                        severity: error
-                      allowedBlocks:
-                        - dlist:
+                    document:
+                      sections:
+                        - level: 1
+                          title:
+                            pattern: ".*"
                             severity: error
-                            delimiterStyle:
-                              allowedDelimiters: ["::", ":::"]
-                              severity: error
-                """;
-            
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                delimiterStyle:
+                                  allowedDelimiters: ["::", ":::"]
+                                  severity: error
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                Term1:: Valid delimiter
-                Term2::: Also valid
-                Term3:::: Invalid delimiter
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    Term1:: Valid delimiter
+                    Term2::: Also valid
+                    Term3:::: Invalid delimiter
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then - delimiter validation is not implemented
             assertFalse(result.hasErrors());
             assertFalse(result.hasWarnings());
         }
-        
+
         @Test
         @DisplayName("should pass valid definition list")
         void shouldPassValidDefinitionList() {
             // Given
             String rules = """
-                document:
-                  sections:
-                    - level: 1
-                      title:
-                        pattern: ".*"
-                        severity: error
-                      allowedBlocks:
-                        - dlist:
+                    document:
+                      sections:
+                        - level: 1
+                          title:
+                            pattern: ".*"
                             severity: error
-                            terms:
-                              min: 2
-                              max: 5
-                              pattern: "^[A-Z].*"
-                            descriptions:
-                              required: true
-                """;
-            
+                          allowedBlocks:
+                            - dlist:
+                                severity: error
+                                terms:
+                                  min: 2
+                                  max: 5
+                                  pattern: "^[A-Z].*"
+                                descriptions:
+                                  required: true
+                    """;
+
             String adocContent = """
-                = Document
-                
-                == Section
-                
-                API:: Application Programming Interface
-                HTTP:: Hypertext Transfer Protocol
-                REST:: Representational State Transfer
-                """;
-            
+                    = Document
+
+                    == Section
+
+                    API:: Application Programming Interface
+                    HTTP:: Hypertext Transfer Protocol
+                    REST:: Representational State Transfer
+                    """;
+
             LinterConfiguration config = configLoader.loadConfiguration(rules);
-            
+
             // When
             ValidationResult result = linter.validateContent(adocContent, config);
-            
+
             // Then
             assertFalse(result.hasErrors());
             assertFalse(result.hasWarnings());

--- a/src/test/java/com/dataliquid/linter/cli/CLIConfigTest.java
+++ b/src/test/java/com/dataliquid/linter/cli/CLIConfigTest.java
@@ -21,22 +21,20 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 
 @DisplayName("CLIConfig")
 class CLIConfigTest {
-    
+
     @Nested
     @DisplayName("Builder")
     class BuilderTest {
-        
+
         @Test
         @DisplayName("should create config with required fields")
         void shouldCreateConfigWithRequiredFields() {
             // Given
             List<String> patterns = Arrays.asList("**/*.adoc", "docs/**/*.asciidoc");
-            
+
             // When
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(patterns)
-                .build();
-            
+            CLIConfig config = CLIConfig.builder().inputPatterns(patterns).build();
+
             // Then
             assertEquals(patterns, config.getInputPatterns());
             assertNotNull(config.getBaseDirectory());
@@ -47,7 +45,7 @@ class CLIConfigTest {
             assertNull(config.getReportOutput());
             assertFalse(config.isOutputToFile());
         }
-        
+
         @Test
         @DisplayName("should create config with all fields")
         void shouldCreateConfigWithAllFields() {
@@ -56,17 +54,11 @@ class CLIConfigTest {
             Path baseDir = Paths.get("/custom/base");
             Path configFile = Paths.get("config.yaml");
             Path reportOutput = Paths.get("report.json");
-            
+
             // When
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(patterns)
-                .baseDirectory(baseDir)
-                .configFile(configFile)
-                .reportFormat("json")
-                .reportOutput(reportOutput)
-                .failLevel(Severity.WARN)
-                .build();
-            
+            CLIConfig config = CLIConfig.builder().inputPatterns(patterns).baseDirectory(baseDir).configFile(configFile)
+                    .reportFormat("json").reportOutput(reportOutput).failLevel(Severity.WARN).build();
+
             // Then
             assertEquals(patterns, config.getInputPatterns());
             assertEquals(baseDir, config.getBaseDirectory());
@@ -76,36 +68,29 @@ class CLIConfigTest {
             assertEquals(Severity.WARN, config.getFailLevel());
             assertTrue(config.isOutputToFile());
         }
-        
+
         @Test
         @DisplayName("should throw exception for null input patterns")
         void shouldThrowExceptionForNullInputPatterns() {
-            assertThrows(NullPointerException.class, () -> 
-                CLIConfig.builder().build()
-            );
+            assertThrows(NullPointerException.class, () -> CLIConfig.builder().build());
         }
-        
+
         @Test
         @DisplayName("should throw exception for empty input patterns")
         void shouldThrowExceptionForEmptyInputPatterns() {
-            assertThrows(IllegalArgumentException.class, () -> 
-                CLIConfig.builder()
-                    .inputPatterns(Arrays.asList())
-                    .build()
-            );
+            assertThrows(IllegalArgumentException.class,
+                    () -> CLIConfig.builder().inputPatterns(Arrays.asList()).build());
         }
-        
+
         @Test
         @DisplayName("should have sensible defaults")
         void shouldHaveSensibleDefaults() {
             // Given
             CLIConfig.Builder builder = CLIConfig.builder();
-            
+
             // When
-            CLIConfig config = builder
-                .inputPatterns(Arrays.asList("*.adoc"))
-                .build();
-            
+            CLIConfig config = builder.inputPatterns(Arrays.asList("*.adoc")).build();
+
             // Then
             assertEquals("console", config.getReportFormat());
             assertEquals(Severity.ERROR, config.getFailLevel());
@@ -114,11 +99,11 @@ class CLIConfigTest {
             assertNull(config.getReportOutput());
         }
     }
-    
+
     @Nested
     @DisplayName("Getters")
     class GettersTest {
-        
+
         @Test
         @DisplayName("should return correct values")
         void shouldReturnCorrectValues() {
@@ -126,15 +111,10 @@ class CLIConfigTest {
             List<String> patterns = Arrays.asList("**/*.adoc");
             Path configFile = Paths.get("config.yaml");
             Path reportOutput = Paths.get("output.json");
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(patterns)
-                .configFile(configFile)
-                .reportFormat("json-compact")
-                .reportOutput(reportOutput)
-                .failLevel(Severity.INFO)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(patterns).configFile(configFile)
+                    .reportFormat("json-compact").reportOutput(reportOutput).failLevel(Severity.INFO).build();
+
             // Then
             assertEquals(patterns, config.getInputPatterns());
             assertEquals(configFile, config.getConfigFile());
@@ -143,15 +123,13 @@ class CLIConfigTest {
             assertEquals(Severity.INFO, config.getFailLevel());
             assertTrue(config.isOutputToFile());
         }
-        
+
         @Test
         @DisplayName("should return false for isOutputToFile when reportOutput is null")
         void shouldReturnFalseForIsOutputToFileWhenReportOutputIsNull() {
             // Given
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("*.adoc"))
-                .build();
-            
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("*.adoc")).build();
+
             // Then
             assertFalse(config.isOutputToFile());
         }

--- a/src/test/java/com/dataliquid/linter/cli/FileDiscoveryServicePerformanceTest.java
+++ b/src/test/java/com/dataliquid/linter/cli/FileDiscoveryServicePerformanceTest.java
@@ -20,121 +20,116 @@ import com.dataliquid.asciidoc.linter.cli.FileDiscoveryService;
  */
 @DisplayName("FileDiscoveryService Performance")
 class FileDiscoveryServicePerformanceTest {
-    
+
     @TempDir
     Path tempDir;
-    
+
     private FileDiscoveryService service;
-    
+
     @BeforeEach
     void setUp() {
         service = new FileDiscoveryService();
     }
-    
+
     @Test
     @DisplayName("should demonstrate improved performance with pattern caching")
     void shouldDemonstrateImprovedPerformance() throws IOException {
         // Create test files
         createTestFileStructure();
-        
+
         // Warm up
         for (int i = 0; i < 10; i++) {
             service.discoverFiles(List.of("**/*.adoc"), tempDir);
         }
-        
+
         // Measure performance with caching
         long startTime = System.nanoTime();
         int iterations = 1000;
-        
+
         for (int i = 0; i < iterations; i++) {
             List<Path> files = service.discoverFiles(List.of("**/*.adoc"), tempDir);
             assertTrue(files.size() > 0, "Should find files");
         }
-        
+
         long elapsedTime = System.nanoTime() - startTime;
         double avgTimeMs = (elapsedTime / 1_000_000.0) / iterations;
-        
+
         // The cached version should be significantly faster
         // We expect sub-millisecond performance per iteration
         System.out.printf("Average time per iteration: %.3f ms%n", avgTimeMs);
         assertTrue(avgTimeMs < 5.0, "Average time should be less than 5ms per iteration");
     }
-    
+
     @Test
     @DisplayName("should handle multiple different patterns efficiently")
     void shouldHandleMultiplePatternsEfficiently() throws IOException {
         createTestFileStructure();
-        
-        List<String> patterns = List.of(
-            "**/*.adoc",
-            "docs/**/*.adoc",
-            "src/*/docs/*.adoc",
-            "**/*example*.adoc",
-            "test?.adoc"
-        );
-        
+
+        List<String> patterns = List.of("**/*.adoc", "docs/**/*.adoc", "src/*/docs/*.adoc", "**/*example*.adoc",
+                "test?.adoc");
+
         // Warm up cache
         for (String pattern : patterns) {
             service.discoverFiles(List.of(pattern), tempDir);
         }
-        
+
         // Measure performance with different patterns
         long startTime = System.nanoTime();
         int iterations = 100;
-        
+
         for (int i = 0; i < iterations; i++) {
             for (String pattern : patterns) {
                 service.discoverFiles(List.of(pattern), tempDir);
                 // Just ensure it runs without error
             }
         }
-        
+
         long elapsedTime = System.nanoTime() - startTime;
         double avgTimeMs = (elapsedTime / 1_000_000.0) / (iterations * patterns.size());
-        
+
         System.out.printf("Average time per pattern match: %.3f ms%n", avgTimeMs);
         assertTrue(avgTimeMs < 2.0, "Pattern matching should be fast with caching");
     }
-    
+
     @Test
     @DisplayName("should not have memory leaks with bounded cache")
     void shouldNotHaveMemoryLeaksWithCache() throws IOException {
         createTestFileStructure();
-        
+
         // Generate many unique patterns to test cache behavior
         List<String> patterns = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             patterns.add(String.format("test%d*.adoc", i));
             patterns.add(String.format("**/*pattern%d*.adoc", i));
         }
-        
+
         // Run all patterns
         long beforeMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        
+
         for (String pattern : patterns) {
             service.discoverFiles(List.of(pattern), tempDir);
         }
-        
+
         // Force garbage collection
         System.gc();
         Thread.yield();
         System.gc();
-        
+
         long afterMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
         long memoryIncrease = afterMemory - beforeMemory;
-        
+
         // Memory increase should be reasonable (less than 10MB for 2000 patterns)
         System.out.printf("Memory increase: %.2f MB%n", memoryIncrease / (1024.0 * 1024.0));
         assertTrue(memoryIncrease < 10 * 1024 * 1024, "Memory usage should be reasonable");
     }
-    
+
     private void createTestFileStructure() throws IOException {
         // Create a realistic file structure
         Files.createDirectories(tempDir.resolve("docs"));
         Files.createDirectories(tempDir.resolve("src/main/docs"));
         Files.createDirectories(tempDir.resolve("src/test/docs"));
         Files.createDirectories(tempDir.resolve("examples"));
-        
+
         // Create test files
         Files.writeString(tempDir.resolve("README.adoc"), "= README");
         Files.writeString(tempDir.resolve("test1.adoc"), "= Test 1");
@@ -144,7 +139,7 @@ class FileDiscoveryServicePerformanceTest {
         Files.writeString(tempDir.resolve("src/main/docs/example.adoc"), "= Example");
         Files.writeString(tempDir.resolve("src/test/docs/test-example.adoc"), "= Test Example");
         Files.writeString(tempDir.resolve("examples/sample.adoc"), "= Sample");
-        
+
         // Create some non-matching files
         Files.writeString(tempDir.resolve("notes.txt"), "Notes");
         Files.writeString(tempDir.resolve("docs/readme.md"), "# Readme");

--- a/src/test/java/com/dataliquid/linter/cli/FileDiscoveryServiceTest.java
+++ b/src/test/java/com/dataliquid/linter/cli/FileDiscoveryServiceTest.java
@@ -22,41 +22,39 @@ import com.dataliquid.asciidoc.linter.cli.FileDiscoveryService;
 
 @DisplayName("FileDiscoveryService")
 class FileDiscoveryServiceTest {
-    
+
     @TempDir
     Path tempDir;
-    
+
     private FileDiscoveryService service;
-    
+
     @BeforeEach
     void setUp() {
         service = new FileDiscoveryService();
     }
-    
+
     @Nested
     @DisplayName("Simple file patterns")
     class SimpleFilePatterns {
-        
+
         @Test
         @DisplayName("should find single file by exact name")
         void shouldFindSingleFileByExactName() throws IOException {
             // Given
             Path file = tempDir.resolve("README.adoc");
             Files.createFile(file);
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("README.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("README.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(1, files.size());
             assertEquals(file.normalize(), files.get(0));
         }
-        
+
         @Test
         @DisplayName("should find files with wildcard pattern")
         void shouldFindFilesWithWildcardPattern() throws IOException {
@@ -64,29 +62,25 @@ class FileDiscoveryServiceTest {
             Files.createFile(tempDir.resolve("doc1.adoc"));
             Files.createFile(tempDir.resolve("doc2.adoc"));
             Files.createFile(tempDir.resolve("readme.txt"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("*.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(2, files.size());
-            List<String> fileNames = files.stream()
-                .map(p -> p.getFileName().toString())
-                .collect(Collectors.toList());
+            List<String> fileNames = files.stream().map(p -> p.getFileName().toString()).collect(Collectors.toList());
             assertTrue(fileNames.contains("doc1.adoc"));
             assertTrue(fileNames.contains("doc2.adoc"));
         }
     }
-    
+
     @Nested
     @DisplayName("Ant patterns with **")
     class AntPatternsWithDoubleWildcard {
-        
+
         @Test
         @DisplayName("should find files recursively with **/*.adoc")
         void shouldFindFilesRecursivelyWithDoubleWildcard() throws IOException {
@@ -94,30 +88,27 @@ class FileDiscoveryServiceTest {
             Path subDir = tempDir.resolve("subdir");
             Path deepDir = subDir.resolve("deep");
             Files.createDirectories(deepDir);
-            
+
             Files.createFile(tempDir.resolve("root.adoc"));
             Files.createFile(subDir.resolve("sub.adoc"));
             Files.createFile(deepDir.resolve("deep.adoc"));
             Files.createFile(tempDir.resolve("readme.txt"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("**/*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("**/*.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(3, files.size());
-            List<String> relativePaths = files.stream()
-                .map(p -> tempDir.relativize(p).toString())
-                .collect(Collectors.toList());
+            List<String> relativePaths = files.stream().map(p -> tempDir.relativize(p).toString())
+                    .collect(Collectors.toList());
             assertTrue(relativePaths.contains("root.adoc"));
             assertTrue(relativePaths.contains("subdir/sub.adoc".replace('/', java.io.File.separatorChar)));
             assertTrue(relativePaths.contains("subdir/deep/deep.adoc".replace('/', java.io.File.separatorChar)));
         }
-        
+
         @Test
         @DisplayName("should find files in specific subdirectories with docs/**/*.adoc")
         void shouldFindFilesInSpecificSubdirectories() throws IOException {
@@ -127,36 +118,33 @@ class FileDiscoveryServiceTest {
             Path docsSubDir = docsDir.resolve("api");
             Files.createDirectories(docsSubDir);
             Files.createDirectories(srcDir);
-            
+
             Files.createFile(tempDir.resolve("root.adoc"));
             Files.createFile(docsDir.resolve("manual.adoc"));
             Files.createFile(docsSubDir.resolve("api.adoc"));
             Files.createFile(srcDir.resolve("code.adoc"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("docs/**/*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("docs/**/*.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(2, files.size());
-            List<String> relativePaths = files.stream()
-                .map(p -> tempDir.relativize(p).toString())
-                .collect(Collectors.toList());
+            List<String> relativePaths = files.stream().map(p -> tempDir.relativize(p).toString())
+                    .collect(Collectors.toList());
             assertTrue(relativePaths.contains("docs/manual.adoc".replace('/', java.io.File.separatorChar)));
             assertTrue(relativePaths.contains("docs/api/api.adoc".replace('/', java.io.File.separatorChar)));
             assertFalse(relativePaths.contains("root.adoc"));
             assertFalse(relativePaths.contains("src/code.adoc".replace('/', java.io.File.separatorChar)));
         }
     }
-    
+
     @Nested
     @DisplayName("Multiple patterns")
     class MultiplePatterns {
-        
+
         @Test
         @DisplayName("should combine results from multiple patterns")
         void shouldCombineResultsFromMultiplePatterns() throws IOException {
@@ -164,43 +152,37 @@ class FileDiscoveryServiceTest {
             Files.createFile(tempDir.resolve("README.adoc"));
             Files.createFile(tempDir.resolve("guide.asciidoc"));
             Files.createFile(tempDir.resolve("manual.txt"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("*.adoc", "*.asciidoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("*.adoc", "*.asciidoc"))
+                    .baseDirectory(tempDir).build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(2, files.size());
-            List<String> fileNames = files.stream()
-                .map(p -> p.getFileName().toString())
-                .collect(Collectors.toList());
+            List<String> fileNames = files.stream().map(p -> p.getFileName().toString()).collect(Collectors.toList());
             assertTrue(fileNames.contains("README.adoc"));
             assertTrue(fileNames.contains("guide.asciidoc"));
         }
-        
+
         @Test
         @DisplayName("should remove duplicates when patterns overlap")
         void shouldRemoveDuplicatesWhenPatternsOverlap() throws IOException {
             // Given
             Files.createFile(tempDir.resolve("doc.adoc"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("*.adoc", "doc.*", "**/*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("*.adoc", "doc.*", "**/*.adoc"))
+                    .baseDirectory(tempDir).build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(1, files.size());
             assertEquals("doc.adoc", files.get(0).getFileName().toString());
         }
-        
+
         @Test
         @DisplayName("should handle complex comma-separated patterns")
         void shouldHandleComplexCommaSeparatedPatterns() throws IOException {
@@ -209,28 +191,27 @@ class FileDiscoveryServiceTest {
             Path examplesDir = tempDir.resolve("examples");
             Files.createDirectories(docsDir);
             Files.createDirectories(examplesDir);
-            
+
             Files.createFile(tempDir.resolve("README.adoc"));
             Files.createFile(docsDir.resolve("guide.adoc"));
             Files.createFile(examplesDir.resolve("example.asciidoc"));
-            
+
             CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("docs/**/*.adoc", "examples/**/*.asciidoc", "README.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+                    .inputPatterns(Arrays.asList("docs/**/*.adoc", "examples/**/*.asciidoc", "README.adoc"))
+                    .baseDirectory(tempDir).build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(3, files.size());
         }
     }
-    
+
     @Nested
     @DisplayName("Pattern matching")
     class PatternMatching {
-        
+
         @Test
         @DisplayName("should match single character wildcard (?)")
         void shouldMatchSingleCharacterWildcard() throws IOException {
@@ -238,25 +219,21 @@ class FileDiscoveryServiceTest {
             Files.createFile(tempDir.resolve("doc1.adoc"));
             Files.createFile(tempDir.resolve("doc2.adoc"));
             Files.createFile(tempDir.resolve("docs.adoc"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("doc?.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("doc?.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(3, files.size());
-            List<String> fileNames = files.stream()
-                .map(p -> p.getFileName().toString())
-                .collect(Collectors.toList());
+            List<String> fileNames = files.stream().map(p -> p.getFileName().toString()).collect(Collectors.toList());
             assertTrue(fileNames.contains("doc1.adoc"));
             assertTrue(fileNames.contains("doc2.adoc"));
             assertTrue(fileNames.contains("docs.adoc")); // ? matches exactly one character, so 's' is matched
         }
-        
+
         @Test
         @DisplayName("should handle patterns with directory wildcards")
         void shouldHandlePatternsWithDirectoryWildcards() throws IOException {
@@ -265,77 +242,69 @@ class FileDiscoveryServiceTest {
             Path moduleB = tempDir.resolve("module-b").resolve("docs");
             Files.createDirectories(moduleA);
             Files.createDirectories(moduleB);
-            
+
             Files.createFile(moduleA.resolve("guide.adoc"));
             Files.createFile(moduleB.resolve("guide.adoc"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("module-*/docs/*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("module-*/docs/*.adoc"))
+                    .baseDirectory(tempDir).build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(2, files.size());
         }
     }
-    
+
     @Nested
     @DisplayName("Edge cases")
     class EdgeCases {
-        
+
         @Test
         @DisplayName("should return empty list when no files match")
         void shouldReturnEmptyListWhenNoFilesMatch() throws IOException {
             // Given
             Files.createFile(tempDir.resolve("readme.txt"));
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("*.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertTrue(files.isEmpty());
         }
-        
+
         @Test
         @DisplayName("should handle absolute paths")
         void shouldHandleAbsolutePaths() throws IOException {
             // Given
             Path file = tempDir.resolve("test.adoc");
             Files.createFile(file);
-            
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList(file.toAbsolutePath().toString()))
-                .baseDirectory(tempDir)
-                .build();
-            
+
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList(file.toAbsolutePath().toString()))
+                    .baseDirectory(tempDir).build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertEquals(1, files.size());
             assertEquals(file.normalize(), files.get(0));
         }
-        
+
         @Test
         @DisplayName("should handle empty directory")
         void shouldHandleEmptyDirectory() throws IOException {
             // Given
-            CLIConfig config = CLIConfig.builder()
-                .inputPatterns(Arrays.asList("**/*.adoc"))
-                .baseDirectory(tempDir)
-                .build();
-            
+            CLIConfig config = CLIConfig.builder().inputPatterns(Arrays.asList("**/*.adoc")).baseDirectory(tempDir)
+                    .build();
+
             // When
             List<Path> files = service.discoverFiles(config);
-            
+
             // Then
             assertTrue(files.isEmpty());
         }


### PR DESCRIPTION
## Summary
- Updated parent-oss from version 2.1.0 to 2.2.0
- Applied automatic code style formatting changes from the updated parent POM

## Test plan
- [x] Build passes with `mvn clean install`
- [x] All unit tests pass
- [x] No functional changes - only formatting updates
- [x] Linter functionality remains unchanged