### PR TITLE
#85 Update to use maven.compiler.release property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <asciidoctorj.version>2.5.13</asciidoctorj.version>
         <jackson.version>2.19.2</jackson.version>
         <junit.version>5.13.4</junit.version>
@@ -121,19 +120,6 @@
     
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                    <compilerArgs>
-                        <arg>-Xlint:deprecation</arg>
-                        <arg>-Xlint:unchecked</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Replace maven.compiler.source and maven.compiler.target with maven.compiler.release=17
- Remove explicit maven-compiler-plugin declaration as it's inherited from parent-oss

## Test plan
- [x] Build passes with `mvn clean install`
- [x] Tests pass successfully
- [x] Code compiles with Java 17 features