### PR TITLE
Upgrade to Jackson 3.0.3 and json-schema-validator 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <asciidoctorj.version>3.0.1</asciidoctorj.version>
-        <jackson.version>2.20.1</jackson.version>
+        <jackson.version>3.0.3</jackson.version>
         <junit.version>6.0.1</junit.version>
         <jacoco.version>0.8.14</jacoco.version>
     </properties>
@@ -46,13 +46,13 @@
         
         <!-- Jackson dependencies for YAML parsing -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        
+
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.0</version>
+            <version>3.0.0</version>
         </dependency>
         
         <!-- Log4j2 dependencies -->

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AdmonitionBlock.java
@@ -12,7 +12,7 @@ import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Admonition.ICON;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Admonition.TYPE;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/AudioBlock.java
@@ -8,7 +8,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.ALLOWED;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MAX_LENGTH;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/DlistBlock.java
@@ -7,7 +7,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Literal.CONSISTENT;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MAX;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ExampleBlock.java
@@ -9,7 +9,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Configuration for EXAMPLE blocks. Validates example blocks with optional

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ImageBlock.java
@@ -8,7 +8,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize
 public final class ImageBlock extends AbstractBlock {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ListingBlock.java
@@ -12,7 +12,7 @@ import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize
 public final class ListingBlock extends AbstractBlock {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/LiteralBlock.java
@@ -7,7 +7,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Configuration for literal blocks in AsciiDoc. Literal blocks are delimited by

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ParagraphBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/ParagraphBlock.java
@@ -8,7 +8,7 @@ import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.dataliquid.asciidoc.linter.config.rule.LineConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.*;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Paragraph.*;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/PassBlock.java
@@ -11,7 +11,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Configuration for pass blocks (passthrough content) in AsciiDoc. Pass blocks

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/QuoteBlock.java
@@ -21,7 +21,7 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Com
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.LINES;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MIN;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MAX;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Configuration for quote blocks. Based on the YAML schema structure for

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/SidebarBlock.java
@@ -27,7 +27,7 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Com
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MIN;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MAX;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.ALLOWED;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Configuration for sidebar blocks in AsciiDoc. Sidebar blocks are used for

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/TableBlock.java
@@ -26,7 +26,7 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Com
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MAX_LENGTH;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Table.STYLE;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Table.BORDERS;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize
 public final class TableBlock extends AbstractBlock {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/UlistBlock.java
@@ -7,7 +7,7 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Configuration for unordered list (ulist) blocks in AsciiDoc. Represents

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VerseBlock.java
@@ -21,7 +21,7 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Com
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.PATTERN;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.REQUIRED;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.SEVERITY;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize
 public final class VerseBlock extends AbstractBlock {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlock.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/blocks/VideoBlock.java
@@ -24,7 +24,7 @@ import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Com
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Media.CONTROLS;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MIN_LENGTH;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.MAX_LENGTH;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize
 public class VideoBlock extends AbstractBlock {

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/loader/BlockListDeserializer.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/loader/BlockListDeserializer.java
@@ -1,6 +1,5 @@
 package com.dataliquid.asciidoc.linter.config.loader;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,11 +20,11 @@ import com.dataliquid.asciidoc.linter.config.blocks.TableBlock;
 import com.dataliquid.asciidoc.linter.config.blocks.UlistBlock;
 import com.dataliquid.asciidoc.linter.config.blocks.VerseBlock;
 import com.dataliquid.asciidoc.linter.config.blocks.VideoBlock;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 /**
  * Custom deserializer for Block lists in YAML. Handles the special YAML
@@ -47,18 +46,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * This deserializer expects valid YAML that conforms to the schema. No
  * transformations or default values are applied.
  */
-public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
+@SuppressWarnings("rawtypes")
+public class BlockListDeserializer extends StdDeserializer<List> {
+
+    public BlockListDeserializer() {
+        super(List.class);
+    }
 
     @Override
-    public List<Block> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public List<Block> deserialize(JsonParser p, DeserializationContext ctxt) {
         List<Block> blocks = new ArrayList<>();
-        JsonNode node = p.getCodec().readTree(p);
+        JsonNode node = p.readValueAsTree();
 
         if (!node.isArray()) {
-            throw new IOException("Expected array for block list");
+            throw new IllegalArgumentException("Expected array for block list");
         }
-
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
 
         for (JsonNode blockNode : node) {
             if (!blockNode.isObject()) {
@@ -66,7 +68,7 @@ public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
             }
 
             // Each block is an object with a single key (the block type)
-            String blockType = blockNode.fieldNames().next();
+            String blockType = blockNode.propertyNames().iterator().next();
             JsonNode blockData = blockNode.get(blockType);
 
             // Convert blockType string to BlockType enum
@@ -74,21 +76,21 @@ public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
 
             // Deserialize based on block type - Jackson will handle all validation
             Block block = switch (type) {
-            case PARAGRAPH -> mapper.treeToValue(blockData, ParagraphBlock.class);
-            case LISTING -> mapper.treeToValue(blockData, ListingBlock.class);
-            case TABLE -> mapper.treeToValue(blockData, TableBlock.class);
-            case IMAGE -> mapper.treeToValue(blockData, ImageBlock.class);
-            case VERSE -> mapper.treeToValue(blockData, VerseBlock.class);
-            case ADMONITION -> mapper.treeToValue(blockData, AdmonitionBlock.class);
-            case PASS -> mapper.treeToValue(blockData, PassBlock.class);
-            case LITERAL -> mapper.treeToValue(blockData, LiteralBlock.class);
-            case AUDIO -> mapper.treeToValue(blockData, AudioBlock.class);
-            case QUOTE -> mapper.treeToValue(blockData, QuoteBlock.class);
-            case SIDEBAR -> mapper.treeToValue(blockData, SidebarBlock.class);
-            case EXAMPLE -> mapper.treeToValue(blockData, ExampleBlock.class);
-            case VIDEO -> mapper.treeToValue(blockData, VideoBlock.class);
-            case ULIST -> mapper.treeToValue(blockData, UlistBlock.class);
-            case DLIST -> mapper.treeToValue(blockData, DlistBlock.class);
+            case PARAGRAPH -> ctxt.readTreeAsValue(blockData, ParagraphBlock.class);
+            case LISTING -> ctxt.readTreeAsValue(blockData, ListingBlock.class);
+            case TABLE -> ctxt.readTreeAsValue(blockData, TableBlock.class);
+            case IMAGE -> ctxt.readTreeAsValue(blockData, ImageBlock.class);
+            case VERSE -> ctxt.readTreeAsValue(blockData, VerseBlock.class);
+            case ADMONITION -> ctxt.readTreeAsValue(blockData, AdmonitionBlock.class);
+            case PASS -> ctxt.readTreeAsValue(blockData, PassBlock.class);
+            case LITERAL -> ctxt.readTreeAsValue(blockData, LiteralBlock.class);
+            case AUDIO -> ctxt.readTreeAsValue(blockData, AudioBlock.class);
+            case QUOTE -> ctxt.readTreeAsValue(blockData, QuoteBlock.class);
+            case SIDEBAR -> ctxt.readTreeAsValue(blockData, SidebarBlock.class);
+            case EXAMPLE -> ctxt.readTreeAsValue(blockData, ExampleBlock.class);
+            case VIDEO -> ctxt.readTreeAsValue(blockData, VideoBlock.class);
+            case ULIST -> ctxt.readTreeAsValue(blockData, UlistBlock.class);
+            case DLIST -> ctxt.readTreeAsValue(blockData, DlistBlock.class);
             };
 
             blocks.add(block);

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoader.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoader.java
@@ -11,14 +11,16 @@ import org.apache.logging.log4j.Logger;
 import com.dataliquid.asciidoc.linter.config.LinterConfiguration;
 import com.dataliquid.asciidoc.linter.config.validation.RuleSchemaValidator;
 import com.dataliquid.asciidoc.linter.config.validation.RuleValidationException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 public class ConfigurationLoader {
 
     private static final Logger logger = LogManager.getLogger(ConfigurationLoader.class);
 
-    private final ObjectMapper mapper;
+    private final YAMLMapper mapper;
     private final RuleSchemaValidator schemaValidator;
     private final boolean skipRuleSchemaValidation;
 
@@ -27,7 +29,11 @@ public class ConfigurationLoader {
     }
 
     public ConfigurationLoader(boolean skipRuleSchemaValidation) {
-        this.mapper = new ObjectMapper(new YAMLFactory());
+        this.mapper = YAMLMapper
+                .builder()
+                .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
         this.skipRuleSchemaValidation = skipRuleSchemaValidation;
 
         if (!skipRuleSchemaValidation) {
@@ -71,7 +77,7 @@ public class ConfigurationLoader {
                 throw new ConfigurationException("Missing required 'document' section in configuration");
             }
             return config;
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new ConfigurationException("Failed to parse YAML configuration: " + e.getMessage(), e);
         }
     }
@@ -83,7 +89,7 @@ public class ConfigurationLoader {
                 throw new ConfigurationException("Missing required 'document' section in configuration");
             }
             return config;
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new ConfigurationException("Failed to load configuration: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationLoader.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputConfigurationLoader.java
@@ -6,8 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 /**
  * Loads output configuration from YAML files.
@@ -15,7 +14,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 public class OutputConfigurationLoader {
     private static final String SCHEMA_PATH = "/schemas/output/output-config-schema.yaml";
 
-    private final ObjectMapper mapper;
+    private final YAMLMapper mapper;
     private final OutputSchemaValidator validator;
 
     /**
@@ -30,7 +29,7 @@ public class OutputConfigurationLoader {
      */
     @SuppressWarnings("PMD.NullAssignment")
     public OutputConfigurationLoader(boolean skipValidation) {
-        this.mapper = new ObjectMapper(new YAMLFactory());
+        this.mapper = new YAMLMapper();
         this.validator = skipValidation ? null : new OutputSchemaValidator(SCHEMA_PATH);
     }
 

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputSchemaValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/output/OutputSchemaValidator.java
@@ -5,10 +5,11 @@ import java.io.InputStream;
 import java.util.List;
 
 import com.dataliquid.asciidoc.linter.config.SchemaConstants;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.networknt.schema.Error;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaRegistry;
@@ -22,11 +23,11 @@ import com.networknt.schema.path.PathType;
 public class OutputSchemaValidator {
     private final String schemaPath;
     private final Schema schema;
-    private final ObjectMapper yamlMapper;
+    private final YAMLMapper yamlMapper;
 
     public OutputSchemaValidator(String schemaPath) {
         this.schemaPath = schemaPath;
-        this.yamlMapper = new ObjectMapper(new YAMLFactory());
+        this.yamlMapper = new YAMLMapper();
         this.schema = loadSchema();
     }
 
@@ -85,7 +86,7 @@ public class OutputSchemaValidator {
                 }
                 throw new OutputConfigurationException(errorMessage.toString());
             }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new OutputConfigurationException("Failed to parse YAML", e);
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/rule/SectionConfig.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/rule/SectionConfig.java
@@ -9,7 +9,7 @@ import com.dataliquid.asciidoc.linter.config.blocks.Block;
 import com.dataliquid.asciidoc.linter.config.loader.BlockListDeserializer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Common.*;
 import static com.dataliquid.asciidoc.linter.config.common.JsonPropertyNames.Document.ALLOWED_BLOCKS;

--- a/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleSchemaValidator.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/config/validation/RuleSchemaValidator.java
@@ -7,10 +7,11 @@ import java.nio.file.Path;
 import java.util.List;
 
 import com.dataliquid.asciidoc.linter.config.SchemaConstants;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.networknt.schema.Error;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaRegistry;
@@ -29,10 +30,10 @@ public class RuleSchemaValidator {
     private static final String MSG_KEY_REQUIRED = "required";
 
     private final Schema schema;
-    private final ObjectMapper yamlMapper;
+    private final YAMLMapper yamlMapper;
 
     public RuleSchemaValidator() {
-        this.yamlMapper = new ObjectMapper(new YAMLFactory());
+        this.yamlMapper = new YAMLMapper();
         this.schema = loadSchema();
     }
 
@@ -66,7 +67,7 @@ public class RuleSchemaValidator {
                 return registry.getSchema(SchemaLocation.of(schemaUri), schemaNode);
             }
 
-        } catch (IOException e) {
+        } catch (JacksonException | IOException e) {
             throw new RuleValidationException("Failed to load schema", e);
         }
     }
@@ -86,7 +87,7 @@ public class RuleSchemaValidator {
         try {
             JsonNode configNode = yamlMapper.readTree(userConfigFile.toFile());
             validateUserConfig(configNode);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RuleValidationException("Failed to read configuration file: " + userConfigFile, e);
         }
     }
@@ -117,7 +118,7 @@ public class RuleSchemaValidator {
         try {
             JsonNode configNode = yamlMapper.readTree(yamlStream);
             validateUserConfig(configNode);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RuleValidationException("Failed to parse YAML configuration", e);
         }
     }
@@ -133,7 +134,7 @@ public class RuleSchemaValidator {
         try {
             JsonNode configNode = yamlMapper.readTree(yamlContent);
             validateUserConfig(configNode);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RuleValidationException("Failed to parse YAML configuration string", e);
         }
     }

--- a/src/main/java/com/dataliquid/asciidoc/linter/report/JsonFormatter.java
+++ b/src/main/java/com/dataliquid/asciidoc/linter/report/JsonFormatter.java
@@ -1,6 +1,5 @@
 package com.dataliquid.asciidoc.linter.report;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -13,8 +12,10 @@ import java.util.stream.Collectors;
 
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Formats validation results as JSON using Jackson. Supports both
@@ -28,7 +29,7 @@ public class JsonFormatter implements ReportFormatter {
     private static final int MILLIS_PER_SECOND = 1000;
 
     private final String name;
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
     /**
      * Creates a JSON formatter with the specified name and pretty-print setting.
@@ -38,12 +39,10 @@ public class JsonFormatter implements ReportFormatter {
      */
     public JsonFormatter(String name, boolean prettyPrint) {
         this.name = name;
-        this.objectMapper = new ObjectMapper();
-
         if (prettyPrint) {
-            this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+            this.jsonMapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
         } else {
-            this.objectMapper.disable(SerializationFeature.INDENT_OUTPUT);
+            this.jsonMapper = JsonMapper.builder().disable(SerializationFeature.INDENT_OUTPUT).build();
         }
     }
 
@@ -93,9 +92,9 @@ public class JsonFormatter implements ReportFormatter {
 
         // Write JSON to PrintWriter
         try {
-            objectMapper.writeValue(writer, root);
+            jsonMapper.writeValue(writer, root);
             writer.flush();
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException("Failed to write JSON output", e);
         }
     }

--- a/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoaderTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/config/loader/ConfigurationLoaderTest.java
@@ -193,8 +193,10 @@ class ConfigurationLoaderTest {
                     () -> loader.loadConfiguration(yaml));
 
             // Then
-            // Jackson throws UnrecognizedPropertyException when encountering unknown fields
-            assertTrue(exception.getMessage().contains("Unrecognized field"));
+            // Jackson throws UnrecognizedPropertyException when encountering unknown
+            // properties
+            assertTrue(exception.getMessage().contains("Unrecognized property"),
+                    "Expected 'Unrecognized property' in: " + exception.getMessage());
             assertTrue(exception.getMessage().contains("someOtherKey"));
             assertTrue(exception.getMessage().contains("one known property: \"document\""));
         }

--- a/src/test/java/com/dataliquid/asciidoc/linter/report/JsonCompactFormatterTest.java
+++ b/src/test/java/com/dataliquid/asciidoc/linter/report/JsonCompactFormatterTest.java
@@ -18,8 +18,9 @@ import com.dataliquid.asciidoc.linter.config.common.Severity;
 import com.dataliquid.asciidoc.linter.validator.SourceLocation;
 import com.dataliquid.asciidoc.linter.validator.ValidationMessage;
 import com.dataliquid.asciidoc.linter.validator.ValidationResult;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Unit tests for JSON compact formatting.
@@ -35,14 +36,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 class JsonCompactFormatterTest {
 
     private JsonFormatter formatter;
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
 
     @BeforeEach
     void setUp() {
         formatter = JsonFormatter.compact();
-        objectMapper = new ObjectMapper();
+        jsonMapper = new JsonMapper();
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
@@ -77,7 +78,7 @@ class JsonCompactFormatterTest {
         assertFalse(output.contains("  "), "Output should not contain indentation");
 
         // Parse and verify structure
-        JsonNode json = objectMapper.readTree(output);
+        JsonNode json = jsonMapper.readTree(output);
         assertTrue(json.has("timestamp"));
         assertTrue(json.has("duration"));
         assertTrue(json.has("summary"));
@@ -143,7 +144,7 @@ class JsonCompactFormatterTest {
         assertFalse(output.contains("  "), "Output should not contain indentation");
 
         // Parse and verify structure
-        JsonNode json = objectMapper.readTree(output);
+        JsonNode json = jsonMapper.readTree(output);
 
         // Verify summary
         JsonNode summary = json.get("summary");
@@ -197,7 +198,7 @@ class JsonCompactFormatterTest {
         String output1 = stringWriter.toString();
 
         // Then
-        JsonNode json1 = objectMapper.readTree(output1);
+        JsonNode json1 = jsonMapper.readTree(output1);
         assertEquals("999ms", json1.get("duration").asText());
 
         // Given - test with seconds
@@ -214,7 +215,7 @@ class JsonCompactFormatterTest {
         String output2 = stringWriter.toString();
 
         // Then
-        JsonNode json2 = objectMapper.readTree(output2);
+        JsonNode json2 = jsonMapper.readTree(output2);
         assertEquals("1.500s", json2.get("duration").asText());
     }
 
@@ -241,7 +242,7 @@ class JsonCompactFormatterTest {
         String output = stringWriter.toString();
 
         // Then
-        JsonNode json = objectMapper.readTree(output);
+        JsonNode json = jsonMapper.readTree(output);
         JsonNode messages = json.get("messages");
         JsonNode message = messages.get(0);
 
@@ -286,7 +287,7 @@ class JsonCompactFormatterTest {
 
         // Then
         // Verify it's valid JSON
-        JsonNode json = objectMapper.readTree(output);
+        JsonNode json = jsonMapper.readTree(output);
         JsonNode messages = json.get("messages");
         JsonNode message = messages.get(0);
 


### PR DESCRIPTION
## Summary
- Upgrade Jackson from 2.20.1 to 3.0.3
- Upgrade json-schema-validator from 2.0.0 to 3.0.0
- Migrate package imports from `com.fasterxml.jackson` to `tools.jackson`
- Adapt to Jackson 3 API changes (YAMLMapper, JsonMapper, JacksonException)
- Configure Jackson 3 defaults for backward compatibility

## Changes
- **pom.xml**: Updated Jackson and json-schema-validator versions
- **16 Block classes**: Updated `@JsonDeserialize` import
- **Core classes**: Migrated to Jackson 3 API (ConfigurationLoader, BlockListDeserializer, JsonFormatter, etc.)
- **Test classes**: Adapted to new Jackson 3 imports and error message text

## Test plan
- [x] All 1177 tests pass
- [x] Build completes successfully
- [x] Manual verification of linter functionality